### PR TITLE
Add security context to deployments interacting with pulp-file-storage PVC

### DIFF
--- a/CHANGES/5142.misc
+++ b/CHANGES/5142.misc
@@ -1,0 +1,1 @@
+Add security context runAsUser and fsGroup to deployments interacting with pulp-file-storage PVC

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -16,6 +16,9 @@ spec:
       labels:
         app: pulp-api
     spec:
+      securityContext:
+        runAsUser: 0
+        fsGroup: 0
       #serviceAccountName: "{{ project_name }}-anyuid"
       volumes:
         - name: pulp-server

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -16,6 +16,9 @@ spec:
       labels:
         app: pulp-content
     spec:
+      securityContext:
+        runAsUser: 0
+        fsGroup: 0
       #serviceAccountName: "{{ project_name }}-anyuid"
       volumes:
         - name: pulp-server

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -16,6 +16,9 @@ spec:
       labels:
         app: pulp-resource-manager
     spec:
+      securityContext:
+        runAsUser: 0
+        fsGroup: 0
       #serviceAccountName: "{{ project_name }}-anyuid"
       volumes:
         - name: pulp-server

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -16,6 +16,9 @@ spec:
       labels:
         app: pulp-worker
     spec:
+      securityContext:
+        runAsUser: 0
+        fsGroup: 0
       #serviceAccountName: "{{ project_name }}-anyuid"
       volumes:
         - name: pulp-server


### PR DESCRIPTION
Add security context runAsUser and fsGroup to deployments interacting with pulp-file-storage PVC

fixes #5142
https://pulp.plan.io/issues/5142