### PR TITLE
Remove deployment_state variable

### DIFF
--- a/playbooks/pulp.yml
+++ b/playbooks/pulp.yml
@@ -24,7 +24,6 @@
       redis_port:  6379
       redis_password: ''
 #     content_origin: # Queried and set in pulp-api role
-    deployment_state: present
     registry: quay.io
     project: pulp
     image: pulp

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -1,21 +1,21 @@
 ---
 - name: postgres persistent volume claim
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.pvc.yaml.j2') | from_yaml }}"
   with_items:
     - postgres
 
 - name: postgres service
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.service.yaml.j2') | from_yaml }}"
   with_items:
     - postgres
 
 - name: postgres deployment
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
   with_items:
     - postgres

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: pulp-file-storage persistent volume claim
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.pvc.yaml.j2') | from_yaml }}"
   with_items:
     - pulp-file-storage
@@ -36,21 +36,21 @@
 
 - name: pulp-server config-map
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.config-map.yaml.j2') | from_yaml }}"
   with_items:
     - pulp-server
 
 - name: pulp-api service
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.service.yaml.j2') | from_yaml }}"
   with_items:
     - pulp-api
 
 - name: pulp-api deployment
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
   with_items:
     - pulp-api

--- a/roles/pulp-content/tasks/main.yml
+++ b/roles/pulp-content/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: pulp-content service
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.service.yaml.j2') | from_yaml }}"
   with_items:
     - pulp-content
 
 - name: pulp-content deployment
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
   with_items:
     - pulp-content

--- a/roles/pulp-resource-manager/tasks/main.yml
+++ b/roles/pulp-resource-manager/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: pulp-resource-manager deployment
   k8s:
-    state: "{{ deployment_state }}"
+    apply : true
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
   with_items:
     - pulp-resource-manager

--- a/roles/pulp-routes/tasks/main.yml
+++ b/roles/pulp-routes/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: pulp routes
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.route.yaml.j2') | from_yaml }}"
   with_items:
     - pulp

--- a/roles/pulp-worker/tasks/main.yml
+++ b/roles/pulp-worker/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: pulp-worker deployment
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
   with_items:
     - pulp-worker

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -1,21 +1,21 @@
 ---
 - name: redis persistent volume claim
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.pvc.yaml.j2') | from_yaml }}"
   with_items:
     - redis
 
 - name: redis service
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.service.yaml.j2') | from_yaml }}"
   with_items:
     - redis
 
 - name: redis deployment
   k8s:
-    state: "{{ deployment_state }}"
+    apply: true
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
   with_items:
     - redis


### PR DESCRIPTION
> The default behavior of an Ansible Operator is to delete all resources
> the operator created during reconciliation when a managed resource is
> marked for deletion.

Source: https://v0-19-x.sdk.operatorframework.io/docs/ansible/reference/finalizers/

Because of the above statement, having a `deployment_state` variable
becomes not needed.

Also, has a sanity for reconciliation loop, let's use `apply = true` to
ensure if the resource already exist it is re-applied nonetheless to be
always in the state desired.

[noissue]