### PR TITLE
Always get the latest operator version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,21 @@ addons:
   apt:
     packages:
       - httpie
+      - jq
 before_install:
   .travis/before_install.sh
   # Created template_config.yml with plugin_template,
   # and after that I removed manually travis files not related to validating commit
   # also removed some python related stuff like flake8, black and pip installing doc/test requirements
 install:
-  - pip install jmespath
   # Need /usr/bin/http script, so use sudo
   # It can mess up ownership of the python cache dir, so run it after the
   # non-sudo pip command.
   - .travis/k3s-install.sh
-  - sudo wget https://github.com/operator-framework/operator-sdk/releases/download/v0.9.0/operator-sdk-v0.9.0-x86_64-linux-gnu -O /usr/local/bin/operator-sdk
+  - CURRENT_VERSION=$(head -1 ./build/Dockerfile  | cut -d ":" -f 2)
+  - SDK_LATEST_VERSION=$(http https://api.github.com/repos/operator-framework/operator-sdk/releases/latest | jq -r '.tag_name')
+  - sed -i "s/$CURRENT_VERSION/$SDK_LATEST_VERSION/g" ./build/Dockerfile
+  - sudo wget https://github.com/operator-framework/operator-sdk/releases/download/$SDK_LATEST_VERSION/operator-sdk-$SDK_LATEST_VERSION-x86_64-linux-gnu -O /usr/local/bin/operator-sdk
   - sudo chmod +x /usr/local/bin/operator-sdk
 jobs:
   include:
@@ -51,8 +54,7 @@ after_failure:
   - sudo docker images
   # With the selector (which eliminates the need to look up the pod name),
   # we cannot show all logs. 10000 lines should be sufficient.
-  - sudo kubectl logs -l name=pulp-operator -c ansible --tail=10000
-  - sudo kubectl logs -l name=pulp-operator -c operator --tail=10000
+  - sudo kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
   - sudo kubectl logs -l app=pulp-api --tail=10000
   - sudo kubectl logs -l app=pulp-content --tail=10000
   - sudo kubectl logs -l app=pulp-worker --tail=10000

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,18 +14,7 @@ spec:
     spec:
       serviceAccountName: pulp-operator
       containers:
-        - name: ansible
-          command:
-          - /usr/local/bin/ao-logs
-          - /tmp/ansible-operator/runner
-          - stdout
-          image: "quay.io/pulp/pulp-operator:latest"
-          imagePullPolicy: "IfNotPresent"
-          volumeMounts:
-          - mountPath: /tmp/ansible-operator/runner
-            name: runner
-            readOnly: true
-        - name: operator
+        - name: pulp-operator
           image: "quay.io/pulp/pulp-operator:latest"
           imagePullPolicy: "IfNotPresent"
           volumeMounts:

--- a/molecule/test-local/playbook.yml
+++ b/molecule/test-local/playbook.yml
@@ -111,7 +111,7 @@
 
     - name: get ansible logs
       failed_when: false
-      command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ namespace }} -c ansible
+      command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ namespace }} -c pulp-operator
       environment:
         KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
       vars:


### PR DESCRIPTION
Doing it, CI could catch if the new ansible-operator version has a breaking change

-----------------------------------------------------------------------------------------------------
`/bin/ao-logs` was removed on v0.18.0:
https://github.com/operator-framework/operator-sdk/blob/191d79824df3db82f98bd8e658551d0f846fe8f5/website/content/en/docs/migration/v0.18.0.md#remove-the-file-binao-logs-for-ansible-based-operators
How to migrate:
https://github.com/operator-framework/operator-sdk/blob/e128b9e5d147ef43fbca46b8ddb5037a9b1e3cbd/website/content/en/docs/migration/version-upgrade-guide.md