### PR TITLE
Update liveness probe defaults

### DIFF
--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -356,8 +356,8 @@ spec:
                   httpGet:
                     path: /healthz
                     port: 6789
-                  initialDelaySeconds: 5
-                  periodSeconds: 3
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
                 name: pulp-operator
                 resources: {}
                 volumeMounts:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -38,8 +38,8 @@ spec:
             httpGet:
               path: /healthz
               port: 6789
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 20
       volumes:
         - name: runner
           emptyDir: {}


### PR DESCRIPTION
The liveness probes default are too agressive and can lead to
undeployable operators[1][2] - We are bumping them as per the
operator-sdk default in 1.0[3]

[1] https://github.com/operator-framework/operator-sdk/issues/3216
[2] https://github.com/operator-framework/operator-sdk/issues/3267
[3]
https://github.com/operator-framework/operator-sdk/commit/ea43495073a543ede5f10ea5790660004cf750be

[noissue]