### PR TITLE
Fix support for Fedora pulp containers & other fixes/debugging improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ script:
   - .travis/pulp_file-tests.sh
 after_failure:
   - http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
+  - sudo docker images
   # With the selector (which eliminates the need to look up the pod name),
   # we cannot show all logs. 10000 lines should be sufficient.
   - sudo kubectl logs -l app=pulp-api --tail=10000
+  - sudo kubectl logs -l app=pulp-content --tail=10000
+  - sudo kubectl logs -l app=pulp-worker --tail=10000
+  - sudo kubectl logs -l app=pulp-resource-manager --tail=10000

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 before_install:
   - git clone https://github.com/pulp/pulp_file.git
 install:
-  - pip install docker molecule openshift jmespath
+  - pip install jmespath
   # Need /usr/bin/http script, so use sudo
   # It can mess up ownership of the python cache dir, so run it after the
   # non-sudo pip command.

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ script:
   - sudo docker images
   - sudo ./up.sh
   - .travis/pulp-operator-check-and-wait.sh
-  - .travis/pulp_file-tests.sh
+  # This step will run indefinitely if we do not limit it to 5 mins.
+  # If the entire build reaches 50 mins, the after_failure steps never run.
+  - timeout 5m .travis/pulp_file-tests.sh
 after_failure:
   - http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
   - sudo docker images

--- a/.travis/pulp-operator-check-and-wait.sh
+++ b/.travis/pulp-operator-check-and-wait.sh
@@ -101,3 +101,16 @@ for tries in {0..120}; do
     break
   fi
 done
+
+if [[ "$(echo "$output" | sed -ne '/{/,$ p' | jq -r .online_content_apps)" = "[]" ]]; then
+    echo "ERROR 5: Content app never actually came online"
+    storage_debug
+    echo "$output"
+    exit 5
+fi
+if [[ "$(echo "$output" | sed -ne '/{/,$ p' | jq -r .online_workers)" = "[]" ]]; then
+    echo "ERROR 6: Worker(s) never actually came online"
+    storage_debug
+    echo "$output"
+    exit 6
+fi

--- a/.travis/pulp-operator-check-and-wait.sh
+++ b/.travis/pulp-operator-check-and-wait.sh
@@ -46,7 +46,10 @@ done
 # up in time.
 STORAGE_POD=$(sudo kubectl -n local-path-storage get pod | awk '/local-path-provisioner/{print $1}')
 
-for tries in {0..120}; do
+# NOTE: Before the pods can be started, they must be downloaded/cached from
+# quay.io .
+# Therefore, this wait is highly dependent on network speed.
+for tries in {0..180}; do
   pods=$(sudo kubectl get pods -o wide)
   if [[ $(echo "$pods" | grep -c -v -E "STATUS|Running") -eq 0 ]]; then
     echo "PODS:"
@@ -57,13 +60,13 @@ for tries in {0..120}; do
     # Often after 30 tries (150 secs), not all of the pods are running yet.
     # Let's keep Travis from ending the build by outputting.
     if [[ $(( tries % 30 )) == 0 ]]; then
-      echo "STATUS: Still waiting on pods to transitiion to running state."
+      echo "STATUS: Still waiting on pods to transition to running state."
       echo "PODS:"
       echo "$pods"
       echo "DOCKER IMAGE CACHE:"
       sudo docker images
     fi
-    if [[ $tries -eq 120 ]]; then
+    if [[ $tries -eq 180 ]]; then
       echo "ERROR 3: Pods never all transitioned to Running state"
       storage_debug
       exit 3

--- a/.travis/pulp-operator-check-and-wait.sh
+++ b/.travis/pulp-operator-check-and-wait.sh
@@ -83,18 +83,21 @@ echo $URL
 #
 # --pretty format --print hb almost make it behave as if it were not redirected
 for tries in {0..120}; do
