### PR TITLE
Set or generate admin password with kubernetes secret.

### DIFF
--- a/.ci/assets/kubernetes/pulp-admin-password.secret.yaml
+++ b/.ci/assets/kubernetes/pulp-admin-password.secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: 'example-pulp-admin-password'
+  namespace: 'default'
+stringData:
+  password: 'password'

--- a/CHANGES/8353.misc
+++ b/CHANGES/8353.misc
@@ -1,0 +1,1 @@
+Allow ability to set the administrator password using a secret or have one automatically generated

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.ci.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.ci.yaml
@@ -4,6 +4,7 @@ metadata:
   name: example-pulp
 spec:
   tag: "latest"
+  pulp_admin_password_secret: "example-pulp-admin-password"
   pulp_file_storage:
     # k3s local-path requires this
     access_mode: "ReadWriteOnce"

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.default.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.default.yaml
@@ -31,7 +31,9 @@ metadata:
 #                      If on a cluster, you should set this manually until
 #                      ingress(es) are implemented. Example:
 #                      http://myserver.fqdn:24816
-  # PostgreSQL container settings
+  # The pulp adminstrator password secret.
+# pulp_admin_password_secret:
+  # PostgreSQL container settings secret.
 # postgres_configuration_secret: pg_secret_name
   # Configuration for the persistentVolumeClaim for /var/lib/pulp
 # pulp_file_storage:

--- a/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
@@ -44,6 +44,9 @@ spec:
               pulp_settings:
                 description: The pulp settings.
                 type: object
+              pulp_admin_password_secret:
+                  description: Secret where the administrator password can be found
+                  type: string
               postgres_configuration_secret:
                   description: Secret where the database configuration can be found
                   type: string

--- a/down.sh
+++ b/down.sh
@@ -27,3 +27,7 @@ $KUBECTL delete -f deploy/cluster_role_binding.yaml
 # It doesn't matter which cr we specify; the metadata up top is the same.
 $KUBECTL delete -f deploy/crds/pulpproject_v1beta1_pulp_cr.default.yaml
 $KUBECTL delete -f deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
+
+if [[ "$CI_TEST" == "true" ]]; then
+  $KUBECTL delete -f .ci/assets/kubernetes/pulp-admin-password.secret.yaml
+fi

--- a/roles/pulp-api/defaults/main.yml
+++ b/roles/pulp-api/defaults/main.yml
@@ -5,3 +5,7 @@ pulp_api:
 # Here we use  _pulpproject_org_pulp to get un-modified cr
 # see: https://github.com/operator-framework/operator-sdk/issues/1770
 raw_spec: "{{ vars['_pulp_pulpproject_org_pulp']['spec'] }}"
+
+# Secret to lookup that provide the admin password
+#
+pulp_admin_password_secret: ''

--- a/roles/pulp-api/tasks/admin_password_configuration.yml
+++ b/roles/pulp-api/tasks/admin_password_configuration.yml
@@ -1,0 +1,42 @@
+---
+- name: Check for specified admin password configuration
+  k8s_info:
+    kind: Secret
+    namespace: '{{ meta.namespace }}'
+    name: '{{ pulp_admin_password_secret }}'
+  register: _custom_admin_password
+  when: pulp_admin_password_secret | length
+
+- name: Check for default admin password configuration
+  k8s_info:
+    kind: Secret
+    namespace: '{{ meta.namespace }}'
+    name: '{{ meta.name }}-admin-password'
+  register: _default_admin_password
+
+- name: Set admin password secret
+  set_fact:
+    _admin_password_secret: '{{ _custom_admin_password["resources"] | default([]) | length | ternary(_custom_admin_password, _default_admin_password) }}'
+
+- block:
+    - name: Create admin password secret
+      k8s:
+        apply: true
+        definition: "{{ lookup('template', 'pulp-admin-password.secret.yaml.j2') }}"
+
+    - name: Read admin password secret
+      k8s_info:
+        kind: Secret
+        namespace: '{{ meta.namespace }}'
+        name: '{{ meta.name }}-admin-password'
+      register: _generated_admin_password
+
+  when: not _admin_password_secret['resources'] | default([]) | length
+
+- name: Set admin password secret
+  set_fact:
+    pulp_admin_password_secret_obj: '{{ _generated_admin_password["resources"] | default([]) | length | ternary(_generated_admin_password, _admin_password_secret) }}'
+
+- name: Store admin password
+  set_fact:
+    admin_password: "{{ pulp_admin_password_secret_obj['resources'][0]['data']['password'] | b64decode }}"

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -41,6 +41,9 @@
   with_items:
     - pulp-server
 
+- include_tasks:
+    file: admin_password_configuration.yml
+
 - name: pulp-api service
   community.kubernetes.k8s:
     state: "{{ deployment_state }}"

--- a/roles/pulp-api/templates/pulp-admin-password.secret.yaml.j2
+++ b/roles/pulp-api/templates/pulp-admin-password.secret.yaml.j2
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ meta.name }}-admin-password'
+  namespace: '{{ meta.namespace }}'
+stringData:
+  password: '{{ lookup('password', 'ts' + meta.name + 'pg length=32 chars=ascii_letters,digits') }}'

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -38,7 +38,7 @@ spec:
           env:
             # TODO: Replace with k8s secrets
             - name: PULP_ADMIN_PASSWORD
-              value: "password"
+              value: "{{ admin_password }}"
             - name: POSTGRES_SERVICE_HOST
               value: "{{ postgres_host }}"
             - name: POSTGRES_SERVICE_PORT

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -20,13 +20,6 @@ spec:
         - name: redis
           image: "{{ redis_image }}"
           imagePullPolicy: "IfNotPresent"
-          env:
-            - name: REDIS_DB
-              value: pulp
-            - name: REDIS_USER
-              value: pulp
-            - name: REDIS_PASS
-              value: pulp
           volumeMounts:
             - readOnly: false
               mountPath: /var/lib/redis

--- a/up.sh
+++ b/up.sh
@@ -24,6 +24,8 @@ if [[ -e deploy/crds/pulpproject_v1beta1_pulp_cr.yaml ]]; then
   CUSTOM_RESOURCE=pulpproject_v1beta1_pulp_cr.yaml
 elif [[ "$CI_TEST" == "true" ]]; then
   CUSTOM_RESOURCE=pulpproject_v1beta1_pulp_cr.ci.yaml
+  echo "Will deploy admin password secret for testing ..."
+  $KUBECTL apply -f .ci/assets/kubernetes/pulp-admin-password.secret.yaml
 elif [[ "$(hostname)" == "pulp-demo"* ]]; then
   CUSTOM_RESOURCE=pulpproject_v1beta1_pulp_cr.pulp-demo.yaml
 else


### PR DESCRIPTION
* Add option to specify the secret in the CRD
* Add tasks to check or generate the secret
* Update API deployment to use the value from the secret

closes #8353
https://pulp.plan.io/issues/8353