### PR TITLE
Add security context fsGroup to deployment of postgres container

### DIFF
--- a/CHANGES/5141.misc
+++ b/CHANGES/5141.misc
@@ -1,0 +1,1 @@
+Add security context fsGroup to deployment of postgres

--- a/roles/postgres/templates/postgres.deployment.yaml.j2
+++ b/roles/postgres/templates/postgres.deployment.yaml.j2
@@ -16,6 +16,9 @@ spec:
       labels:
         app: postgres
     spec:
+      securityContext:
+        runAsUser: 26
+        fsGroup: 26
       containers:
         - name: postgres
           env:


### PR DESCRIPTION
Persistent volume will be accessed with UID and group associated with postgres as defined in the image

fixes #5141
https://pulp.plan.io/issues/5141