### PR TITLE
Problem: pulpcore 3.0 CI was failing

### DIFF
--- a/deploy/crds/pulpproject_v1alpha1_pulp_cr.default.yaml
+++ b/deploy/crds/pulpproject_v1alpha1_pulp_cr.default.yaml
@@ -9,8 +9,8 @@ metadata:
 # project: pulp
   # The image name (repo name) for the pulp image.
 # image: pulp
-  # The image tag for the pulp image.
-# tag: stable
+  # The image tag for the pulp image. Quotes needed for '.' on certain K8s.
+# tag: "stable"
   # Pulp settings.
 # pulp_settings:
 #    databases:

--- a/deploy/crds/pulpproject_v1alpha1_pulp_cr.travis.yaml
+++ b/deploy/crds/pulpproject_v1alpha1_pulp_cr.travis.yaml
@@ -3,7 +3,7 @@ kind: Pulp
 metadata:
   name: example-pulp
 spec:
-  tag: latest
+  tag: "latest"
   pulp_file_storage:
     # k3s local-path requires this
     access_mode: "ReadWriteOnce"


### PR DESCRIPTION
Was due to k3s interpreting the 3.0 image tag as 3 due to lack of quotes.
And therefore thinking the image does not exist (ImagePullBackoff)

Solution: Put quotes around the tag in all the cr.yaml files here,
even though their strings do not require them.

[noissue]