### PR TITLE
Build and publish pulp container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
       deploy:
         provider: script
         # Push image to quay. That is our upstream "deployment".
-        script: sudo .travis/quay-push.sh
+        script: sudo .travis/deploy.sh
         on:
           # Only run on the master branch, because "latest" is hardcoded
           branch: master

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#!/usr/bin/env bash
+
+echo "Deploy pulp-operator"
+sudo $TRAVIS_BUILD_DIR/.travis/quay-push.sh
+
+echo "Build pulp and pulpcore"
+cd $TRAVIS_BUILD_DIR/../pulpcore/containers/
+cp $TRAVIS_BUILD_DIR/.travis/vars.yaml vars/vars.yaml
+pip install ansible
+ansible-playbook -v build.yaml
+
+echo "Deploy pulp latest"
+sudo QUAY_REPO_NAME=pulp $TRAVIS_BUILD_DIR/.travis/quay-push.sh
+
+echo "Deploy pulpcore latest"
+sudo QUAY_REPO_NAME=pulpcore $TRAVIS_BUILD_DIR/.travis/quay-push.sh

--- a/.travis/vars.yaml
+++ b/.travis/vars.yaml
@@ -1,0 +1,22 @@
+images:
+  - pulpcore_master:
+      image_name: pulpcore
+      tag: latest
+      # Must specify egg name here so that the Dockerfile can specify the
+      # setuptools extra of postgres
+      pulpcore: git+https://github.com/pulp/pulpcore.git#egg=pulpcore
+  - pulp_master_plugins_master:
+      image_name: pulp
+      tag: latest
+      pulpcore: git+https://github.com/pulp/pulpcore.git#egg=pulpcore
+      plugins:
+        - "git+https://github.com/pulp/pulp-certguard.git"
+        - "git+https://github.com/pulp/pulp_file.git"
+        - "git+https://github.com/pulp/pulp_ansible.git"
+        - "git+https://github.com/gmbnomis/pulp_cookbook.git"
+        - "git+https://github.com/pulp/pulp_container.git"
+        - "git+https://github.com/pulp/pulp_maven.git"
+        - "git+https://github.com/pulp/pulp_python.git"
+        - "git+https://github.com/pulp/pulp_rpm.git"
+registry: quay.io
+project: pulp


### PR DESCRIPTION
5 months ago was last time `pulp` image was pushed - https://quay.io/repository/pulp/pulp?tag=latest&tab=tags

it is using:
```json
"versions": [
        {
            "component": "pulpcore",
            "version": "3.0.1"
        },
        {
            "component": "pulp_rpm",
            "version": "3.0.0"
        },
        {
            "component": "pulp_python",
            "version": "3.0.0b8"
        },
        {
            "component": "pulp_maven",
            "version": "0.1.0b3"
        },
        {
            "component": "pulp_file",
            "version": "0.1.0"
        },
        {
            "component": "pulp_cookbook",
            "version": "0.1.0b5"
        },
        {
            "component": "pulp_container",
            "version": "1.0.0"
        },
        {
            "component": "pulp_certguard",
            "version": "0.1.0rc3.dev0"
        },
        {
            "component": "pulp_ansible",
            "version": "0.2.0b7"
        }
    ]
```