### PR TITLE
Increase pulp-content replicas from 1 to 2

### DIFF
--- a/deploy/crds/pulpproject_v1alpha1_pulp_cr.yaml
+++ b/deploy/crds/pulpproject_v1alpha1_pulp_cr.yaml
@@ -8,7 +8,7 @@ spec:
     replicas: 1
     log_level: INFO
   pulp_content:
-    replicas: 1
+    replicas: 2
     log_level: INFO
   pulp_worker:
     replicas: 2

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,14 +20,14 @@ spec:
           - /tmp/ansible-operator/runner
           - stdout
           image: "quay.io/mikedep333/pulp-operator:latest"
-          imagePullPolicy: "Always"
+          imagePullPolicy: "{{ pull_policy|default('Always') }}"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
             readOnly: true
         - name: operator
           image: "quay.io/mikedep333/pulp-operator:latest"
-          imagePullPolicy: "Always"
+          imagePullPolicy: "{{ pull_policy|default('Always') }}"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner

--- a/roles/pulp-content/defaults/main.yml
+++ b/roles/pulp-content/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 pulp_content:
-  replicas: 1
+  replicas: 2
   log_level: INFO


### PR DESCRIPTION
I tested it successfully on Minikube: Both pulp-content pods are serving content.

I also included a minor cleanup fix

https://etherpad.net/p/Pulp_K8s_Operator_TODO (Medium-term & later tasks will be put on redmine instead.)