### PR TITLE
Enable to choose between docker and podman when deploying

### DIFF
--- a/.ci/scripts/deploy.sh
+++ b/.ci/scripts/deploy.sh
@@ -16,7 +16,7 @@ sudo -E ./up.sh
 podman images
 
 echo "Deploy pulp-operator"
-sudo -E $GITHUB_WORKSPACE/.ci/scripts/quay-push.sh
+sudo -E PODMAN_OR_DOCKER=docker $GITHUB_WORKSPACE/.ci/scripts/quay-push.sh
 
 echo "Deploy pulp latest"
 sudo -E QUAY_REPO_NAME=pulp $GITHUB_WORKSPACE/.ci/scripts/quay-push.sh

--- a/.ci/scripts/quay-push.sh
+++ b/.ci/scripts/quay-push.sh
@@ -17,6 +17,8 @@ QUAY_IMAGE_TAG=${QUAY_IMAGE_TAG:-latest}
 
 QUAY_BOT_USERNAME=${QUAY_BOT_USERNAME:-pulp+github}
 
+RUNNER=${PODMAN_OR_DOCKER:-podman}
+
 # Reference: https://adriankoshka.github.io/blog/posts/travis-and-quay/
-echo "$QUAY_BOT_PASSWORD" | podman login -u "$QUAY_BOT_USERNAME" --password-stdin quay.io
-podman push "quay.io/$QUAY_PROJECT_NAME/$QUAY_REPO_NAME:$QUAY_IMAGE_TAG"
+echo "$QUAY_BOT_PASSWORD" | $RUNNER login -u "$QUAY_BOT_USERNAME" --password-stdin quay.io
+$RUNNER push "quay.io/$QUAY_PROJECT_NAME/$QUAY_REPO_NAME:$QUAY_IMAGE_TAG"

--- a/insta-demo/pulp-insta-demo.sh
+++ b/insta-demo/pulp-insta-demo.sh
@@ -58,8 +58,10 @@ fi
 if command -v git > /dev/null && [[ "$(basename `git rev-parse --show-toplevel`)" == "pulp-operator" ]]; then
   set -x
   # Travis does not checkout a branch, just a specific commit.
-  if [ -n "${GITHUB_REF}" ]; then
+  if [ -n "${GITHUB_HEAD_REF}" ]; then
     BRANCH=${GITHUB_HEAD_REF##*/}
+  elif [ -n "${GITHUB_REF}" ]; then
+    BRANCH=${GITHUB_REF##*/}
   else
     BRANCH=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} | cut -f 2- -d /)
   fi


### PR DESCRIPTION
pulp-operator image is built with docker, with the operator machinery.
While pulp and pulpcore images are built with podman.
[noissue]