### PR TITLE
Use Docker rather than k3s-bundled containerd

### DIFF
--- a/.travis/k3s-install.sh
+++ b/.travis/k3s-install.sh
@@ -17,7 +17,7 @@
 #
 # TODO: Fix access to registry.centos.org
 # https://github.com/rancher/k3s/issues/145#issuecomment-490143506
-curl -sfL https://get.k3s.io | sudo INSTALL_K3S_EXEC="--kube-apiserver-arg service-node-port-range=80-32767" sh -
+curl -sfL https://get.k3s.io | sudo INSTALL_K3S_EXEC="--docker --kube-apiserver-arg service-node-port-range=80-32767" sh -
 status=$(sudo systemctl status --full --lines=200 k3s)
 if ! [[ $? ]] ; then
   echo "${status}"


### PR DESCRIPTION
So that built & cached images can be used later during CI.

This means that the pulp-operator CI now actually tests the current
version of the image it builds, rather than the version from quay.

re: #5062
[Create pulpcore and pulp_file container images automatically via CI](https://pulp.plan.io/issues/5062)