### PR TITLE
Fix storage option check so that Azure Blob Storage can be used as a backend

### DIFF
--- a/CHANGES/8424.bugfix
+++ b/CHANGES/8424.bugfix
@@ -1,0 +1,1 @@
+Fix storage option check so that Azure Blob Storage can be used as a backend

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -5,7 +5,7 @@
 - set_fact:
     file_storage: false
   when:
-    - pulp_object_storage_s3_secret is defined or pulp_object_storage_s3_secret is defined
+    - pulp_object_storage_s3_secret is defined or pulp_object_storage_azure_secret is defined
 
 - name: pulp-file-storage persistent volume claim
   community.kubernetes.k8s:


### PR DESCRIPTION

* Correct storage option check logic

fixes #8424
https://pulp.plan.io/issues/8424