### PR TITLE
Enable resource req specification and have operator do health check

### DIFF
--- a/CHANGES/8456.feature
+++ b/CHANGES/8456.feature
@@ -1,0 +1,1 @@
+Enable resource requirement specification for deployments and have operator check for running nodes and healthy status

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.ci.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.ci.yaml
@@ -12,3 +12,21 @@ spec:
     access_mode: "ReadWriteOnce"
     # We have a little over 10GB free on GHA VMs/instances
     size: "10Gi"
+  pulp_content:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+  pulp_worker:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+  pulp_web:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 100m
+        memory: 256Mi

--- a/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
@@ -157,6 +157,28 @@ spec:
               route_tls_secret:
                 description: Secret where the TLS related credentials are stored
                 type: string
+              redis_resource_requirements:
+                description: Resource requirements for the Redis container
+                properties:
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                type: object
               pulp_web:
                 description: The pulp web deployment.
                 properties:
@@ -165,6 +187,28 @@ spec:
                     type: integer
                     default: 1
                     format: int32
+                  resource_requirements:
+                    description: Resource requirements for the pulp web container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
                 type: object
               pulp_api:
                 description: The pulp api deployment.
@@ -184,6 +228,28 @@ spec:
                       - WARNING
                       - ERROR
                       - CRITICAL
+                  resource_requirements:
+                    description: Resource requirements for the pulp api container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
                 type: object
               pulp_content:
                 description: The pulp content deployment.
@@ -203,6 +269,28 @@ spec:
                       - WARNING
                       - ERROR
                       - CRITICAL
+                  resource_requirements:
+                    description: Resource requirements for the pulp content container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
                 type: object
               pulp_worker:
                 description: The pulp worker deployment.
@@ -212,6 +300,28 @@ spec:
                     type: integer
                     default: 2
                     format: int32
+                  resource_requirements:
+                    description: Resource requirements for the pulp worker container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
                 type: object
               pulp_resource_manager:
                 description: The pulp resource manager deployment.
@@ -221,6 +331,28 @@ spec:
                     type: integer
                     default: 1
                     format: int32
+                  resource_requirements:
+                    description: Resource requirements for the pulp resource manager container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
                 type: object
             type: object
           status:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -151,26 +151,67 @@ spec:
         path: pulp_settings
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: In-memory data store resource requirements
+        path: redis_resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Pulp API Configuration
         path: pulp_api
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Pulp API log level
+        path: pulp_api.log_level
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Pulp API resource requirements
+        path: pulp_api.resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Pulp Content Configuration
         path: pulp_content
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Pulp Content log level
+        path: pulp_content.log_level
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Pulp Content resource requirements
+        path: pulp_content.resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Pulp Resource Manager Configuration
         path: pulp_resource_manager
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Pulp Resource Manager resource requirements
+        path: pulp_resource_manager.resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Pulp Worker Configuration
         path: pulp_worker
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Pulp Worker resource requirements
+        path: pulp_worker.resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Pulp Web Server Configuration
         path: pulp_web
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Pulp Web Server resource requirements
+        path: pulp_web.resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Deployment Type
         path: deployment_type
         x-descriptors:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
@@ -157,6 +157,28 @@ spec:
               route_tls_secret:
                 description: Secret where the TLS related credentials are stored
                 type: string
+              redis_resource_requirements:
+                description: Resource requirements for the Redis container
+                properties:
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                type: object
               pulp_web:
                 description: The pulp web deployment.
                 properties:
@@ -165,6 +187,28 @@ spec:
                     type: integer
                     default: 1
                     format: int32
+                  resource_requirements:
+                    description: Resource requirements for the pulp web container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
                 type: object
               pulp_api:
                 description: The pulp api deployment.
@@ -184,6 +228,28 @@ spec:
                       - WARNING
                       - ERROR
                       - CRITICAL
+                  resource_requirements:
+                    description: Resource requirements for the pulp api container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
                 type: object
               pulp_content:
                 description: The pulp content deployment.
@@ -203,6 +269,28 @@ spec:
                       - WARNING
                       - ERROR
                       - CRITICAL
+                  resource_requirements:
+                    description: Resource requirements for the pulp content container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
                 type: object
               pulp_worker:
                 description: The pulp worker deployment.
@@ -212,6 +300,28 @@ spec:
                     type: integer
                     default: 2
                     format: int32
+                  resource_requirements:
+                    description: Resource requirements for the pulp worker container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
                 type: object
               pulp_resource_manager:
                 description: The pulp resource manager deployment.
@@ -221,6 +331,28 @@ spec:
                     type: integer
                     default: 1
                     format: int32
+                  resource_requirements:
+                    description: Resource requirements for the pulp resource manager container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
                 type: object
             type: object
           status:

--- a/roles/pulp-api/defaults/main.yml
+++ b/roles/pulp-api/defaults/main.yml
@@ -2,6 +2,11 @@
 pulp_api:
   replicas: 1
   log_level: INFO
+  resource_requirements:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+
 # Here we use  _pulpproject_org_pulp to get un-modified cr
 # see: https://github.com/operator-framework/operator-sdk/issues/1770
 raw_spec: "{{ vars['_pulp_pulpproject_org_pulp']['spec'] }}"

--- a/roles/pulp-api/tasks/get_node_ip.yml
+++ b/roles/pulp-api/tasks/get_node_ip.yml
@@ -12,12 +12,28 @@
     content_origin: "{{ web_protocol }}://{{ pulp_hostname }}"
   when:
     - ingress_type|lower == "ingress"
