### PR TITLE
Starting to update to v1.0.0-alpha.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,11 @@ install:
   # It can mess up ownership of the python cache dir, so run it after the
   # non-sudo pip command.
   - .travis/k3s-install.sh
-  - CURRENT_VERSION=$(head -1 ./build/Dockerfile  | cut -d ":" -f 2)
-  - sudo wget https://github.com/operator-framework/operator-sdk/releases/download/$CURRENT_VERSION/operator-sdk-$CURRENT_VERSION-x86_64-linux-gnu -O /usr/local/bin/operator-sdk
-  - sudo chmod +x /usr/local/bin/operator-sdk
 jobs:
   include:
     - name: test-all-components
       script:
-        - sudo operator-sdk build quay.io/pulp/pulp-operator:latest
+        - sudo make docker-build
         - sudo docker images
         - sudo ./up.sh
         - .travis/pulp-operator-check-and-wait.sh
@@ -34,7 +31,7 @@ jobs:
         - .travis/pulp_file-tests.sh
     - name: test-insta-demo
       script:
-        - sudo operator-sdk build quay.io/pulp/pulp-operator:latest
+        - sudo make docker-build
         - sudo docker images
         - sudo insta-demo/pulp-insta-demo.sh
     - name: molecule
@@ -47,7 +44,7 @@ jobs:
       name: push-to-quay
       # Push image to quay. That is our upstream "deployment".
       script:
-        - sudo operator-sdk build quay.io/pulp/pulp-operator:latest
+        - sudo make docker-build
         - sudo .travis/deploy.sh
       if: type != pull_request
 after_failure:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM quay.io/operator-framework/ansible-operator:v0.18.2
+FROM quay.io/operator-framework/ansible-operator:v1.0.0-alpha.1
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible
 
 COPY watches.yaml ${HOME}/watches.yaml
-
 COPY roles/ ${HOME}/roles/
