### PR TITLE
Enable the deployment of galaxy via CR with web content

### DIFF
--- a/.ci/assets/kubernetes/pulp-object-storage.aws.secret.yaml
+++ b/.ci/assets/kubernetes/pulp-object-storage.aws.secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: 'example-pulp-object-storage'
+  namespace: 'default'
+stringData:
+  s3-access-key-id: 'myaccesskey'
+  s3-secret-access-key: 'mysecret'
+  s3-bucket-name: 'mybucket'
+  s3-region: 'us-east-1'

--- a/.ci/assets/kubernetes/pulp-object-storage.azure.secret.yaml
+++ b/.ci/assets/kubernetes/pulp-object-storage.azure.secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: 'example-pulp-object-storage'
+  namespace: 'default'
+stringData:
+  azure-account-name: 'myaccount'
+  azure-account-key: 'mykey'
+  azure-container: 'mycontainer'
+  azure-container-path: 'mypath'

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,9 @@ Pipfile.lock
 
 # Ignore generated container files
 containers/images/pulp/Containerfile.core.p*
+containers/images/pulp/Containerfile.core.g*
 containers/images/pulp/Containerfile.web.p*
+containers/images/pulp/Containerfile.web.g*
+
+# Ignore testing directory
+testing/*

--- a/CHANGES/8399.misc
+++ b/CHANGES/8399.misc
@@ -1,0 +1,1 @@
+Simplify various deployments with sample custom resources and scripted deployment

--- a/containers/images/pulp/Containerfile.web.j2
+++ b/containers/images/pulp/Containerfile.web.j2
@@ -1,13 +1,24 @@
 FROM {{ registry | default('quay.io') }}/{{ project | default('pulp') }}/{{ item.value.base_image_name | default('pulp') }}:{{ item.value.tag | default('latest') }} as builder
 
-RUN mkdir -p /etc/nginx/pulp
+RUN mkdir -p /etc/nginx/pulp \
+             /www/data
 {% for plugin in item.value.plugin_snippets %}
 RUN ln /usr/local/lib/python{{ item.value.python_version }}/site-packages/{{ plugin }}/app/webserver_snippets/nginx.conf /etc/nginx/pulp/{{ plugin }}.conf
 {% endfor %}
 
+{% if item.value.base_image_name == "galaxy" %}
+RUN cp -fr /usr/local/lib/python{{ item.value.python_version }}/site-packages/galaxy_ng/app/static/galaxy_ng/. /www/data
+{% endif %}
+
+
 FROM nginx:latest
 
-RUN mkdir -p /etc/nginx/pulp
+RUN mkdir -p /etc/nginx/pulp \
+             /www/data
 WORKDIR /etc/nginx/pulp
 COPY --from=builder /etc/nginx/pulp .
+{% if item.value.base_image_name == "galaxy" %}
+WORKDIR /www/data
+COPY --from=builder /www/data .
+{% endif %}
 WORKDIR /

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.galaxy.ci.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.galaxy.ci.yaml
@@ -1,0 +1,16 @@
+apiVersion: pulp.pulpproject.org/v1beta1
+kind: Pulp
+metadata:
+  name: example-pulp
+spec:
+  image: galaxy
+  image_web: "galaxy-web"
+  tag: "latest"
+  ingress_type: Ingress
+  pulp_admin_password_secret: "example-pulp-admin-password"
+  pulp_storage:
+    file:
+      # k3s local-path requires this
+      access_mode: "ReadWriteOnce"
+      # We have a little over 10GB free on GHA VMs/instances
+      size: "10Gi"

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.object_storage.aws.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.object_storage.aws.yaml
@@ -1,0 +1,14 @@
+apiVersion: pulp.pulpproject.org/v1beta1
+kind: Pulp
+metadata:
+  name: example-pulp
+spec:
+  tag: "latest"
+  ingress_type: Ingress
+  pulp_admin_password_secret: "example-pulp-admin-password"
+  pulp_settings:
+    debug: "True"
+  pulp_storage:
+    object_storage:
+      s3_secret: example-pulp-object-storage
+

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.object_storage.azure.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.object_storage.azure.yaml
@@ -1,0 +1,14 @@
+apiVersion: pulp.pulpproject.org/v1beta1
+kind: Pulp
+metadata:
+  name: example-pulp
+spec:
+  tag: "latest"
+  ingress_type: Ingress
+  pulp_admin_password_secret: "example-pulp-admin-password"
+  pulp_settings:
+    debug: "True"
+  pulp_storage:
+    object_storage:
+      azure_secret: example-pulp-object-storage
+

--- a/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
@@ -37,6 +37,10 @@ spec:
                 description: The image name (repo name) for the pulp image.
                 type: string
                 default: pulp
+              image_web:
+                description: The image name (repo name) for the pulp webserver image.
+                type: string
+                default: pulp-web
               tag:
                 description: The image tag for the pulp image.
                 type: string

--- a/roles/pulp-web/defaults/main.yml
+++ b/roles/pulp-web/defaults/main.yml
@@ -26,3 +26,5 @@ route_tls_termination_mechanism: edge
 route_tls_secret: ''
 
 ca_trust_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
+
+pulp_webserver_static_dir: "/www/data"

--- a/roles/pulp-web/templates/pulp-web.configmap.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.configmap.yaml.j2
@@ -72,6 +72,10 @@ data:
             # Gunicorn docs suggest this value.
             keepalive_timeout 5;
 
+            # static files that can change dynamically, or are needed for TLS
+            # purposes are served through the webserver.
+            root {{ pulp_webserver_static_dir }};
+
             location /pulp/content/ {
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header X-Forwarded-Proto $scheme;

--- a/up.sh
+++ b/up.sh
@@ -16,6 +16,8 @@ else
     echo "$0: ERROR 1: Cannot find kubectl"
 fi
 
+KUBE_ASSETS_DIR=${KUBE_ASSETS_DIR:-".ci/assets/kubernetes"}
+
 # TODO: Check if these should only ever be run once; or require
 # special logic to update
 # The Custom Resource (and any ConfigMaps) do not.
@@ -25,7 +27,23 @@ if [[ -e deploy/crds/pulpproject_v1beta1_pulp_cr.yaml ]]; then
 elif [[ "$CI_TEST" == "true" ]]; then
   CUSTOM_RESOURCE=pulpproject_v1beta1_pulp_cr.ci.yaml
   echo "Will deploy admin password secret for testing ..."
-  $KUBECTL apply -f .ci/assets/kubernetes/pulp-admin-password.secret.yaml
+  $KUBECTL apply -f $KUBE_ASSETS_DIR/pulp-admin-password.secret.yaml
+elif [[ "$CI_TEST" == "aws" ]]; then
+  CUSTOM_RESOURCE=pulpproject_v1beta1_pulp_cr.object_storage.aws.yaml
+  echo "Will deploy admin password secret for testing ..."
+  $KUBECTL apply -f $KUBE_ASSETS_DIR/pulp-admin-password.secret.yaml
+  echo "Will deploy object storage secret for testing ..."
+  $KUBECTL apply -f $KUBE_ASSETS_DIR/pulp-object-storage.aws.secret.yaml
+elif [[ "$CI_TEST" == "azure" ]]; then
+  CUSTOM_RESOURCE=pulpproject_v1beta1_pulp_cr.object_storage.azure.yaml
+  echo "Will deploy admin password secret for testing ..."
+  $KUBECTL apply -f $KUBE_ASSETS_DIR/pulp-admin-password.secret.yaml
+  echo "Will deploy object storage secret for testing ..."
+  $KUBECTL apply -f $KUBE_ASSETS_DIR/pulp-object-storage.azure.secret.yaml
+elif [[ "$CI_TEST" == "galaxy" ]]; then
+  CUSTOM_RESOURCE=pulpproject_v1beta1_pulp_cr.galaxy.ci.yaml
+  echo "Will deploy admin password secret for testing ..."
+  $KUBECTL apply -f $KUBE_ASSETS_DIR/pulp-admin-password.secret.yaml
 elif [[ "$(hostname)" == "pulp-demo"* ]]; then
   CUSTOM_RESOURCE=pulpproject_v1beta1_pulp_cr.pulp-demo.yaml
 else


### PR DESCRIPTION
* Include static file in galaxy-web image
* Update CRD to supply web image
* Add example CRs to simplify testing
* Update up.sh to simplify deployment testing

fixes #8399
https://pulp.plan.io/issues/8399