### PR TITLE
Fix upload /var/lib/pulp/temp Permission Denied and nginx logging

### DIFF
--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -38,6 +38,9 @@ spec:
         - name: pulp-file-storage
           persistentVolumeClaim:
             claimName: pulp-file-storage
+{% else %}
+        - name: pulp-tmp-file-storage
+          emptyDir: {}
 {% endif %}
       containers:
         - name: pulp-api
@@ -88,4 +91,7 @@ spec:
             - name: pulp-file-storage
               readOnly: false
               mountPath: "/var/lib/pulp"
+{% else %}
+            - name: pulp-tmp-file-storage
+              mountPath: "/var/lib/pulp/tmp"
 {% endif %}

--- a/roles/pulp-web/templates/pulp-web.configmap.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.configmap.yaml.j2
@@ -8,6 +8,7 @@ metadata:
     app: '{{ deployment_type }}'
 data:
   nginx_conf: |
+    error_log /dev/stdout info;
     worker_processes 1;
     events {
         worker_connections 1024;  # increase if you have lots of clients
@@ -15,6 +16,7 @@ data:
     }
 
     http {
+        access_log /dev/stdout;
         include mime.types;
         # fallback in case we can't determine a type
         default_type application/octet-stream;


### PR DESCRIPTION
[noissue]

Uploading a collection on OCP with object storage hit the following error on the API pod:
<img width="1062" alt="api_pod_error" src="https://user-images.githubusercontent.com/29379759/112370080-594a2c80-8cb3-11eb-8609-7f72dcfa7d67.png">

Fix nginx to logging output (was not displaying before):
![image](https://user-images.githubusercontent.com/29379759/112370213-7da60900-8cb3-11eb-81ff-4aa6a0dc0579.png)
