### PR TITLE
Enable container based database migration support

### DIFF
--- a/CHANGES/8472.feature
+++ b/CHANGES/8472.feature
@@ -1,0 +1,1 @@
+Enable container based database migration support

--- a/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
@@ -94,6 +94,12 @@ spec:
               postgres_data_path:
                 description: Path where the PostgreSQL data are located
                 type: string
+              postgres_migrant_configuration_secret:
+                description: Secret where the old database configuration can be found for data migration
+                type: string
+              postgres_label_selector:
+                description: Label selector used to identify postgres pod for executing migration
+                type: string
               pulp_storage_type:
                 description: Configuration for the storage type to be utilized
                 type: string
@@ -368,6 +374,9 @@ spec:
                 type: string
               deployedImage:
                 description: URL of the image used for the deployed instance
+                type: string
+              migrantDatabaseConfigurationSecret:
+                description: The configuration secret used for migrating an old deployment.
                 type: string
               conditions:
                 description: The resulting conditions when a Service Telemetry is instantiated

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -81,6 +81,17 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Migrant database configuration secret
+        path: postgres_migrant_configuration_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Database migration label selector
+        path: postgres_label_selector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Ingress Type
         path: ingress_type
         x-descriptors:
@@ -267,6 +278,11 @@ spec:
         path: deployedImage
         x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Migrated Database
+        description: Configuration secret for previously deployed database
+        path: migrantDatabaseConfigurationSecret
+        x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
   description: Pulp operator
   displayName: Pulp
   icon:
@@ -288,6 +304,7 @@ spec:
           - rbac.authorization.k8s.io
           resources:
           - pods
+          - pods/log
           - services
           - services/finalizers
           - endpoints
@@ -350,6 +367,19 @@ spec:
           - deployments
           verbs:
           - get
+        - apiGroups:
+            - apps
+          resources:
+            - deployments/scale
+          verbs:
+            - patch
+        - apiGroups:
+            - ""
+          resources:
+            - pods/exec
+          verbs:
+            - create
+            - get
         - apiGroups:
           - pulp.pulpproject.org
           resources:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
@@ -94,6 +94,12 @@ spec:
               postgres_data_path:
                 description: Path where the PostgreSQL data are located
                 type: string
+              postgres_migrant_configuration_secret:
+                description: Secret where the old database configuration can be found for data migration
+                type: string
+              postgres_label_selector:
+                description: Label selector used to identify postgres pod for executing migration
+                type: string
               pulp_storage_type:
                 description: Configuration for the storage type to be utilized
                 type: string
@@ -368,6 +374,9 @@ spec:
                 type: string
               deployedImage:
                 description: URL of the image used for the deployed instance
+                type: string
+              migrantDatabaseConfigurationSecret:
+                description: The configuration secret used for migrating an old deployment.
                 type: string
               conditions:
                 description: The resulting conditions when a Service Telemetry is instantiated

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -15,6 +15,7 @@ rules:
   - ""
   resources:
   - pods
+  - pods/log
   - services
   - services/finalizers
   - endpoints
@@ -75,6 +76,19 @@ rules:
   - deployments
   verbs:
   - get
+- apiGroups:
+    - apps
+  resources:
+    - deployments/scale
+  verbs:
+    - patch
+- apiGroups:
+    - ""
+  resources:
+    - pods/exec
+  verbs:
+    - create
+    - get
 - apiGroups:
   - pulp.pulpproject.org
   resources:

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -11,5 +11,11 @@ postgres_data_path: '/var/lib/postgresql/data/pgdata'
 # Secret to lookup that provide the PostgreSQL configuration
 postgres_configuration_secret: ''
 
+# Secret to lookup that provide the PostgreSQL configuration for old database
+postgres_migrant_configuration_secret: ''
+
 postgres_initdb_args: '--auth-host=scram-sha-256'
 postgres_host_auth_method: 'scram-sha-256'
+
+custom_resource_key: '_pulp_pulpproject_org_pulp'
+database_status_present: false

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -1,4 +1,25 @@
 ---