+    - pulp_hostname is defined
+
+- name: Fail if pulp_hostname is not defined when ingress is specified
+  fail:
+    msg: "The hostname must be specified when using ingress_type {{ ingress_type }}."
+  when:
+    - ingress_type|lower == "ingress"
+    - pulp_hostname is not defined
 
 - name: Set node address for route
   set_fact:
     content_origin: "{{ web_protocol }}://{{ route_host }}"
   when:
     - ingress_type|lower == "route"
+    - route_host is defined
+
+- name: Fail if route_host is not defined when route is specified
+  fail:
+    msg: "The route_host must be specified when using ingress_type {{ ingress_type }}."
+  when:
+    - ingress_type|lower == "route"
+    - route_host is not defined
 
 - name: Look up the 1st address of the 1st node
   k8s_info:

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -78,6 +78,9 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
+{% if pulp_api.resource_requirements is defined %}
+          resources: {{ pulp_api.resource_requirements }}
+{% endif %}
           volumeMounts:
             - name: {{ meta.name }}-pulp-server
               mountPath: "/etc/pulp/settings.py"

--- a/roles/pulp-content/defaults/main.yml
+++ b/roles/pulp-content/defaults/main.yml
@@ -2,3 +2,7 @@
 pulp_content:
   replicas: 2
   log_level: INFO
+  resource_requirements:
+    requests:
+      cpu: 200m
+      memory: 512Mi

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -39,6 +39,9 @@ spec:
           imagePullPolicy: "IfNotPresent"
           # We set args, not command, so as to not override the entrypoint script
           args: ["pulp-content"]
+{% if pulp_content.resource_requirements is defined %}
+          resources: {{ pulp_content.resource_requirements }}
+{% endif %}
           env:
             - name: POSTGRES_SERVICE_HOST
               value: "{{ postgres_host }}"

--- a/roles/pulp-resource-manager/defaults/main.yml
+++ b/roles/pulp-resource-manager/defaults/main.yml
@@ -3,3 +3,7 @@ pulp_resource_manager:
   # Waiting on this to be implemented:
   # https://pulp.plan.io/issues/3707
   replicas: 1
+  resource_requirements:
+    requests:
+      cpu: 200m
+      memory: 512Mi

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -62,3 +62,6 @@ spec:
             - name: pulp-tmp-file-storage
               mountPath: "/var/lib/pulp/tmp"
 {% endif %}
+{% if pulp_resource_manager.resource_requirements is defined %}
+          resources: {{ pulp_resource_manager.resource_requirements }}
+{% endif %}

--- a/roles/pulp-routes/tasks/main.yml
+++ b/roles/pulp-routes/tasks/main.yml
@@ -5,3 +5,6 @@
     definition: "{{ lookup('template', 'templates/' + item + '.ingress.yaml.j2') | from_yaml }}"
   with_items:
     - pulp
+  when:
+    - ingress_type is defined
+    - ('route' == ingress_type|lower) or ('ingress' == ingress_type|lower)

--- a/roles/pulp-status/tasks/main.yml
+++ b/roles/pulp-status/tasks/main.yml
@@ -1,4 +1,26 @@
 ---
+
+- name: Get the resource pod information.
+  k8s_info:
+    kind: Pod
+    namespace: '{{ meta.namespace }}'
+    label_selectors:
+      - "app=pulp-web"
+  register: pulp_pods
+  until: "pulp_pods['resources'][0]['status']['phase'] == 'Running'"
+  delay: 5
+  retries: 100
+
+- name: Set the resource pod name as a variable.
+  set_fact:
+    pulp_web_pod_name: "{{ pulp_pods['resources'][0]['metadata']['name'] }}"
+
+- name: Check that status and it returns a status 200
+  uri:
+    url: 'http://{{ meta.name }}-web-svc:24880/pulp/api/v3/status/'
+  delay: 5
+  retries: 10
+
 - name: Set apiVersion and kind variables
   set_fact:
     api_version: '{{ hostvars["localhost"]["inventory_file"].split("/")[4:6] | join("/")  }}'

--- a/roles/pulp-web/defaults/main.yml
+++ b/roles/pulp-web/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 pulp_web:
   replicas: 1
+  resource_requirements:
+    requests:
+      cpu: 200m
+      memory: 512Mi
 
 ingress_type: none
 

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -54,6 +54,9 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
+{% if pulp_web.resource_requirements is defined %}
+          resources: {{ pulp_web.resource_requirements }}
+{% endif %}
       volumes:
         - name: {{ meta.name }}-nginx-conf
           configMap:

--- a/roles/pulp-worker/defaults/main.yml
+++ b/roles/pulp-worker/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 pulp_worker:
   replicas: 2
+  resource_requirements:
+    requests:
+      cpu: 200m
+      memory: 512Mi

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -66,3 +66,6 @@ spec:
             - name: pulp-tmp-file-storage
               mountPath: "/var/lib/pulp/tmp"
 {% endif %}
+{% if pulp_worker.resource_requirements is defined %}
+          resources: {{ pulp_worker.resource_requirements }}
+{% endif %}

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,2 +1,7 @@
 ---
 redis_image: redis:latest
+
+redis_resource_requirements:
+  requests:
+    cpu: 200m
+    memory: 512Mi

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -27,6 +27,9 @@ spec:
           ports:
             - protocol: TCP
               containerPort: 6379
+{% if redis_resource_requirements is defined %}
+          resources: {{ redis_resource_requirements }}
+{% endif %}
       volumes:
         - name: '{{ meta.name }}-redis-data'
           persistentVolumeClaim:


### PR DESCRIPTION
* Update CRD
* Update UI display in cluster version
* Add resource requirements specification to defaults and deployments
* Add checks for needed inputs during ingress and route deployments
* Add pod running check for web server and successful health check for successful reconciliation

fixes #8456
https://pulp.plan.io/issues/8456