+  if [[ $tries -eq 120 ]]; then
+    echo "ERROR 4: Status page never accessible or returning success"
+    storage_debug
+    exit 4
+  fi
   output=$(http --timeout 5 --check-status --pretty format --print hb $URL 2>&1)
   rc=$?
   if echo "$output" | grep "Errno 111" ; then
     # if connection refused, httpie does not wait 5 seconds
     sleep 5
+  elif echo "$output" | grep "Request timed out" ; then
+    continue
   elif [[ $rc ]] ; then
     echo "Successfully got the status page after _roughly_ $((tries * 5)) seconds"
     echo "$output"
     break
-  elif [[ $tries -eq 120 ]]; then
-    echo "ERROR 4: Status page never accessible or returning success"
-    storage_debug
-    exit 4
   fi
 done

--- a/.travis/pulp_file-tests.sh
+++ b/.travis/pulp_file-tests.sh
@@ -11,5 +11,6 @@ pushd pulp_file/docs/_scripts
 # Let's only do sync tests.
 # So as to check that Pulp can work in containers, including writing to disk.
 # If the upload tests are simpler in the long run, just use them.
+set -x
 source docs_check_sync_publish.sh
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,14 +20,12 @@ spec:
           - /tmp/ansible-operator/runner
           - stdout
           image: "quay.io/pulp/pulp-operator:latest"
-          imagePullPolicy: "Always"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
             readOnly: true
         - name: operator
           image: "quay.io/pulp/pulp-operator:latest"
-          imagePullPolicy: "Always"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml
@@ -32,7 +32,6 @@ spec:
           image: "{{ registry }}/{{ image }}:{{ version }}"
           # We set args, not command, so as to not override the entrypoint script
           args: ["pulp-api"]
-          imagePullPolicy: Always
           env:
             # TODO: Replace with k8s secrets
             - name: PULP_ADMIN_PASSWORD

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml
@@ -30,7 +30,8 @@ spec:
       containers:
         - name: pulp-api
           image: "{{ registry }}/{{ image }}:{{ version }}"
-          command: ["pulp-api"]
+          # We set args, not command, so as to not override the entrypoint script
+          args: ["pulp-api"]
           imagePullPolicy: Always
           env:
             # TODO: Replace with k8s secrets

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml
@@ -30,7 +30,8 @@ spec:
       containers:
         - name: pulp-content
           image: "{{ registry }}/{{ image }}:{{ version }}"
-          command: ["pulp-content"]
+          # We set args, not command, so as to not override the entrypoint script
+          args: ["pulp-content"]
           imagePullPolicy: Always
           ports:
             - protocol: TCP

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml
@@ -32,7 +32,6 @@ spec:
           image: "{{ registry }}/{{ image }}:{{ version }}"
           # We set args, not command, so as to not override the entrypoint script
           args: ["pulp-content"]
-          imagePullPolicy: Always
           ports:
             - protocol: TCP
               containerPort: 24816

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml
@@ -30,7 +30,8 @@ spec:
       containers:
         - name: pulp-resource-manager
           image: "{{ registry }}/{{ image }}:{{ version }}"
-          command: ["pulp-resource-manager"]
+          # We set args, not command, so as to not override the entrypoint script
+          args: ["pulp-resource-manager"]
           volumeMounts:
             - name: pulp-server
               mountPath: "/etc/pulp/"

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml
@@ -30,7 +30,8 @@ spec:
       containers:
         - name: pulp-worker
           image: "{{ registry }}/{{ image }}:{{ version }}"
-          command: ["pulp-worker"]
+          # We set args, not command, so as to not override the entrypoint script
+          args: ["pulp-worker"]
           volumeMounts:
             - name: pulp-server
               mountPath: "/etc/pulp/"


### PR DESCRIPTION
"Fix using the entrypoint script" is the commit that fixes Fedora container support (the bug is not Fedora-specific, but is harmless on the CentOS containers currently.)

re: #5176
https://pulp.plan.io/issues/5176
"Port pulp containers to Fedora 30"