+
+- name: Obtain custom resource information
+  set_fact:
+    custom_resource: "{{ hostvars[inventory_hostname][custom_resource_key] }}"
+    custom_resource_status: "{{ hostvars[inventory_hostname][custom_resource_key]['status'] }}"
+
+
+- name: Record migrant database secret
+  set_fact:
+    recorded_db_migration_secret: "{{ custom_resource_status['migrantDatabaseConfigurationSecret'] }}"
+  when:
+    - custom_resource_status['migrantDatabaseConfigurationSecret'] is defined
+
+- name: Check if data migration has been performed
+  set_fact:
+    database_status_present: true
+  when:
+    - recorded_db_migration_secret is defined
+    - postgres_migrant_configuration_secret is defined
+    - recorded_db_migration_secret == postgres_migrant_configuration_secret
+
 - name: Check for specified PostgreSQL configuration
   k8s_info:
     kind: Secret
@@ -13,6 +34,22 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ meta.name }}-postgres-configuration'
   register: _default_pg_config_resources
+
+- name: Check for old PostgreSQL configuration secret
+  k8s_info:
+    kind: Secret
+    namespace: '{{ meta.namespace }}'
+    name: '{{ postgres_migrant_configuration_secret }}'
+  register: old_pg_config
+  when: postgres_migrant_configuration_secret | length
+
+- name: Set proper database name when migrating from old deployment
+  set_fact:
+    database_name: "{{ old_pg_config['resources'][0]['data']['database'] | b64decode }}"
+    database_username: "{{ old_pg_config['resources'][0]['data']['username'] | b64decode }}"
+  when:
+    - old_pg_config['resources'] is defined
+    - old_pg_config['resources'] | length
 
 - name: Set PostgreSQL configuration
   set_fact:
@@ -51,3 +88,11 @@
     postgres_database: "{{ pg_config['resources'][0]['data']['database'] | b64decode }}"
     postgres_port: "{{ pg_config['resources'][0]['data']['port'] | b64decode }}"
     postgres_host: "{{ pg_config['resources'][0]['data']['host'] | b64decode }}"
+
+
+- name: Migrate data from old Openshift instance
+  import_tasks: migrate_data.yml
+  when:
+    - old_pg_config['resources'] is defined
+    - old_pg_config['resources'] | length
+    - not database_status_present

--- a/roles/postgres/tasks/migrate_data.yml
+++ b/roles/postgres/tasks/migrate_data.yml
@@ -1,0 +1,74 @@
+---
+
+- name: Store Database Configuration
+  set_fact:
+    migrant_postgres_user: "{{ old_pg_config['resources'][0]['data']['username'] | b64decode }}"
+    migrant_postgres_pass: "{{ old_pg_config['resources'][0]['data']['password'] | b64decode }}"
+    migrant_postgres_database: "{{ old_pg_config['resources'][0]['data']['database'] | b64decode }}"
+    migrant_postgres_port: "{{ old_pg_config['resources'][0]['data']['port'] | b64decode }}"
+    migrant_postgres_host: "{{ old_pg_config['resources'][0]['data']['host'] | b64decode }}"
+
+- name: Default label selector to custom resource generated postgres
+  set_fact:
+    postgres_label_selector: "app={{ meta.name }}-{{ deployment_type }}-postgres"
+  when: postgres_label_selector is not defined
+
+- name: Get the postgres pod information
+  k8s_info:
+    kind: Pod
+    namespace: '{{ meta.namespace }}'
+    label_selectors:
+      - "{{ postgres_label_selector }}"
+  register: postgres_pod
+  until: "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
+  delay: 5
+  retries: 60
+
+- name: Set the resource pod name as a variable.
+  set_fact:
+    postgres_pod_name: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
+
+- include: scale_down.yml deployment_name={{ item }}
+  with_items:
+    - "{{ meta.name }}-api"
+    - "{{ meta.name }}-content"
+    - "{{ meta.name }}-resource-manager"
+    - "{{ meta.name }}-worker"
+    - "{{ meta.name }}-web"
+
+- name: Set pg_dump command
+  set_fact:
+    pgdump: >-
+      pg_dump --clean --create
+      -h {{ migrant_postgres_host }}
+      -U {{ migrant_postgres_user }}
+      -d {{ migrant_postgres_database }}
+      -p {{ migrant_postgres_port }}
+
+- name: Set pg_restore command
+  set_fact:
+    psql_restore: >-
+      psql -U {{ postgres_user }}
+      -d {{ postgres_database }}
+      -p {{ postgres_port }}
+
+- name: Stream backup from pg_dump to the new postgresql container
+  community.kubernetes.k8s_exec:
+    namespace: "{{ meta.namespace }}"
+    pod: "{{ postgres_pod_name }}"
+    command: |
+      bash -c """
+      set -e -o pipefail
+      PGPASSWORD={{ migrant_postgres_pass }} {{ pgdump }} | PGPASSWORD={{ postgres_pass }} {{ psql_restore }}
+      echo 'Successful'
+      """
+  register: data_migration
+  failed_when: "'Successful' not in data_migration['stdout']"
+
+- name: Set flag signifying that this instance has been migrated
+  set_fact:
+    postgres_migrated_from_secret: "{{ postgres_migrant_configuration_secret }}"
+
+- name: Migration succesful from previous database
+  debug:
+    msg: "Database migrated from secret: {{ postgres_migrated_from_secret }}"

