### PR TITLE
Travis Ubuntu 18.04 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 sudo: required
 language: python
 services:

--- a/insta-demo/Vagrantfile
+++ b/insta-demo/Vagrantfile
@@ -28,4 +28,10 @@ Vagrant.configure("2") do |config|
     a.vm.provision "shell",
       path: "pulp-insta-demo.sh"
   end
+
+  config.vm.define "bionic-pulp-insta-demo" do |a|
+    a.vm.box = "generic/ubuntu1804"
+    a.vm.provision "shell",
+      path: "pulp-insta-demo.sh"
+  end
 end


### PR DESCRIPTION
About 2-3 months ago, k3s failed to start.
Now, due to either our changes or k3s's is, it does.

plugin-template task:
re: 5156
Update travis to run on ubuntu b18.04
https://pulp.plan.io/issues/5156

[noissue]