### PR TITLE
Problem: Travis CI is failing due to master branch pulp_file tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
         - .travis/pulp-operator-check-and-wait.sh
         # This step will run indefinitely if we do not limit it to 5 mins.
         # If the entire build reaches 50 mins, the after_failure steps never run.
-        - timeout 5m .travis/pulp_file-tests.sh
+        - .travis/pulp_file-tests.sh
       deploy:
         provider: script
         # Push image to quay. That is our upstream "deployment".

--- a/.travis/pulp_file-tests.sh
+++ b/.travis/pulp_file-tests.sh
@@ -11,6 +11,14 @@ pushd pulp_file/docs/_scripts
 # Let's only do sync tests.
 # So as to check that Pulp can work in containers, including writing to disk.
 # If the upload tests are simpler in the long run, just use them.
-set -x
-source docs_check_sync_publish.sh
+#
+# If the master branch tests fail, run the stable tests.
+# The git command is to checkout the newest stag, which should be the
+# stable release.
+# Temporary workaround until we replace with pulp-smash.
+timeout 5m bash -x docs_check_sync_publish.sh || {
+  echo "Master branch of pulp_file tests failed. Using newest tag (stable release.)"
+  git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
+  timeout 5m bash -x docs_check_sync_publish.sh
+}
 


### PR DESCRIPTION
being run against stable release of pulp_file.

Solution: Try the newest tag for pulp_file if the master branch fails.

[noissue]