--- a/roles/postgres/tasks/scale_down.yml
+++ b/roles/postgres/tasks/scale_down.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Check for presence of Deployment
+  k8s_info:
+    api_version: v1
+    kind: Deployment
+    name: "{{ deployment_name }}"
+    namespace: "{{ meta.namespace }}"
+  register: scale_deployment
+
+- name: Scale down Deployment for migration
+  k8s_scale:
+    api_version: v1
+    kind: Deployment
+    name: "{{ deployment_name }}"
+    namespace: "{{ meta.namespace }}"
+    replicas: 0
+  when: scale_deployment['resources'] | length

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -6,11 +6,11 @@ metadata:
   name: '{{ meta.name }}-postgres'
   namespace: '{{ meta.namespace }}'
   labels:
-    app: '{{ deployment_type }}-postgres'
+    app: '{{ meta.name }}-{{ deployment_type }}-postgres'
 spec:
   selector:
     matchLabels:
-      app: '{{ deployment_type }}-postgres'
+      app: '{{ meta.name }}-{{ deployment_type }}-postgres'
   serviceName: '{{ meta.name }}'
   replicas: 1
   updateStrategy:
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        app: '{{ deployment_type }}-postgres'
+        app: '{{ meta.name }}-{{ deployment_type }}-postgres'
     spec:
       containers:
         - image: '{{ postgres_image }}'
@@ -71,10 +71,10 @@ metadata:
   name: '{{ meta.name }}-postgres'
   namespace: '{{ meta.namespace }}'
   labels:
-    app: '{{ deployment_type }}-postgres'
+    app: '{{ meta.name }}-{{ deployment_type }}-postgres'
 spec:
   ports:
     - port: 5432
   clusterIP: None
   selector:
-    app: '{{ deployment_type }}-postgres'
+    app: '{{ meta.name }}-{{ deployment_type }}-postgres'

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -5,16 +5,16 @@ metadata:
   name: "{{ meta.name }}-api"
   namespace: "{{ project_name }}"
   labels:
-    app: "{{ deployment_type }}-api"
+    app: "{{ meta.name }}-{{ deployment_type }}-api"
 spec:
   replicas: {{ pulp_api.replicas }}
   selector:
     matchLabels:
-      app: "{{ deployment_type }}-api"
+      app: "{{ meta.name }}-{{ deployment_type }}-api"
   template:
     metadata:
       labels:
-        app: "{{ deployment_type }}-api"
+        app: "{{ meta.name }}-{{ deployment_type }}-api"
     spec:
 {% if is_k8s %}
       securityContext:
@@ -37,7 +37,7 @@ spec:
 {% if file_storage %}
         - name: pulp-file-storage
           persistentVolumeClaim:
-            claimName: pulp-file-storage
+            claimName: {{ meta.name }}-pulp-file-storage
 {% else %}
         - name: pulp-tmp-file-storage
           emptyDir: {}

--- a/roles/pulp-api/templates/pulp-api.service.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.service.yaml.j2
@@ -5,10 +5,10 @@ metadata:
   name: "{{ meta.name }}-api-svc"
   namespace: "{{ project_name }}"
   labels:
-    app: "{{ deployment_type }}-api"
+    app: "{{ meta.name }}-{{ deployment_type }}-api"
 spec:
   selector:
-    app: "{{ deployment_type }}-api"
+    app: "{{ meta.name }}-{{ deployment_type }}-api"
   ports:
     - protocol: TCP
       targetPort: 24817

