### PR TITLE
Redis: Fix Permission denied and multiple deployment in same namespace

### DIFF
--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -22,12 +22,12 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - readOnly: false
-              mountPath: /var/lib/redis
-              name: redis-data
+              mountPath: /data
+              name: '{{ meta.name }}-redis-data'
           ports:
             - protocol: TCP
               containerPort: 6379
       volumes:
-        - name: redis-data
+        - name: '{{ meta.name }}-redis-data'
           persistentVolumeClaim:
-            claimName: redis-data
+            claimName: '{{ meta.name }}-redis-data'

--- a/roles/redis/templates/redis.pvc.yaml.j2
+++ b/roles/redis/templates/redis.pvc.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: redis-data
+  name: '{{ meta.name }}-redis-data'
   namespace: "{{ project_name }}"
 spec:
   resources:


### PR DESCRIPTION
This PR fixes the following issues that were happening in the redis pod

```
24 Mar 2021 10:21:16.062 # Failed opening the RDB file dump.rdb (in
server root dir /data) for saving: Permission denied
24 Mar 2021 10:21:16.162 # Background saving error
```

As it is written today. PVC is always made with `redis-data` name and
does not take in consideration the deployment name. This allows for
multiple deployment of pulp in single namespace.

[noissue]