### PR TITLE
Problem: When Travis CI fails to see the operator's services come up,…

### DIFF
--- a/.travis/pulp-operator-check-and-wait.sh
+++ b/.travis/pulp-operator-check-and-wait.sh
@@ -54,6 +54,12 @@ for tries in {0..30}; do
       echo "ERROR 2: 1 or more external services never came up"
       echo "SERVICES:"
       echo "$services"
+      if [ -x "$(command -v docker)" ]; then
+        echo "DOCKER IMAGE CACHE:"
+        sudo docker images
+      fi
+      echo "PODS:"
+      sudo $KUBECTL get pods -o wide
       storage_debug
       exit 2
     fi


### PR DESCRIPTION
… insufficient debug is outputted

Solution: Output the running pods and the docker image cache at that

stage of pulp-operator-check-and-wait.sh

Fixes: #5846