### PR TITLE
Update ansible-operator image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.7.0
+FROM quay.io/operator-framework/ansible-operator:v0.18.2
 
 COPY watches.yaml ${HOME}/watches.yaml
 


### PR DESCRIPTION
Currently, the CI is getting v0.17.2 because it is the latest release.
https://github.com/operator-framework/operator-sdk/releases
We want to get the most recent one (which is v0.18.2)
