### PR TITLE
Deploy standard redis image with CR naming convention.

### DIFF
--- a/CHANGES/8345.misc
+++ b/CHANGES/8345.misc
@@ -1,0 +1,1 @@
+Use standard redis image for operator deployment and parameterize deployment using custom resource naming

--- a/playbook.yml
+++ b/playbook.yml
@@ -17,7 +17,7 @@
           PORT: "{{ postgres_port }}"
           CONN_MAX_AGE: 0
       debug: "True"
-      redis_host: redis
+      redis_host: "{{ meta.name }}-redis"
       redis_port:  6379
       redis_password: ''
     deployment_state: present

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -43,6 +43,10 @@ spec:
               value: "{{ postgres_host }}"
             - name: POSTGRES_SERVICE_PORT
               value: "{{ postgres_port }}"
+            - name: REDIS_SERVICE_HOST
+              value: "{{ meta.name }}-redis"
+            - name: REDIS_SERVICE_PORT
+              value: "{{ pulp_default_settings.redis_port }}"
           ports:
             - protocol: TCP
               containerPort: 24817

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -41,6 +41,10 @@ spec:
               value: "{{ postgres_host }}"
             - name: POSTGRES_SERVICE_PORT
               value: "{{ postgres_port }}"
+            - name: REDIS_SERVICE_HOST
+              value: "{{ meta.name }}-redis"
+            - name: REDIS_SERVICE_PORT
+              value: "{{ pulp_default_settings.redis_port }}"
           ports:
             - protocol: TCP
               containerPort: 24816

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -41,6 +41,10 @@ spec:
               value: "{{ postgres_host }}"
             - name: POSTGRES_SERVICE_PORT
               value: "{{ postgres_port }}"
+            - name: REDIS_SERVICE_HOST
+              value: "{{ meta.name }}-redis"
+            - name: REDIS_SERVICE_PORT
+              value: "{{ pulp_default_settings.redis_port }}"
           volumeMounts:
             - name: pulp-server
               mountPath: "/etc/pulp/"

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -41,6 +41,10 @@ spec:
               value: "{{ postgres_host }}"
             - name: POSTGRES_SERVICE_PORT
               value: "{{ postgres_port }}"
+            - name: REDIS_SERVICE_HOST
+              value: "{{ meta.name }}-redis"
+            - name: REDIS_SERVICE_PORT
+              value: "{{ pulp_default_settings.redis_port }}"
           volumeMounts:
             - name: pulp-server
               mountPath: "/etc/pulp/"

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+redis_image: redis:latest

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -2,24 +2,23 @@
 apiVersion: v1
 kind: Deployment
 metadata:
-  name: redis
+  name: "{{ meta.name }}-redis"
   namespace: "{{ project_name }}"
   labels:
-    app: redis
+    app: '{{ deployment_type }}-redis'
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: redis
+      app: '{{ deployment_type }}-redis'
   template:
     metadata:
       labels:
-        app: redis
+        app: '{{ deployment_type }}-redis'
     spec:
-      #serviceAccountName: "{{ project_name }}-anyuid"
       containers:
         - name: redis
-          image: "{{ registry }}/{{ project }}/redis:latest"
+          image: "{{ redis_image }}"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: REDIS_DB

--- a/roles/redis/templates/redis.service.yaml.j2
+++ b/roles/redis/templates/redis.service.yaml.j2
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: redis
+  name: "{{ meta.name }}-redis"
   namespace: "{{ project_name }}"
   labels:
-    app: redis
+    app: "{{ deployment_type }}-redis"
 spec:
   selector:
-    app: redis
+    app: "{{ deployment_type }}-redis"
   ports:
     - protocol: TCP
       targetPort: 6379


### PR DESCRIPTION
* Move redis image to "redis:latest" aligning with other operators
* Parameterize deployment and service using CR naming
* Update consuming deployments with host & port informaiton

closes #8345
https://pulp.plan.io/issues/8345