### PR TITLE
Enable the use of S3 compliant or Azure object storage as storage backend

### DIFF
--- a/.ci/scripts/pulp-operator-check-and-wait.sh
+++ b/.ci/scripts/pulp-operator-check-and-wait.sh
@@ -18,12 +18,12 @@ fi
 
 storage_debug() {
   echo "VOLUMES:"
-  sudo $KUBECTL get pvc
-  sudo $KUBECTL get pv
+  sudo -E $KUBECTL get pvc
+  sudo -E $KUBECTL get pv
   df -h
   if [ "$KUBE" = "k3s" ]; then
-    sudo $KUBECTL -n local-path-storage get pod
-    sudo $KUBECTL -n local-path-storage logs $STORAGE_POD
+    sudo -E $KUBECTL -n local-path-storage get pod
+    sudo -E $KUBECTL -n local-path-storage logs $STORAGE_POD
   fi
 }
 
@@ -51,7 +51,7 @@ echo "Waiting for services to come up ..."
 # Before the services are both up, the pods may not exist at all.
 # So check for the services being up 1st.
 for tries in {0..90}; do
-  services=$(sudo $KUBECTL get services)
+  services=$(sudo -E $KUBECTL get services)
   if [[ $(echo "$services" | grep -c NodePort) > 1 ]]; then
     # parse string like this. 30805 is the external port
     # pulp-api-svc     NodePort    10.43.170.79   <none>        24817:30805/TCP   0s
@@ -64,15 +64,15 @@ for tries in {0..90}; do
     if [[ $tries -eq 90 ]]; then
       echo "ERROR 2: 1 or more external services never came up"
       echo "NAMESPACES:"
-      sudo $KUBECTL get namespaces
+      sudo -E $KUBECTL get namespaces
       echo "SERVICES:"
       echo "$services"
       if [ -x "$(command -v docker)" ]; then
         echo "DOCKER IMAGE CACHE:"
-        sudo docker images
+        sudo -E docker images
       fi
       echo "PODS:"
-      sudo $KUBECTL get pods -o wide
+      sudo -E $KUBECTL get pods -o wide
       storage_debug
       exit 2
     fi
@@ -83,7 +83,7 @@ done
 if [[ "$KUBE" == "k3s" ]]; then
   # This needs to be down here. Otherwise, the storage pod may not be
   # up in time.
-  STORAGE_POD=$(sudo $KUBECTL -n local-path-storage get pod | awk '/local-path-provisioner/{print $1}')
+  STORAGE_POD=$(sudo -E $KUBECTL -n local-path-storage get pod | awk '/local-path-provisioner/{print $1}')
 fi
 
 echo "Waiting for pods to transition to Running ..."
@@ -91,7 +91,7 @@ echo "Waiting for pods to transition to Running ..."
 # quay.io .
 # Therefore, this wait is highly dependent on network speed.
 for tries in {0..180}; do
-  pods=$(sudo $KUBECTL get pods -o wide)
+  pods=$(sudo -E $KUBECTL get pods -o wide)
   if [[ $(echo "$pods" | grep -c -v -E "STATUS|Running") -eq 0 ]]; then
     echo "PODS:"
     echo "$pods"
@@ -106,7 +106,7 @@ for tries in {0..180}; do
       echo "$pods"
       if [ -x "$(command -v docker)" ]; then
         echo "DOCKER IMAGE CACHE:"
