### PR TITLE
Set content_origin to the 1st node's 1st address.

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: pulp-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pulp-operator
+subjects:
+- kind: ServiceAccount
+  name: pulp-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: pulp-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/crds/pulpproject_v1alpha1_pulp_cr.default.yaml
+++ b/deploy/crds/pulpproject_v1alpha1_pulp_cr.default.yaml
@@ -26,7 +26,11 @@ metadata:
 #    redis_host: redis
 #    redis_port:  6379
 #    redis_password: ''
-#    content_host: ''
+#    content_origin: # pulp-operator will query the 1st address of the 1st k8s
+#                      node. This suffices for most single node deployments.
+#                      If on a cluster, you should set this manually until
+#                      ingress(es) are implemented. Example:
+#                      http://myserver.fqdn:24816
   # PostrgreSQL container settings for user accounts
 # database_connection:
 #   username: pulp

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -46,3 +46,10 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list

--- a/down.sh
+++ b/down.sh
@@ -21,7 +21,9 @@ $KUBECTL delete -f deploy/operator.yaml
 
 $KUBECTL delete -f deploy/service_account.yaml
 $KUBECTL delete -f deploy/role.yaml
+$KUBECTL delete -f deploy/cluster_role.yaml
 $KUBECTL delete -f deploy/role_binding.yaml
+$KUBECTL delete -f deploy/cluster_role_binding.yaml
 # It doesn't matter which cr we specify; the metadata up top is the same.
 $KUBECTL delete -f deploy/crds/pulpproject_v1alpha1_pulp_cr.default.yaml
 $KUBECTL delete -f deploy/crds/pulpproject_v1alpha1_pulp_crd.yaml

--- a/playbook.yml
+++ b/playbook.yml
@@ -19,6 +19,7 @@
       redis_host: redis
       redis_port:  6379
       redis_password: ''
+#     content_origin: # Queried and set in pulp-api role
     deployment_state: present
     registry: quay.io
     project: pulp

--- a/roles/pulp-api/tasks/get_node_ip.yml
+++ b/roles/pulp-api/tasks/get_node_ip.yml
@@ -1,0 +1,18 @@
+---
+- name: Look up the 1st address of the 1st node
+  k8s_facts:
+    api_version: v1
+    kind: Node
+  register: k8s_nodes
+
+- name: DEBUG Show k8s_nodes
+  debug:
+    msg: "{{ k8s_nodes }}"
+
+- name: Set content_origin
+  set_fact:
+    pulp_default_settings: "{{ pulp_default_settings|combine({'content_origin': 'http://{{ k8s_nodes.resources[0].status.addresses[0].address }}:24816' }) }}"
+
+- name: DEBUG Show content_origin
+  debug:
+    msg: "{{ pulp_default_settings.content_origin }}"

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -2,15 +2,30 @@
 - set_fact:
     secret_key: "{{ lookup('password', '/dev/null length=50 chars=ascii_letters') }}"
 
-- set_fact:
-    pulp_combined_settings: "{{ pulp_default_settings|combine(pulp_settings, recursive=True) if pulp_settings is defined and pulp_settings is not none else pulp_default_settings }}"
-
 - name: pulp-file-storage persistent volume claim
   k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.pvc.yaml') | from_yaml }}"
   with_items:
     - pulp-file-storage
+
+# Workaround being unable to do the following, for the subsequent task:
+# when: (pulp_settings is not defined) or
+#   (pulp_settings.content_origin is not defined)
+# (short-circuit evaluation only works for multiple separate when statements)
+# https://github.com/ansible/ansible/issues/50554
+- set_fact:
+    content_origin_temp: pulp_settings.content_origin
+  when:
+    - pulp_settings is defined
+    - pulp_settings.content_origin is defined
+
+- include_tasks:
+    file: get_node_ip.yml
+  when: content_origin_temp is not defined
+
+- set_fact:
+    pulp_combined_settings: "{{ pulp_default_settings|combine(pulp_settings, recursive=True) if pulp_settings is defined and pulp_settings is not none else pulp_default_settings }}"
 
 - name: pulp-server config-map
   k8s:

--- a/up.sh
+++ b/up.sh
@@ -33,5 +33,7 @@ echo "Will deploy config Custom Resource deploy/crds/$CUSTOM_RESOURCE"
 $KUBECTL apply -f deploy/crds/$CUSTOM_RESOURCE
 $KUBECTL apply -f deploy/service_account.yaml
 $KUBECTL apply -f deploy/role.yaml
+$KUBECTL apply -f deploy/cluster_role.yaml
 $KUBECTL apply -f deploy/role_binding.yaml
+$KUBECTL apply -f deploy/cluster_role_binding.yaml
 $KUBECTL apply -f deploy/operator.yaml


### PR DESCRIPTION
If not set by the user.

Limited scope (single-node clusters), but sufficient for
minikube/k3s/our Travis CI.
fixes: #5138
In pulp-operator, the content_origin should be set to the actual accessible service URL
https://pulp.plan.io/issues/5138

re: #5629
[Epic] Introduce CONTENT_ORIGIN as a required setting
https://pulp.plan.io/issues/5629