### PR TITLE
Updating operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,11 @@ before_install:
   # and after that I removed manually travis files not related to validating commit
   # also removed some python related stuff like flake8, black and pip installing doc/test requirements
 install:
-  - pip install jmespath
   # Need /usr/bin/http script, so use sudo
   # It can mess up ownership of the python cache dir, so run it after the
   # non-sudo pip command.
   - .travis/k3s-install.sh
-  - sudo wget https://github.com/operator-framework/operator-sdk/releases/download/v0.9.0/operator-sdk-v0.9.0-x86_64-linux-gnu -O /usr/local/bin/operator-sdk
+  - sudo wget https://github.com/operator-framework/operator-sdk/releases/download/v0.18.2/operator-sdk-v0.18.2-x86_64-linux-gnu -O /usr/local/bin/operator-sdk
   - sudo chmod +x /usr/local/bin/operator-sdk
 jobs:
   include:
@@ -51,8 +50,7 @@ after_failure:
   - sudo docker images
   # With the selector (which eliminates the need to look up the pod name),
   # we cannot show all logs. 10000 lines should be sufficient.
-  - sudo kubectl logs -l name=pulp-operator -c ansible --tail=10000
-  - sudo kubectl logs -l name=pulp-operator -c operator --tail=10000
+  - sudo kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
   - sudo kubectl logs -l app=pulp-api --tail=10000
   - sudo kubectl logs -l app=pulp-content --tail=10000
   - sudo kubectl logs -l app=pulp-worker --tail=10000

--- a/.travis/pulp-operator-check-and-wait.sh
+++ b/.travis/pulp-operator-check-and-wait.sh
@@ -33,6 +33,8 @@ if command -v kubectl > /dev/null; then
   KUBECTL=$(command -v kubectl)
 elif [ -x /usr/local/bin/kubectl ]; then
   KUBECTL=/usr/local/bin/kubectl
+elif which kubectl > /dev/null; then
+  KUBECTL=$(which kubectl)
 else
     echo "$0: ERROR 1: Cannot find kubectl"
 fi

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.7.0
+FROM quay.io/operator-framework/ansible-operator:v0.18.2
 
 COPY watches.yaml ${HOME}/watches.yaml
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,18 +14,7 @@ spec:
     spec:
       serviceAccountName: pulp-operator
       containers:
-        - name: ansible
-          command:
-          - /usr/local/bin/ao-logs
-          - /tmp/ansible-operator/runner
-          - stdout
-          image: "quay.io/pulp/pulp-operator:latest"
-          imagePullPolicy: "IfNotPresent"
-          volumeMounts:
-          - mountPath: /tmp/ansible-operator/runner
-            name: runner
-            readOnly: true
-        - name: operator
+        - name: pulp-operator
           image: "quay.io/pulp/pulp-operator:latest"
           imagePullPolicy: "IfNotPresent"
           volumeMounts:

--- a/down.sh
+++ b/down.sh
@@ -12,6 +12,8 @@ if command -v kubectl > /dev/null; then
   KUBECTL=$(command -v kubectl)
 elif [ -x /usr/local/bin/kubectl ]; then
   KUBECTL=/usr/local/bin/kubectl
+elif which kubectl > /dev/null; then
+  KUBECTL=$(which kubectl)
 else
     echo "$0: ERROR 1: Cannot find kubectl"
 fi

--- a/molecule/test-local/playbook.yml
+++ b/molecule/test-local/playbook.yml
@@ -111,7 +111,7 @@
 
     - name: get ansible logs
       failed_when: false
-      command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ namespace }} -c ansible
+      command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ namespace }} -c pulp-operator
       environment:
         KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
       vars:

--- a/up.sh
+++ b/up.sh
@@ -12,6 +12,8 @@ if command -v kubectl > /dev/null; then
   KUBECTL=$(command -v kubectl)
 elif [ -x /usr/local/bin/kubectl ]; then
   KUBECTL=/usr/local/bin/kubectl
+elif which kubectl > /dev/null; then
+  KUBECTL=$(which kubectl)
 else
     echo "$0: ERROR 1: Cannot find kubectl"
 fi


### PR DESCRIPTION
We are using ansible-operator:v0.7.0 and the latest one is ansible-operator:v0.18.2

------------------------------------------------------
`/bin/ao-logs` was removed on v0.18.0:
https://github.com/operator-framework/operator-sdk/blob/191d79824df3db82f98bd8e658551d0f846fe8f5/website/content/en/docs/migration/v0.18.0.md#remove-the-file-binao-logs-for-ansible-based-operators
How to migrate:
https://github.com/operator-framework/operator-sdk/blob/e128b9e5d147ef43fbca46b8ddb5037a9b1e3cbd/website/content/en/docs/migration/version-upgrade-guide.md