-        sudo docker images
+        sudo -E docker images
       fi
     fi
     if [[ $tries -eq 180 ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,12 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo kubectl logs -l app=pulp-api --tail=10000
-          sudo kubectl logs -l app=pulp-content --tail=10000
-          sudo kubectl logs -l app=pulp-worker --tail=10000
-          sudo kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app=pulp-api --tail=10000
+          sudo -E kubectl logs -l app=pulp-content --tail=10000
+          sudo -E kubectl logs -l app=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
 
   components:
@@ -135,12 +135,12 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo kubectl logs -l app=pulp-api --tail=10000
-          sudo kubectl logs -l app=pulp-content --tail=10000
-          sudo kubectl logs -l app=pulp-worker --tail=10000
-          sudo kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app=pulp-api --tail=10000
+          sudo -E kubectl logs -l app=pulp-content --tail=10000
+          sudo -E kubectl logs -l app=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
 
   galaxy:
@@ -211,12 +211,12 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo kubectl logs -l app=pulp-api --tail=10000
-          sudo kubectl logs -l app=pulp-content --tail=10000
-          sudo kubectl logs -l app=pulp-worker --tail=10000
-          sudo kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app=pulp-api --tail=10000
+          sudo -E kubectl logs -l app=pulp-content --tail=10000
+          sudo -E kubectl logs -l app=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
 
   molecule:
@@ -318,10 +318,10 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo kubectl logs -l app=pulp-api --tail=10000
-          sudo kubectl logs -l app=pulp-content --tail=10000
-          sudo kubectl logs -l app=pulp-worker --tail=10000
-          sudo kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app=pulp-api --tail=10000
+          sudo -E kubectl logs -l app=pulp-content --tail=10000
+          sudo -E kubectl logs -l app=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,12 +107,12 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo kubectl logs -l app=pulp-api --tail=10000
-          sudo kubectl logs -l app=pulp-content --tail=10000
-          sudo kubectl logs -l app=pulp-worker --tail=10000
-          sudo kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app=pulp-api --tail=10000
+          sudo -E kubectl logs -l app=pulp-content --tail=10000
+          sudo -E kubectl logs -l app=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
       # - name: Debugging example (uncomment when needed)
       #   if: failure()
@@ -152,7 +152,10 @@ jobs:
           minikube start --vm-driver=docker --extra-config=apiserver.service-node-port-range=80-32000
         # now you can run kubectl to see the pods in the cluster
       - name: Try the cluster !
-        run: kubectl get pods -A
+        run: |
+          kubectl config view > $PWD/kubeconfig
+          kubectl get pods -A
+          echo "KUBECONFIG=$PWD/kubeconfig" >> $GITHUB_ENV
       - name: Setup a minikube docker env
         run: minikube -p minikube docker-env | grep "export" | awk '{$1= ""; print $0}' >> $GITHUB_ENV
       - name: Build Operator
@@ -167,7 +170,10 @@ jobs:
           sudo -E docker images
         shell: bash
       - name: Deploy pulp-operator to K8s
-        run: sudo -E ./up.sh
+        run: |
+          echo $KUBECONFIG
+          cat $KUBECONFIG
+          sudo -E ./up.sh
         shell: bash
       - name: Check and wait pulp-operator deploy
         run: .ci/scripts/pulp-operator-check-and-wait.sh -m
@@ -183,12 +189,12 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo kubectl logs -l app=pulp-api --tail=10000
-          sudo kubectl logs -l app=pulp-content --tail=10000
-          sudo kubectl logs -l app=pulp-worker --tail=10000
-          sudo kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app=pulp-api --tail=10000
+          sudo -E kubectl logs -l app=pulp-content --tail=10000
+          sudo -E kubectl logs -l app=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
       # - name: Debugging example (uncomment when needed)
       #   if: failure()
@@ -263,12 +269,12 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo kubectl logs -l app=pulp-api --tail=10000
-          sudo kubectl logs -l app=pulp-content --tail=10000
-          sudo kubectl logs -l app=pulp-worker --tail=10000
-          sudo kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app=pulp-api --tail=10000
+          sudo -E kubectl logs -l app=pulp-content --tail=10000
+          sudo -E kubectl logs -l app=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
       # - name: Debugging example (uncomment when needed)
       #   if: failure()

--- a/CHANGES/8361.feature
+++ b/CHANGES/8361.feature
@@ -1,0 +1,1 @@
+Enable the use of S3 compliant or Azure object storage as storage backend

--- a/containers/images/pulp/Containerfile.core.j2
+++ b/containers/images/pulp/Containerfile.core.j2
@@ -47,10 +47,12 @@ RUN		dnf -y update && \
 # Need to install optional dep, rhsm, for pulp-certguard
 RUN pip install rhsm
 
-RUN mkdir -p /etc/pulp
-RUN mkdir -p /var/lib/pulp/media
+RUN mkdir -p /etc/pulp \
+			 /var/lib/pulp/media \
+			 /var/lib/pulp/assets \
+			 /var/lib/pulp/tmp
 
-RUN pip install gunicorn django-storages[boto3]
+RUN pip install gunicorn django-storages[boto3,azure]
 {% if s3_test is defined %}
 # Hacking botocore (https://github.com/boto/botocore/pull/1990):
 RUN sed -i "s/hasattr(body, 'read')/getattr(body, '_size', None)/g" $(pip show botocore | grep -i location | awk '{ print $2 }')/botocore/handlers.py

--- a/containers/images/pulp/container-assets/pulp-api
+++ b/containers/images/pulp/container-assets/pulp-api
@@ -24,7 +24,9 @@ if [ -n "${PULP_ADMIN_PASSWORD}" ]; then
     django-admin reset-admin-password --password "${PULP_ADMIN_PASSWORD}"
 fi
 
-mkdir -p /var/lib/pulp/media
+mkdir -p /var/lib/pulp/media \
+         /var/lib/pulp/assets \
+         /var/lib/pulp/tmp
 
 # NOTE: Due to the Linux dual-stack functionality, this will listen on both IPv4
 # IPv6, even though netstat may seem to indicate it is IPv6 only.

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.ci.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.ci.yaml
@@ -6,8 +6,9 @@ spec:
   # image: pulp
   tag: "latest"
   pulp_admin_password_secret: "example-pulp-admin-password"
-  pulp_file_storage:
-    # k3s local-path requires this
-    access_mode: "ReadWriteOnce"
-    # We have a little over 10GB free on GHA VMs/instances
-    size: "10Gi"
+  pulp_storage:
+    file:
+      # k3s local-path requires this
+      access_mode: "ReadWriteOnce"
+      # We have a little over 10GB free on GHA VMs/instances
+      size: "10Gi"

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.default.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.default.yaml
@@ -13,49 +13,35 @@ metadata:
 # tag: "stable"
   # Pulp settings.
 # pulp_settings:
-#    databases:
-#      default:
-#        HOST: postgres
-#        ENGINE: django.db.backends.postgresql_psycopg2
-#        NAME: pulp
-#        USER: pulp
-#        PASSWORD: pulp
-#        PORT: 5432,
-#        CONN_MAX_AGE: 0
 #    debug: "True"
-#    redis_host: redis
-#    redis_port:  6379
-#    redis_password: ''
-#    content_origin: # pulp-operator will query the 1st address of the 1st k8s
-#                      node. This suffices for most single node deployments.
-#                      If on a cluster, you should set this manually until
-#                      ingress(es) are implemented. Example:
-#                      http://myserver.fqdn:24816
   # The pulp adminstrator password secret.
 # pulp_admin_password_secret:
   # PostgreSQL container settings secret.
 # postgres_configuration_secret: pg_secret_name
   # Configuration for the persistentVolumeClaim for /var/lib/pulp
-# pulp_file_storage:
-     # If your K8s cluster is only 1 node, and its StorageClass /
-     # provisioner does not support ReadWriteMany, then you must change
-     # this to "ReadWriteOnce".
-     #
-     # If your K8s cluster is multiple nodes, and does not support
-     # ReadWriteMany, then pulp-operator is currently incompatible.
-     #
-     # Reference on which support ReadWriteMany:
-     # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
-#      access_mode: "ReadWriteMany"
+# pulp_storage:
+#   file:
+      # If your K8s cluster is only 1 node, and its StorageClass /
+      # provisioner does not support ReadWriteMany, then you must change
+      # this to "ReadWriteOnce".
+      #
+      # If your K8s cluster is multiple nodes, and does not support
+      # ReadWriteMany, then pulp-operator is currently incompatible.
+      #
+      # Reference on which support ReadWriteMany:
+      # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
+#       access_mode: "ReadWriteMany"
 
-     # How much space do you want to give Pulp for storing content under
-     # /var/lib/pulp ?
-     # https://docs.pulpproject.org/en/3.0/nightly/installation/configuration.html#media-root
+      # How much space do you want to give Pulp for storing content under
+      # /var/lib/pulp ?
+      # https://docs.pulpproject.org/en/3.0/nightly/installation/configuration.html#media-root
 
-     # For reference, epel7 x86_64 is currently (2019-07) 30G. So 100G
-     # should be sufficient for a test deployment with only the RPM
-     # content plugin.
-#    size: "100Gi"
+      # For reference, epel7 x86_64 is currently (2019-07) 30G. So 100G
+      # should be sufficient for a test deployment with only the RPM
+      # content plugin.
+#     size: "100Gi"
+#   object_storage:
+#     s3_secret: "s3secret"
   # Values below are set in roles rather than in playbook.yaml
 # pulp_api:
 #   replicas: 1

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.pulp-demo.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.pulp-demo.yaml
@@ -3,10 +3,11 @@ kind: Pulp
 metadata:
   name: example-pulp
 spec:
-  pulp_file_storage:
-    # This doesn't really matter for minikube. Single node by design,
-    # but the storage provisioner allows for ReadWriteMany. So let's
-    # stick to our default.
-    access_mode: "ReadWriteMany"
-    # The minikube VM won't go any larger.
-    size: "375Gi"
+  pulp_storage:
+    file:
+      # This doesn't really matter for minikube. Single node by design,
+      # but the storage provisioner allows for ReadWriteMany. So let's
+      # stick to our default.
+      access_mode: "ReadWriteMany"
+      # The minikube VM won't go any larger.
+      size: "375Gi"

--- a/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
@@ -43,6 +43,9 @@ spec:
                 default: stable
               pulp_settings:
                 description: The pulp settings.
+                properties:
+                  debug:
+                    type: string
                 type: object
               pulp_admin_password_secret:
                   description: Secret where the administrator password can be found
@@ -87,19 +90,33 @@ spec:
               postgres_data_path:
                 description: Path where the PostgreSQL data are located
                 type: string
-              pulp_file_storage:
-                description: Configuration for the persistentVolumeClaim for /var/lib/pulp.
+              pulp_storage:
+                description: Configuration for the storage to be utilized
                 properties:
-                  access_mode:
-                    description: The file storage access mode.
-                    type: string
-                    default: ReadWriteMany
-                    enum:
-                      - ReadWriteMany
-                      - ReadWriteOnce
-                  size:
-                    description: The size of the file storage; for example 100Gi.
-                    type: string
+                  file:
+                    description: Configuration for the persistentVolumeClaim for /var/lib/pulp.
+                    properties:
+                      access_mode:
+                        description: The file storage access mode.
+                        type: string
+                        default: ReadWriteMany
+                        enum:
+                          - ReadWriteMany
+                          - ReadWriteOnce
+                      size:
+                        description: The size of the file storage; for example 100Gi.
+                        type: string
+                    type: object
+                  object_storage:
+                    description: Configuration for the object storage.
+                    properties:
+                      s3_secret:
+                        description: The secret for S3 compliant object storage configuration.
+                        type: string
+                      azure_secret:
+                        description: The secret for Azure blob storage configuration.
+                        type: string
+                    type: object
                 type: object
               pulp_hostname:
                 description: The hostname of the instance

--- a/playbook.yml
+++ b/playbook.yml
@@ -26,9 +26,10 @@
     image: pulp
     image_web: pulp-web
     tag: stable
-    pulp_file_storage:
-      access_mode: "ReadWriteMany"
-      size: "100Gi"
+    pulp_storage:
+      file:
+        access_mode: "ReadWriteMany"
+        size: "100Gi"
   roles:
     - postgres
     - redis

--- a/roles/pulp-api/README.md
+++ b/roles/pulp-api/README.md
@@ -19,26 +19,17 @@ Role Variables
     [Dynaconf syntax](https://dynaconf.readthedocs.io/en/latest/guides/environment_variables.html#precedence-and-type-casting)
     Please see [pulpcore configuration docs](https://docs.pulpproject.org/en/master/nightly/installation/configuration.html#id2)
     for documentation on the possible variable names and their values.
-    * `databases`: The default database config.
-        * `default`: A dictionary with the default database values.
-              * `HOST`: The database host.
-              * `ENGINE`: The django backend engine.
-              * `NAME`: The database name.
-              * `USER`: The database user.
-              * `PASSWORD`: The database password.
-              * `PORT`: The database port.
-              * `CONN_MAX_AGE`: The lifetime of a database connection.
     * `debug`: Wether to run pulp in debug mode.
-    * `redis_host`: The redis host.
-    * `redis_port`: The redis port.
-    * `redis_password`: The redis password.
 * `registry`: The container registry.
 * `project`: The project name e.g. user or org name at the container registry.
 * `image`: The image name.
 * `tag`: The tag name.
-* `pulp_file_storage`: A dict for specifying a persistent volume claim for pulp-file.
-    * `access_mode`: The access mode for the volume.
-    * `size`: The storage size.
+* `pulp_storage`: A dict for specifying storage configuration.
+    * `file`: A dict for specifying a persistent volume claim for pulp-file.
+        * `access_mode`: The access mode for the volume.
+        * `size`: The storage size.
+    * `object_storage`: A dict for specifying s3 compliant object storage configuation.
+        * `s3_secret`: The kubernetes secret with s3 configuration information.
 
 Dependencies
 ------------

--- a/roles/pulp-api/defaults/main.yml
+++ b/roles/pulp-api/defaults/main.yml
@@ -29,3 +29,31 @@ ingress_tls_secret: ''
 # credentials to deploy
 #
 route_tls_secret: ''
+
+file_storage: true
+
+object_storage_path: ''
+
+s3_secret_data_avaiable: false
+s3_access_key_id_available: false
+s3_secret_access_key_available: false
+s3_bucket_name_available: false
+s3_region_available: false
+s3_endpoint_available: false
+
+default_s3_settings:
+  AWS_DEFAULT_ACL: "@none None"
+  S3_USE_SIGV4: true
+  AWS_S3_SIGNATURE_VERSION: "s3v4"
+  AWS_S3_ADDRESSING_STYLE: "path"
+  DEFAULT_FILE_STORAGE: "storages.backends.s3boto3.S3Boto3Storage"
+
+azure_secret_data_avaiable: false
+azure_account_name_available: false
+azure_account_key_available: false
+azure_container_available: false
+
+default_azure_settings:
+  AZURE_URL_EXPIRATION_SECS: 60
+  AZURE_OVERWRITE_FILES: "True"
+  DEFAULT_FILE_STORAGE: "storages.backends.azure_storage.AzureStorage"

--- a/roles/pulp-api/tasks/azure-storage-configuration.yml
+++ b/roles/pulp-api/tasks/azure-storage-configuration.yml
@@ -1,0 +1,111 @@
+---
+- name: Check for specified azure storage configuration
+  k8s_info:
+    kind: Secret
+    namespace: '{{ meta.namespace }}'
+    name: '{{ pulp_storage.object_storage.azure_secret  }}'
+  register: _custom_azure_configuration
+
+- name: Check azure secret data format
+  set_fact:
+    azure_secret_data_avaiable: true
+  when:
+    - _custom_azure_configuration is defined
+    - _custom_azure_configuration.resources is defined
+    - _custom_azure_configuration.resources[0] is defined
+    - _custom_azure_configuration.resources[0].data is defined
+
+- name: Fail if azure secret object is an unexpected format
+  fail:
+    msg: "Cannot read the data for secret {{ pulp_storage.object_storage.azure_secret  }}"
+  when:
+    - not azure_secret_data_avaiable
+
+- name: Check if azure-account-name is found
+  set_fact:
+    azure_account_name_available: true
+  when:
+    - azure_secret_data_avaiable
+    - _custom_azure_configuration.resources[0].data['azure-account-name'] is defined
+    - _custom_azure_configuration.resources[0].data['azure-account-name'] | length
+
+- name: Check if azure-account-key is found
+  set_fact:
+    azure_account_key_available: true
+  when:
+    - azure_secret_data_avaiable
+    - _custom_azure_configuration.resources[0].data['azure-account-key'] is defined
+    - _custom_azure_configuration.resources[0].data['azure-account-key'] | length
+
+- name: Check if azure-container is found
+  set_fact:
+    azure_container_available: true
+  when:
+    - azure_secret_data_avaiable
+    - _custom_azure_configuration.resources[0].data['azure-container'] is defined
+    - _custom_azure_configuration.resources[0].data['azure-container'] | length
+
+- name: Fail if required azure secret items are not present
+  fail:
+    msg: "Secret {{ pulp_storage.object_storage.azure_secret  }} is missing required configuration data."
+  when:
+    - azure_secret_data_avaiable
+    - not azure_account_name_available
+    - not azure_account_key_available
+    - not azure_container_available
+
+- name: Store azure account name
+  set_fact:
+    azure_account_name: "{{ _custom_azure_configuration['resources'][0]['data']['azure-account-name'] | b64decode }}"
+
+- name: Store azure account key
+  set_fact:
+    azure_account_key: "{{ _custom_azure_configuration['resources'][0]['data']['azure-account-key'] | b64decode }}"
+
+- name: Store azure account container
+  set_fact:
+    azure_container: "{{ _custom_azure_configuration['resources'][0]['data']['azure-container'] | b64decode }}"
+
+- name: Store azure account container path
+  set_fact:
+    object_storage_path: "{{ _custom_azure_configuration['resources'][0]['data']['azure-container-path'] | b64decode }}"
+  when:
+    - azure_secret_data_avaiable
+    - _custom_azure_configuration.resources[0].data['azure-container-path'] is defined
+    - _custom_azure_configuration.resources[0].data['azure-container-path'] | length
+
+- name: Add azure account name azure settings
+  set_fact:
+    azure_account_name_dict : "{'AZURE_ACCOUNT_NAME': '{{ azure_account_name }}' }"
+
+- name: Add azure account key azure settings
+  set_fact:
+    azure_account_key_dict : "{'AZURE_ACCOUNT_KEY': '{{ azure_account_key }}' }"
+
+- name: Add azure container azure settings
+  set_fact:
+    azure_container_dict : "{'AZURE_CONTAINER': '{{ azure_container }}' }"
+
+- name: Add azure container path azure settings
+  set_fact:
+    azure_container_path_dict : "{'AZURE_LOCATION': '{{ object_storage_path }}' }"
+
+- name: merge azure_account_name with settings
+  set_fact:
+    default_azure_settings: "{{ default_azure_settings|combine(azure_account_name_dict) }}"
+
+- name: merge azure_account_key with settings
+  set_fact:
+    default_azure_settings: "{{ default_azure_settings|combine(azure_account_key_dict) }}"
+
+- name: merge azure_container with settings
+  set_fact:
+    default_azure_settings: "{{ default_azure_settings|combine(azure_container_dict) }}"
+
+- name: merge azure_container_path with settings
+  set_fact:
+    default_azure_settings: "{{ default_azure_settings|combine(azure_container_path_dict) }}"
+
+- name: merge default_azure_settings with settings
+  set_fact:
+    pulp_default_settings: "{{ pulp_default_settings|combine(default_azure_settings) }}"

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -2,12 +2,32 @@
 - set_fact:
     secret_key: "{{ lookup('password', '/dev/null length=50 chars=ascii_letters') }}"
 
+- set_fact:
+    file_storage: false
+  when:
+    - pulp_storage.object_storage is defined
+
 - name: pulp-file-storage persistent volume claim
   community.kubernetes.k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.pvc.yaml.j2') | from_yaml }}"
   with_items:
     - pulp-file-storage
+  when: file_storage
+
+- include_tasks:
+    file: s3-storage-configuration.yml
+  when:
+    - not file_storage
+    - pulp_storage.object_storage.s3_secret is defined
+    - pulp_storage.object_storage.s3_secret | length
+
+- include_tasks:
+    file: azure-storage-configuration.yml
+  when:
+    - not file_storage
+    - pulp_storage.object_storage.azure_secret is defined
+    - pulp_storage.object_storage.azure_secret | length
 
 # Workaround being unable to do the following, for the subsequent task:
 # when: (pulp_settings is not defined) or

--- a/roles/pulp-api/tasks/s3-storage-configuration.yml
+++ b/roles/pulp-api/tasks/s3-storage-configuration.yml
@@ -1,0 +1,160 @@
+---
+- name: Check for specified s3 storage configuration
+  k8s_info:
+    kind: Secret
+    namespace: '{{ meta.namespace }}'
+    name: '{{ pulp_storage.object_storage.s3_secret  }}'
+  register: _custom_s3_configuration
+
+- name: Check s3 secret data format
+  set_fact:
+    s3_secret_data_avaiable: true
+  when:
+    - _custom_s3_configuration is defined
+    - _custom_s3_configuration.resources is defined
+    - _custom_s3_configuration.resources[0] is defined
+    - _custom_s3_configuration.resources[0].data is defined
+
+- name: Fail if s3 secret object is an unexpected format
+  fail:
+    msg: "Cannot read the data for secret {{ pulp_storage.object_storage.s3_secret  }}"
+  when:
+    - not s3_secret_data_avaiable
+
+- name: Check if s3-access-key-id is found
+  set_fact:
+    s3_access_key_id_available: true
+  when:
+    - s3_secret_data_avaiable
+    - _custom_s3_configuration.resources[0].data['s3-access-key-id'] is defined
+    - _custom_s3_configuration.resources[0].data['s3-access-key-id'] | length
+
+- name: Check if s3-secret-access-key is found
+  set_fact:
+    s3_secret_access_key_available: true
+  when:
+    - s3_secret_data_avaiable
+    - _custom_s3_configuration.resources[0].data['s3-secret-access-key'] is defined
+    - _custom_s3_configuration.resources[0].data['s3-secret-access-key'] | length
+
+- name: Check if s3-bucket-name is found
+  set_fact:
+    s3_bucket_name_available: true
+  when:
+    - s3_secret_data_avaiable
+    - _custom_s3_configuration.resources[0].data['s3-bucket-name'] is defined
+    - _custom_s3_configuration.resources[0].data['s3-bucket-name'] | length
+
+- name: Check if s3-region is found
+  set_fact:
+    s3_region_available: true
+  when:
+    - s3_secret_data_avaiable
+    - _custom_s3_configuration.resources[0].data['s3-region'] is defined
+    - _custom_s3_configuration.resources[0].data['s3-region'] | length
+
+- name: Check if s3-endpoint is found
+  set_fact:
+    s3_endpoint_available: true
+  when:
+    - s3_secret_data_avaiable
+    - _custom_s3_configuration.resources[0].data['s3-endpoint'] is defined
+    - _custom_s3_configuration.resources[0].data['s3-endpoint'] | length
+
+- name: Fail if required s3 secret items are not present
+  fail:
+    msg: "Secret {{ pulp_storage.object_storage.s3_secret  }} is missing required configuration data."
+  when:
+    - s3_secret_data_avaiable
+    - not s3_access_key_id_available
+    - not s3_secret_access_key_available
+    - not s3_bucket_name_available
+    - not (s3_region_available or s3_endpoint_available)
+
+- name: Store s3 access key
+  set_fact:
+    s3_access_key_id: "{{ _custom_s3_configuration['resources'][0]['data']['s3-access-key-id'] | b64decode }}"
+
+- name: Store s3 secret
+  set_fact:
+    s3_secret_access_key: "{{ _custom_s3_configuration['resources'][0]['data']['s3-secret-access-key'] | b64decode }}"
+
+- name: Store s3 bucket name
+  set_fact:
+    s3_bucket_name: "{{ _custom_s3_configuration['resources'][0]['data']['s3-bucket-name'] | b64decode }}"
+
+- name: Store s3 bucket path
+  set_fact:
+    object_storage_path: "{{ _custom_s3_configuration['resources'][0]['data']['s3-bucket-path'] | b64decode }}"
+  when:
+    - s3_secret_data_avaiable
+    - _custom_s3_configuration.resources[0].data['s3-bucket-path'] is defined
+    - _custom_s3_configuration.resources[0].data['s3-bucket-path'] | length
+
+- name: Store s3 region
+  set_fact:
+    s3_region: "{{ _custom_s3_configuration['resources'][0]['data']['s3-region'] | b64decode }}"
+  when:
+    - s3_region_available
+
+- name: Store s3 endpoint
+  set_fact:
+    s3_endpoint: "{{ _custom_s3_configuration['resources'][0]['data']['s3-endpoint'] | b64decode }}"
+  when:
+    - s3_endpoint_available
+
+- name: Add s3 access key id to s3 settings
+  set_fact:
+    s3_access_key_id_dict : "{'AWS_ACCESS_KEY_ID': '{{ s3_access_key_id }}' }"
+
+- name: Add s3 secret key to s3 settings
+  set_fact:
+    s3_secret_access_key_dict : "{'AWS_SECRET_ACCESS_KEY': '{{ s3_secret_access_key }}' }"
+
+- name: Add s3 bucket to s3 settings
+  set_fact:
+    s3_bucket_name_dict : "{'AWS_STORAGE_BUCKET_NAME': '{{ s3_bucket_name }}' }"
+
+- name: Add s3 bucket path to s3 settings
+  set_fact:
+    s3_bucket_path_dict : "{'MEDIA_ROOT': '{{ object_storage_path }}' }"
+
+- name: Add s3 region to s3 settings
+  set_fact:
+    s3_region_dict : "{'AWS_S3_REGION_NAME': '{{ s3_region }}' }"
+  when: s3_region is defined
+
+- name: Add s3 endpoint to s3 settings
+  set_fact:
+    s3_endpoint_dict : "{'AWS_S3_ENDPOINT_URL': '{{ s3_endpoint }}' }"
+  when: s3_endpoint is defined
+
+- name: merge s3_access_key_id with settings
+  set_fact:
+    default_s3_settings: "{{ default_s3_settings|combine(s3_access_key_id_dict) }}"
+
+- name: merge s3_secret_access_key with settings
+  set_fact:
+    default_s3_settings: "{{ default_s3_settings|combine(s3_secret_access_key_dict) }}"
+
+- name: merge s3_bucket_name with settings
+  set_fact:
+    default_s3_settings: "{{ default_s3_settings|combine(s3_bucket_name_dict) }}"
+
+- name: merge s3_bucket_path with settings
+  set_fact:
+    default_s3_settings: "{{ default_s3_settings|combine(s3_bucket_path_dict) }}"
+
+- name: merge s3_region with settings
+  set_fact:
+    default_s3_settings: "{{ default_s3_settings|combine(s3_region_dict) }}"
+  when: s3_region_dict is defined
+
+- name: merge s3_endpoint with settings
+  set_fact:
+    default_s3_settings: "{{ default_s3_settings|combine(s3_endpoint_dict) }}"
+  when: s3_endpoint_dict is defined
+
+- name: merge default_s3_settings with settings
+  set_fact:
+    pulp_default_settings: "{{ pulp_default_settings|combine(default_s3_settings) }}"

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -32,9 +32,11 @@ spec:
             items:
               - path: pulp-admin-password
                 key: password
+{% if file_storage %}
         - name: pulp-file-storage
           persistentVolumeClaim:
             claimName: pulp-file-storage
+{% endif %}
       containers:
         - name: pulp-api
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
@@ -80,6 +82,8 @@ spec:
               mountPath: "/etc/pulp/pulp-admin-password"
               subPath: pulp-admin-password
               readOnly: true
+{% if file_storage %}
             - name: pulp-file-storage
               readOnly: false
               mountPath: "/var/lib/pulp"
+{% endif %}

--- a/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
+++ b/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
@@ -7,6 +7,6 @@ metadata:
 spec:
   resources:
     requests:
-      storage: "{{ pulp_file_storage.size }}"
+      storage: "{{ pulp_storage.file.size }}"
   accessModes:
-    - "{{ pulp_file_storage.access_mode }}"
+    - "{{ pulp_storage.file.access_mode }}"

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -26,9 +26,11 @@ spec:
             items:
               - path: settings.py
                 key: settings.py
+{% if file_storage %}
         - name: pulp-file-storage
           persistentVolumeClaim:
             claimName: pulp-file-storage
+{% endif %}
       containers:
         - name: pulp-content
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
@@ -50,6 +52,8 @@ spec:
           volumeMounts:
             - name: {{ meta.name }}-pulp-server
               mountPath: "/etc/pulp/"
+{% if file_storage %}
             - name: pulp-file-storage
               readOnly: false
               mountPath: "/var/lib/pulp"
+{% endif %}

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -27,9 +27,11 @@ spec:
             items:
               - path: settings.py
                 key: settings.py
+{% if file_storage %}
         - name: pulp-file-storage
           persistentVolumeClaim:
             claimName: pulp-file-storage
+{% endif %}
       containers:
         - name: pulp-resource-manager
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
@@ -48,6 +50,8 @@ spec:
           volumeMounts:
             - name: {{ meta.name }}-pulp-server
               mountPath: "/etc/pulp/"
+{% if file_storage %}
             - name: pulp-file-storage
               readOnly: false
               mountPath: "/var/lib/pulp"
+{% endif %}

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -26,9 +26,11 @@ spec:
             items:
               - path: settings.py
                 key: settings.py
+{% if file_storage %}
         - name: pulp-file-storage
           persistentVolumeClaim:
             claimName: pulp-file-storage
+{% endif %}
       containers:
         - name: pulp-worker
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
@@ -47,6 +49,8 @@ spec:
           volumeMounts:
             - name: {{ meta.name }}-pulp-server
               mountPath: "/etc/pulp/"
+{% if file_storage %}
             - name: pulp-file-storage
               readOnly: false
               mountPath: "/var/lib/pulp"
+{% endif %}


### PR DESCRIPTION
* Update container with both storage options
* Update CRD with object storage configuration via secret
* Add roles to configure settings.py based on object storage secret
* Do not create and bind PVC if object storage is used

closes #8361
https://pulp.plan.io/issues/8361