### PR TITLE
Permission error hit for static assets when using object storage

### DIFF
--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -41,6 +41,8 @@ spec:
 {% else %}
         - name: pulp-tmp-file-storage
           emptyDir: {}
+        - name: pulp-assets-file-storage
+          emptyDir: {}
 {% endif %}
       containers:
         - name: pulp-api
@@ -97,4 +99,6 @@ spec:
 {% else %}
             - name: pulp-tmp-file-storage
               mountPath: "/var/lib/pulp/tmp"
+            - name: pulp-assets-file-storage
+              mountPath: "/var/lib/pulp/assets"
 {% endif %}


### PR DESCRIPTION
* Add access to /var/lib/pulp/assets when file storage isn't in use

[noissue]