### PR TITLE
Change molecule NodePort range

### DIFF
--- a/.travis/molecule.sh
+++ b/.travis/molecule.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-# Avoid nodePort error:
-# nodePort: Invalid value: 24816 The range of valid ports is 30000-32767
-# nodePort: Invalid value: 24817 The range of valid ports is 30000-32767
-find ./roles/* -exec sed -i 's/24816/31816/g' {} \;
-find ./roles/* -exec sed -i 's/24817/31817/g' {} \;
-
 # deploy/cluster_role_binding.yaml specify the namespace: default
 # The default namespace on molecule is: osdk-test
 # For running the molecule test we should:

--- a/CHANGES/7107.misc
+++ b/CHANGES/7107.misc
@@ -1,0 +1,1 @@
+Change molecule NodePort range

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -9,6 +9,12 @@
         flat: yes
         src: /root/.kube/config
 
+    - name: Change NodePort range
+      lineinfile:
+        path: /etc/kubernetes/manifests/kube-apiserver.yaml
+        line: '    - --service-node-port-range=24810-32767'
+        insertafter: 'service-cluster-ip-range.*'
+
     - name: Change the kubeconfig port to the proper value
       replace:
         regexp: '8443'


### PR DESCRIPTION
https://pulp.plan.io/issues/7107
closes #7107

From:
http://www.thinkcode.se/blog/2019/02/20/kubernetes-service-node-port-range