--- a/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
+++ b/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: pulp-file-storage
+  name: "{{ meta.name }}-pulp-file-storage"
   namespace: "{{ project_name }}"
 spec:
   resources:

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -5,16 +5,16 @@ metadata:
   name: "{{ meta.name }}-content"
   namespace: "{{ project_name }}"
   labels:
-    app: "{{ deployment_type }}-content"
+    app: "{{ meta.name }}-{{ deployment_type }}-content"
 spec:
   replicas: {{ pulp_content.replicas }}
   selector:
     matchLabels:
-      app: "{{ deployment_type }}-content"
+      app: "{{ meta.name }}-{{ deployment_type }}-content"
   template:
     metadata:
       labels:
-        app: "{{ deployment_type }}-content"
+        app: "{{ meta.name }}-{{ deployment_type }}-content"
     spec:
 {% if is_k8s %}
       securityContext:
@@ -31,7 +31,7 @@ spec:
 {% if file_storage %}
         - name: pulp-file-storage
           persistentVolumeClaim:
-            claimName: pulp-file-storage
+            claimName: {{ meta.name }}-pulp-file-storage
 {% endif %}
       containers:
         - name: pulp-content

--- a/roles/pulp-content/templates/pulp-content.service.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.service.yaml.j2
@@ -5,10 +5,10 @@ metadata:
   name: "{{ meta.name }}-content-svc"
   namespace: "{{ project_name }}"
   labels:
-    app: "{{ deployment_type }}-content"
+    app: "{{ meta.name }}-{{ deployment_type }}-content"
 spec:
   selector:
-    app: "{{ deployment_type }}-content"
+    app: "{{ meta.name }}-{{ deployment_type }}-content"
   ports:
     - protocol: TCP
       targetPort: 24816

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -5,16 +5,16 @@ metadata:
   name: "{{ meta.name }}-resource-manager"
   namespace: "{{ project_name }}"
   labels:
-    app: "{{ deployment_type }}-resource-manager"
+    app: "{{ meta.name }}-{{ deployment_type }}-resource-manager"
 spec:
   replicas: {{ pulp_resource_manager.replicas }}
   selector:
     matchLabels:
-      app: "{{ deployment_type }}-resource-manager"
+      app: "{{ meta.name }}-{{ deployment_type }}-resource-manager"
   template:
     metadata:
       labels:
-        app: "{{ deployment_type }}-resource-manager"
+        app: "{{ meta.name }}-{{ deployment_type }}-resource-manager"
     spec:
 {% if is_k8s %}
       securityContext:
@@ -31,7 +31,7 @@ spec:
 {% if file_storage %}
         - name: pulp-file-storage
           persistentVolumeClaim:
-            claimName: pulp-file-storage
+            claimName: {{ meta.name }}-pulp-file-storage
 {% else %}
         - name: pulp-tmp-file-storage
           emptyDir: {}

--- a/roles/pulp-status/defaults/main.yml
+++ b/roles/pulp-status/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+postgres_migrated_from_secret: ''

--- a/roles/pulp-status/tasks/main.yml
+++ b/roles/pulp-status/tasks/main.yml
@@ -1,11 +1,28 @@
 ---
 
+- name: Set apiVersion and kind variables
+  set_fact:
+    api_version: '{{ hostvars["localhost"]["inventory_file"].split("/")[4:6] | join("/")  }}'
+    kind: '{{ hostvars["localhost"]["inventory_file"].split("/")[6]  }}'
+
+- name: Update migrantDatabaseConfigurationSecret status
+  operator_sdk.util.k8s_status:
+    api_version: '{{ api_version }}'
+    kind: "{{ kind }}"
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.namespace }}"
+    status:
+      migrantDatabaseConfigurationSecret: "{{ postgres_migrated_from_secret }}"
+  when:
+    - postgres_migrated_from_secret is defined
+    - postgres_migrated_from_secret | length
+
 - name: Get the resource pod information.
   k8s_info:
     kind: Pod
     namespace: '{{ meta.namespace }}'
     label_selectors:
-      - "app=pulp-web"
+      - "app={{ meta.name }}-{{ deployment_type }}-web"
   register: pulp_pods
   until: "pulp_pods['resources'][0]['status']['phase'] == 'Running'"
   delay: 5