-COPY playbook.yml ${HOME}/playbook.yml
+COPY playbooks/ ${HOME}/playbooks/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,91 @@
+# Current Operator version
+VERSION ?= 0.0.1
+# Default bundle image tag
+BUNDLE_IMG ?= controller-bundle:$(VERSION)
+# Options for 'bundle-build'
+ifneq ($(origin CHANNELS), undefined)
+BUNDLE_CHANNELS := --channels=$(CHANNELS)
+endif
+ifneq ($(origin DEFAULT_CHANNEL), undefined)
+BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
+endif
+BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
+
+.PHONY: bundle
+
+# Image URL to use all building/pushing image targets
+IMG ?= controller:latest
+
+all: docker-build
+
+# Run against the configured Kubernetes cluster in ~/.kube/config
+run: ansible-operator
+	$(ANSIBLE_OPERATOR)
+
+# Install CRDs into a cluster
+install: kustomize
+	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+
+# Uninstall CRDs from a cluster
+uninstall: kustomize
+	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+
+# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
+deploy: kustomize
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default | kubectl apply -f -
+
+# Undeploy controller in the configured Kubernetes cluster in ~/.kube/config
+undeploy: kustomize
+	$(KUSTOMIZE) build config/default | kubectl delete -f -
+
+# Build the docker image
+docker-build:
+	docker build . -t ${IMG}
+
+# Push the docker image
+docker-push:
+	docker push ${IMG}
+
+PATH  := $(PATH):$(PWD)/bin
+SHELL := env PATH=$(PATH) /bin/sh
+OS    = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH  = $(shell uname -m | sed 's/x86_64/amd64/')
+OSOPER   = $(shell uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/apple-darwin/' | sed 's/linux/linux-gnu/')
+ARCHOPER = $(shell uname -m )
+
+kustomize:
+ifeq (, $(shell which kustomize 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p bin ;\
+	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.5.4/kustomize_v3.5.4_$(OS)_$(ARCH).tar.gz | tar xzf - -C bin/ ;\
+	}
+KUSTOMIZE=./bin/kustomize
+else
+KUSTOMIZE=$(shell which kustomize)
+endif
+
+ansible-operator:
+ifeq (, $(shell which ansible-operator 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p bin ;\
+	curl -LO https://github.com/operator-framework/operator-sdk/releases/download/v1.0.0-alpha.1/ansible-operator-v1.0.0-alpha.1-$(ARCHOPER)-$(OSOPER) ;\
+	mv ansible-operator-v1.0.0-alpha.1-$(ARCHOPER)-$(OSOPER) ./bin/ansible-operator ;\
+	chmod +x ./bin/ansible-operator ;\
+	}
+ANSIBLE_OPERATOR=$(realpath ./bin/ansible-operator)
+else
+ANSIBLE_OPERATOR=$(shell which ansible-operator)
+endif
+
+# Generate bundle manifests and metadata, then validate generated files.
+bundle: kustomize
+	operator-sdk generate kustomize manifests -q
+	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	operator-sdk bundle validate ./bundle
+
+# Build the bundle image.
+bundle-build:
+	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .

--- a/PROJECT
+++ b/PROJECT
@@ -1,0 +1,8 @@
+domain: pulpproject.org
+layout: ansible.sdk.operatorframework.io/v1
+projectName: pulp-operator
+resources:
+- group: pulpproject.org
+  kind: Pulp
+  version: v1alpha1
+version: 3-alpha

--- a/config/crd/bases/pulpproject.org.pulpproject.org_pulps.yaml
+++ b/config/crd/bases/pulpproject.org.pulpproject.org_pulps.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pulps.pulpproject.org.pulpproject.org
+spec:
+  group: pulpproject.org.pulpproject.org
+  names:
+    kind: Pulp
+    listKind: PulpList
+    plural: pulps
+    singular: pulp
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Pulp is the Schema for the pulps API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Pulp
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of Pulp
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,0 +1,6 @@
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/pulpproject.org.pulpproject.org_pulps.yaml
+# +kubebuilder:scaffold:crdkustomizeresource

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,0 +1,26 @@
+# Adds namespace to all resources.
+namespace: pulp-operator-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: pulp-operator-
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+- ../crd
+- ../rbac
+- ../manager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+#- ../prometheus
+
+patchesStrategicMerge:
+  # Protect the /metrics endpoint by putting it behind auth.
+  # If you want your controller-manager to expose the /metrics
+  # endpoint w/o any authn/z, please comment the following line.
+- manager_auth_proxy_patch.yaml

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -1,0 +1,26 @@
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+      - name: manager
+        args:
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"
+        - "--leader-election-id=pulp-operator"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- manager.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+        - name: manager
+          args:
+            - "--enable-leader-election"
+            - "--leader-election-id=pulp-operator"
+          image: controller:latest
+      terminationGracePeriodSeconds: 10

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- monitor.yaml

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,0 +1,16 @@
+---
+# Prometheus Monitor Service (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,0 +1,7 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: metrics-reader
+rules:
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: proxy-role
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,0 +1,20 @@
+resources:
+  - role.yaml
+  - role_binding.yaml
+  - leader_election_role.yaml
+  - leader_election_role_binding.yaml
+  # Comment the following 4 lines if you want to disable
+  # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+  # which protects your /metrics endpoint.
+  - auth_proxy_service.yaml
+  - auth_proxy_role.yaml
+  - auth_proxy_role_binding.yaml
+  - auth_proxy_client_clusterrole.yaml
+patchesJson6902:
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: manager-role
+    path: patches/pulp_editor_role.yaml
+# +kubebuilder:scaffold:patch6902

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -1,0 +1,25 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/rbac/patches/pulp_editor_role.yaml
+++ b/config/rbac/patches/pulp_editor_role.yaml
@@ -1,0 +1,27 @@
+---
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - pulpproject.org.pulpproject.org
+    resources:
+      - pulps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - pulpproject.org.pulpproject.org
+    resources:
+      - pulps/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - pods
+  - pods/exec
+  - pods/log
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,0 +1,3 @@
+## This file is auto-generated, do not modify ##
+resources:
+- pulpproject.org_v1alpha1_pulp.yaml

--- a/config/samples/pulpproject.org_v1alpha1_pulp.yaml
+++ b/config/samples/pulpproject.org_v1alpha1_pulp.yaml
@@ -1,0 +1,15 @@
+apiVersion: pulpproject.org.pulpproject.org/v1alpha1
+kind: Pulp
+metadata:
+  name: example-pulp
+spec:
+  tag: "latest"
+  pulp_file_storage:
+    # k3s local-path requires this
+    access_mode: "ReadWriteOnce"
+    # We have a little over 40GB free on Travis VMs/instances
+    size: "40Gi"
+  database_connection:
+    username: pulp
+    password: pulp
+    admin_password: pulp

--- a/config/scorecard/bases/config.yaml
+++ b/config/scorecard/bases/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests: []

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+- bases/config.yaml
+patchesJson6902:
+- path: patches/basic.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config
+- path: patches/olm.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config
+# +kubebuilder:scaffold:patchesJson6902

--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -1,0 +1,10 @@
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: basic
+      test: basic-check-spec-test

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -1,0 +1,50 @@
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test

--- a/config/testing/debug_logs_patch.yaml
+++ b/config/testing/debug_logs_patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - name: ANSIBLE_DEBUG_LOGS
+              value: "TRUE"

--- a/config/testing/kustomization.yaml
+++ b/config/testing/kustomization.yaml
@@ -1,0 +1,24 @@
+# Adds namespace to all resources.
+namespace: osdk-test
+
+namePrefix: osdk-
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+patchesStrategicMerge:
+- manager_image.yaml
+- pull_policy/Never.yaml
+- debug_logs_patch.yaml
+- ../default/manager_auth_proxy_patch.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../crd
+- ../rbac
+- ../manager
+images:
+- name: testing
+  newName: testing-operator

--- a/config/testing/manager_image.yaml
+++ b/config/testing/manager_image.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: testing

--- a/config/testing/pull_policy/Always.yaml
+++ b/config/testing/pull_policy/Always.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          imagePullPolicy: Always

--- a/config/testing/pull_policy/IfNotPresent.yaml
+++ b/config/testing/pull_policy/IfNotPresent.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          imagePullPolicy: IfNotPresent

--- a/config/testing/pull_policy/Never.yaml
+++ b/config/testing/pull_policy/Never.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          imagePullPolicy: Never

--- a/molecule/test-local/converge.yml
+++ b/molecule/test-local/converge.yml
@@ -15,7 +15,7 @@
       changed_when: false
 
     - name: Build Operator Image
-      command: docker build -f /build/build/Dockerfile -t {{ image }} /build
+      command: docker build -f /build/Dockerfile -t {{ image }} /build
       register: build_cmd
       changed_when: not hash or (hash and hash not in cmd_out)
       vars:

--- a/playbooks/pulp.yml
+++ b/playbooks/pulp.yml
@@ -5,7 +5,7 @@
     - community.kubernetes
     - operator_sdk.util
   vars:
-    project_name: "{{ meta.namespace }}"
+    project_name: "{{ ansible_operator_meta.namespace }}"
     database_connection:
       username: pulp
       password: pulp

--- a/watches.yaml
+++ b/watches.yaml
@@ -1,5 +1,7 @@
 ---
+# Use the 'create api' subcommand to add watches to this file.
 - version: v1alpha1
   group: pulpproject.org
   kind: Pulp
-  playbook: playbook.yml
+  playbook: playbooks/pulp.yml
+# +kubebuilder:scaffold:watch


### PR DESCRIPTION
https://master.sdk.operatorframework.io/docs/upgrading-sdk-version/v1.0.0-alpha.1/

```
cd pulp-operator
operator-sdk init --domain=pulpproject.org --plugins=ansible
operator-sdk create api --group pulpproject.org --version v1alpha1 --kind Pulp --generate-playbook
```

As the next step, we need to stop using `deploy/` and start to use `config/`
**Note**: this PR is not using any file from `/config`

Ref: https://github.com/operator-framework/operator-sdk/pull/3571
https://deploy-preview-3571--operator-sdk.netlify.app/docs/building-operators/ansible/migration/