@@ -20,11 +37,6 @@
     url: 'http://{{ meta.name }}-web-svc:24880/pulp/api/v3/status/'
   delay: 5
   retries: 10
-
-- name: Set apiVersion and kind variables
-  set_fact:
-    api_version: '{{ hostvars["localhost"]["inventory_file"].split("/")[4:6] | join("/")  }}'
-    kind: '{{ hostvars["localhost"]["inventory_file"].split("/")[6]  }}'
 
 - name: Update admin password status
   operator_sdk.util.k8s_status:

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -5,16 +5,16 @@ metadata:
   name: "{{ meta.name }}-web"
   namespace: "{{ project_name }}"
   labels:
-    app: pulp-web
+    app: "{{ meta.name }}-{{ deployment_type }}-web"
 spec:
   replicas: {{ pulp_web.replicas }}
   selector:
     matchLabels:
-      app: pulp-web
+      app: "{{ meta.name }}-{{ deployment_type }}-web"
   template:
     metadata:
       labels:
-        app: pulp-web
+        app: "{{ meta.name }}-{{ deployment_type }}-web"
     spec:
       containers:
         - name: pulp-web

--- a/roles/pulp-web/templates/pulp-web.service.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.service.yaml.j2
@@ -5,10 +5,10 @@ metadata:
   name: "{{ meta.name }}-web-svc"
   namespace: "{{ project_name }}"
   labels:
-    app: pulp-web
+    app: "{{ meta.name }}-{{ deployment_type }}-web"
 spec:
   selector:
-    app: pulp-web
+    app: "{{ meta.name }}-{{ deployment_type }}-web"
   ports:
     - protocol: TCP
       targetPort: 8080

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -5,16 +5,16 @@ metadata:
   name: "{{ meta.name }}-worker"
   namespace: "{{ project_name }}"
   labels:
-    app: "{{ deployment_type }}-worker"
+    app: "{{ meta.name }}-{{ deployment_type }}-worker"
 spec:
   replicas: {{ pulp_worker.replicas }}
   selector:
     matchLabels:
-      app: "{{ deployment_type }}-worker"
+      app: "{{ meta.name }}-{{ deployment_type }}-worker"
   template:
     metadata:
       labels:
-        app: "{{ deployment_type }}-worker"
+        app: "{{ meta.name }}-{{ deployment_type }}-worker"
     spec:
 {% if is_k8s %}
       securityContext:
@@ -31,7 +31,7 @@ spec:
 {% if file_storage %}
         - name: pulp-file-storage
           persistentVolumeClaim:
-            claimName: pulp-file-storage
+            claimName: {{ meta.name }}-pulp-file-storage
 {% else %}
         - name: pulp-tmp-file-storage
           emptyDir: {}

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -5,16 +5,16 @@ metadata:
   name: "{{ meta.name }}-redis"
   namespace: "{{ project_name }}"
   labels:
-    app: '{{ deployment_type }}-redis'
+    app: '{{ meta.name }}-{{ deployment_type }}-redis'
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: '{{ deployment_type }}-redis'
+      app: '{{ meta.name }}-{{ deployment_type }}-redis'
   template:
     metadata:
       labels:
-        app: '{{ deployment_type }}-redis'
+        app: '{{ meta.name }}-{{ deployment_type }}-redis'
     spec:
       containers:
         - name: redis

--- a/roles/redis/templates/redis.service.yaml.j2
+++ b/roles/redis/templates/redis.service.yaml.j2
@@ -5,10 +5,10 @@ metadata:
   name: "{{ meta.name }}-redis"
   namespace: "{{ project_name }}"
   labels:
-    app: "{{ deployment_type }}-redis"
+    app: "{{ meta.name }}-{{ deployment_type }}-redis"
 spec:
   selector:
-    app: "{{ deployment_type }}-redis"
+    app: "{{ meta.name }}-{{ deployment_type }}-redis"
   ports:
     - protocol: TCP
       targetPort: 6379


### PR DESCRIPTION
* Add support for container based database migration via CR
* Update operator role to enable command execution on a pod
* Add check to postgres role around migration
* Add migration of data tasks
* Add scale down tasks
* Update status role to record db migration
* Misc. fix for conflicting label selectors

fixes #8472
https://pulp.plan.io/issues/8472