### PR TITLE
Enable backup of storage associated with Pulp custom resource

### DIFF
--- a/CHANGES/8474.feature
+++ b/CHANGES/8474.feature
@@ -1,0 +1,1 @@
+Enable backup of storage associated with Pulp custom resource

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.object_storage.aws.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.object_storage.aws.yaml
@@ -10,4 +10,21 @@ spec:
     debug: "True"
   pulp_storage_type: S3
   pulp_object_storage_s3_secret: example-pulp-object-storage
-
+  pulp_content:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+  pulp_worker:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+  pulp_web:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 100m
+        memory: 256Mi

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.object_storage.azure.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.object_storage.azure.yaml
@@ -10,3 +10,21 @@ spec:
     debug: "True"
   pulp_storage_type: Azure
   pulp_object_storage_azure_secret: example-pulp-object-storage
+  pulp_content:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+  pulp_worker:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+  pulp_web:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 100m
+        memory: 256Mi

--- a/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
@@ -374,6 +374,15 @@ spec:
               databaseConfigruationSecret:
                 description: Database configuration secret used by the deployed instance
                 type: string
+              storageType:
+                description: The type of storage being used by the deployed instance
+                type: string
+              storagePersistentVolumeClaim:
+                description: The name of the persistent volume claim used for storage
+                type: string
+              storageSecret:
+                description: The name of the secret used for object storage
+                type: string
               deployedVersion:
                 description: Version of the deployed instance
                 type: string

--- a/deploy/crds/pulpproject_v1beta1_pulpbackup_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulpbackup_crd.yaml
@@ -51,6 +51,9 @@ spec:
                 pulpBackupDirectory:
                   description: The directory data is backed up to on the PVC
                   type: string
+                pulpDeploymentStorageType:
+                  description: The deployment storage type
+                  type: string
                 conditions:
                   description: The resulting conditions when a Service Telemetry is instantiated
                   items:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -273,6 +273,21 @@ spec:
         path: databaseConfigruationSecret
         x-descriptors:
           - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Storage Type
+        description: The type of storage being used by the deployed instance
+        path: storageType
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: File Storage
+        description: The name of the persistent volume claim used for storage
+        path: storagePersistentVolumeClaim
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Objectstorage Secret
+        description: Configuration secret for objectstorage
+        path: storageSecret
+        x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
       - displayName: Version
         description: Version of the instance deployed
         path: deployedVersion
@@ -327,6 +342,11 @@ spec:
       - displayName: Backup Directory
         description: The directory data is backed up to on the PVC
         path: pulpBackupDirectory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Deployment Storage Type
+        description: The deployment storage type
+        path: pulpDeploymentStorageType
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
   description: Pulp operator

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulpbackups_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulpbackups_crd.yml
@@ -50,6 +50,9 @@ spec:
                 pulpBackupDirectory:
                   description: The directory data is backed up to on the PVC
                   type: string
+                pulpDeploymentStorageType:
+                  description: The deployment storage type
+                  type: string
                 conditions:
                   description: The resulting conditions when a Service Telemetry is instantiated
                   items:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
@@ -374,6 +374,15 @@ spec:
               databaseConfigruationSecret:
                 description: Database configuration secret used by the deployed instance
                 type: string
+              storageType:
+                description: The type of storage being used by the deployed instance
+                type: string
+              storagePersistentVolumeClaim:
+                description: The name of the persistent volume claim used for storage
+                type: string
+              storageSecret:
+                description: The name of the secret used for object storage
+                type: string
               deployedVersion:
                 description: Version of the deployed instance
                 type: string

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -16,3 +16,7 @@ pulp_admin_password_secret: "{{ pulp_name }}-admin-password"
 postgres_configuration_secret: "{{ pulp_name }}-postgres-configuration"
 
 custom_resource_key: '_pulp_pulpproject_org_pulpbackup'
+
+database_type: 'unmanaged'
+
+azure_container_path: ''

--- a/roles/backup/tasks/cleanup.yml
+++ b/roles/backup/tasks/cleanup.yml
@@ -2,12 +2,12 @@
 
 # After copying secret files to the PVC, delete the local tmp copies
 - name: Clean up _secrets directory
-  ansible.builtin.file:
+  file:
     path: "{{ playbook_dir }}/_secrets"
     state: absent
 
 - name: Delete any existing management pod
-  community.kubernetes.k8s:
+  k8s:
     name: "{{ meta.name }}-db-management"
     kind: Pod
     namespace: "{{ meta.namespace }}"

--- a/roles/backup/tasks/error_handling.yml
+++ b/roles/backup/tasks/error_handling.yml
@@ -10,7 +10,6 @@
     now: '{{ lookup("pipe", "date +%FT%TZ") }}'
 
 - name: Emit ocp event with error
-  community.kubernetes.k8s:
-    kind: Event
-    namespace: "{{ meta.namespace }}"
-    template: "event.yml.j2"
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'templates/event.yaml.j2') | from_yaml }}"

--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Delete any existing management pod
-  community.kubernetes.k8s:
+  k8s:
     name: "{{ meta.name }}-db-management"
     kind: Pod
     namespace: "{{ meta.namespace }}"
@@ -46,19 +46,13 @@
     backup_pvc: "{{ pulp_backup_pvc | default(_default_backup_pvc, true) }}"
 
 - name: Create persistent volume claim for backup
-  community.kubernetes.k8s:
+  k8s:
     state: present
     definition: "{{ lookup('template', 'templates/' + item + '.pvc.yaml.j2') | from_yaml }}"
   with_items:
     - backup
   when:
     - pulp_backup_pvc == '' or pulp_backup_pvc is not defined
-
-- name: Create management pod from templated deployment config
-  community.kubernetes.k8s:
-    state: present
-    definition: "{{ lookup('template', 'templates/management-pod.yaml.j2') | from_yaml }}"
-    wait: true
 
 - name: Get Pulp custom resource object
   k8s_info:
@@ -98,3 +92,62 @@
     - pulp_status['databaseConfigruationSecret'] is defined
     - pulp_status['databaseConfigruationSecret'] | length
 
+- name: Set pulp storage type if found
+  set_fact:
+    pulp_storage_type: "{{ pulp_status['storageType'] }}"
+  when:
+    - pulp_status['storageType'] is defined
+    - pulp_status['storageType'] | length
+
+- name: Set pulp file storage claim if found
+  set_fact:
+    pulp_storage_claim: "{{ pulp_status['storagePersistentVolumeClaim'] }}"
+  when:
+    - pulp_status['storagePersistentVolumeClaim'] is defined
+    - pulp_status['storagePersistentVolumeClaim'] | length
+
+- name: Set pulp object storage secret if found
+  set_fact:
+    pulp_storage_secret: "{{ pulp_status['storageSecret'] }}"
+  when:
+    - pulp_status['storageSecret'] is defined
+    - pulp_status['storageSecret'] | length
+
+- name: Get PVC information
+  k8s_info:
+    kind: PersistentVolumeClaim
+    namespace: '{{ meta.namespace }}'
+    name: '{{ pulp_storage_claim }}'
+  register: _storage_claim
+  when: pulp_storage_claim is defined
+
+- name: Set storage claim access mode
+  set_fact:
+    pvc_access_mode: "{{ _storage_claim['resources'][0]['spec']['accessModes'][0] }}"
+  when:
+    - _storage_claim['resources'][0]['spec'] is defined
+    - _storage_claim['resources'][0]['spec']['accessModes'] is defined
+    - _storage_claim['resources'][0]['spec']['accessModes'][0] is defined
+    - _storage_claim['resources'][0]['spec']['accessModes'][0] | length
+
+- name: Surface error to user
+  block:
+    - name: Set error message
+      set_fact:
+        error_msg: "PersistentVolumeClaim accessMode {{ pvc_access_mode }} is not supported for backup, must be ReadWriteMany."
+
+    - name: Handle error
+      import_tasks: error_handling.yml
+
+    - name: Fail if file storge claim access mode is not ReadWriteMany
+      fail:
+        msg: " {{ error_msg }}"
+  when:
+    - pvc_access_mode is defined
+    - pvc_access_mode | lower != "readwritemany"
+
+- name: Create management pod from templated deployment config
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'templates/management-pod.yaml.j2') | from_yaml }}"
+    wait: true

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -12,6 +12,9 @@
 
     - include_tasks: secrets.yml
 
+    - include_tasks: storage.yml
+      when: pulp_storage_type | lower == 'file'
+
     - name: Set flag signifying this backup was successful
       set_fact:
         pulp_backup_complete: "{{ _backup_dir }}"

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -56,21 +56,21 @@
     _backup_dir: "/backups/pulp-openshift-backup-{{ now }}"
 
 - name: Create directory for backup
-  community.kubernetes.k8s_exec:
+  k8s_exec:
     namespace: "{{ meta.namespace }}"
     pod: "{{ meta.name }}-db-management"
     command: >-
       mkdir -p {{ _backup_dir }}
 
 - name: Precreate file for database dump
-  community.kubernetes.k8s_exec:
+  k8s_exec:
     namespace: "{{ meta.namespace }}"
     pod: "{{ meta.name }}-db-management"
     command: >-
       touch {{ _backup_dir }}/pulp.db
 
 - name: Set permissions on file for database dump
-  community.kubernetes.k8s_exec:
+  k8s_exec:
     namespace: "{{ meta.namespace }}"
     pod: "{{ meta.name }}-db-management"
     command: >-
@@ -86,7 +86,7 @@
       -p {{ postgres_port }}
 
 - name: Write pg_dump to backup on PVC
-  community.kubernetes.k8s_exec:
+  k8s_exec:
     namespace: "{{ meta.namespace }}"
     pod: "{{ meta.name }}-db-management"
     command: >-

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -17,7 +17,7 @@
     pulp_object_template: "{{ lookup('file', '_secrets/pulp_object.yaml') }}"
 
 - name: Write pulp object to pvc
-  community.kubernetes.k8s_exec:
+  k8s_exec:
     namespace: "{{ meta.namespace }}"
     pod: "{{ meta.name }}-db-management"
     command: >-
@@ -44,8 +44,8 @@
   set_fact:
     admin_password_template: "{{ lookup('file', '_secrets/admin_password_secret.yaml') }}"
 
-- name: Write secret_key to pvc
-  community.kubernetes.k8s_exec:
+- name: Write admin password secret to pvc
+  k8s_exec:
     namespace: "{{ meta.namespace }}"
     pod: "{{ meta.name }}-db-management"
     command: >-
@@ -65,7 +65,13 @@
     database_name: "{{ _postgres_configuration['resources'][0]['data']['database'] | b64decode }}"
     database_port: "{{ _postgres_configuration['resources'][0]['data']['port'] | b64decode }}"
     database_host: "{{ _postgres_configuration['resources'][0]['data']['host'] | b64decode }}"
+
+- name: Set postgres db type
+  set_fact:
     database_type: "{{ _postgres_configuration['resources'][0]['data']['type'] | b64decode }}"
+  when:
+    - _postgres_configuration['resources'][0]['data']['type'] is defined
+    - _postgres_configuration['resources'][0]['data']['type'] | length
 
 - name: Template postgres configuration definition
   template:
@@ -77,9 +83,116 @@
   set_fact:
     postgres_secret_template: "{{ lookup('file', '_secrets/postgres_secret.yaml') }}"
 
-- name: Write secret_key to pvc
-  community.kubernetes.k8s_exec:
+- name: Write postgres secret to pvc
+  k8s_exec:
     namespace: "{{ meta.namespace }}"
     pod: "{{ meta.name }}-db-management"
     command: >-
       bash -c "echo '{{ postgres_secret_template }}' > {{ _backup_dir }}/postgres_secret.yaml"
+
+- name: Get objectstorage configuration
+  k8s_info:
+    kind: Secret
+    namespace: '{{ meta.namespace }}'
+    name: '{{ pulp_storage_secret }}'
+  register: _objectstorage_configuration
+  when: pulp_storage_secret is defined
+
+- name: Set s3 common configuration values
+  set_fact:
+    s3_data_obj: "{{ _objectstorage_configuration['resources'][0]['data'] }}"
+    s3_access_key_id: "{{ _objectstorage_configuration['resources'][0]['data']['s3-access-key-id'] | b64decode }}"
+    s3_secret_access_key: "{{ _objectstorage_configuration['resources'][0]['data']['s3-secret-access-key'] | b64decode }}"
+    s3_bucket_name: "{{ _objectstorage_configuration['resources'][0]['data']['s3-bucket-name'] | b64decode }}"
+  when:
+    - pulp_storage_secret is defined
+    - pulp_storage_type | lower == 's3'
+
+- name: Set s3 region value if found
+  set_fact:
+    s3_region: "{{ s3_data_obj['s3-region'] | b64decode }}"
+  when:
+    - pulp_storage_secret is defined
+    - pulp_storage_type | lower == 's3'
+    - s3_data_obj['s3-region'] is defined
+    - s3_data_obj['s3-region'] | length
+
+- name: Set s3 endpoint value if found
+  set_fact:
+    s3_endpoint: "{{ s3_data_obj['s3-endpoint'] | b64decode }}"
+  when:
+    - pulp_storage_secret is defined
+    - pulp_storage_type | lower == 's3'
+    - s3_data_obj['s3-endpoint'] is defined
+    - s3_data_obj['s3-endpoint'] | length
+
+- name: Template s3 configuration definition
+  template:
+    src: s3_secret.yaml.j2
+    dest: "_secrets/objectstorage_secret.yaml"
+    mode: '0600'
+  when:
+    - pulp_storage_secret is defined
+    - pulp_storage_type | lower == 's3'
+
+- name: Set s3 configuration
+  set_fact:
+    s3_secret_template: "{{ lookup('file', '_secrets/objectstorage_secret.yaml') }}"
+  when:
+    - pulp_storage_secret is defined
+    - pulp_storage_type | lower == 's3'
+
+- name: Write s3 secret to pvc
+  k8s_exec:
+    namespace: "{{ meta.namespace }}"
+    pod: "{{ meta.name }}-db-management"
+    command: >-
+      bash -c "echo '{{ s3_secret_template }}' > {{ _backup_dir }}/objectstorage_secret.yaml"
+  when:
+    - pulp_storage_secret is defined
+    - pulp_storage_type | lower == 's3'
+
+- name: Set azure common configuration values
+  set_fact:
+    azure_data_obj: "{{ _objectstorage_configuration['resources'][0]['data'] }}"
+    azure_account_name: "{{ _objectstorage_configuration['resources'][0]['data']['azure-account-name] | b64decode }}"
+    azure-account-key: "{{ _objectstorage_configuration['resources'][0]['data']['azure-account-key'] | b64decode }}"
+    azure-container: "{{ _objectstorage_configuration['resources'][0]['data']['azure-container'] | b64decode }}"
+  when:
+    - pulp_storage_secret is defined
+    - pulp_storage_type | lower == 'azure'
+
+- name: Set azure container path value if found
+  set_fact:
+    azure_container_path: "{{ azure_data_obj['azure-container-path'] | b64decode }}"
+  when:
+    - pulp_storage_secret is defined
+    - pulp_storage_type | lower == 'azure'
+    - azure_data_obj['azure-container-path'] is defined
+    - azure_data_obj['azure-container-path'] | length
+
+- name: Template azure configuration definition
+  template:
+    src: azure_secret.yaml.j2
+    dest: "_secrets/objectstorage_secret.yaml"
+    mode: '0600'
+  when:
+    - pulp_storage_secret is defined
+    - pulp_storage_type | lower == 'azure'
+
+- name: Set azure configuration
+  set_fact:
+    azure_secret_template: "{{ lookup('file', '_secrets/objectstorage_secret.yaml') }}"
+  when:
+    - pulp_storage_secret is defined
+    - pulp_storage_type | lower == 'azure'
+
+- name: Write azure secret to pvc
+  k8s_exec:
+    namespace: "{{ meta.namespace }}"
+    pod: "{{ meta.name }}-db-management"
+    command: >-
+      bash -c "echo '{{ azure_secret_template }}' > {{ _backup_dir }}/objectstorage_secret.yaml"
+  when:
+    - pulp_storage_secret is defined
+    - pulp_storage_type | lower == 'azure'

--- a/roles/backup/tasks/storage.yml
+++ b/roles/backup/tasks/storage.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Create directory for backup content files
+  k8s_exec:
+    namespace: "{{ meta.namespace }}"
+    pod: "{{ meta.name }}-db-management"
+    command: >-
+      mkdir -p {{ _backup_dir }}/pulp/
+
+- name: Set file copy command
+  set_fact:
+    copy_cmd: >-
+      cp -fr /var/lib/pulp/. {{ _backup_dir }}/pulp
+
+- name: Write pg_dump to backup on PVC
+  k8s_exec:
+    namespace: "{{ meta.namespace }}"
+    pod: "{{ meta.name }}-db-management"
+    command: >-
+      bash -c "{{ copy_cmd }}"
+  register: file_copy

--- a/roles/backup/tasks/update_status.yml
+++ b/roles/backup/tasks/update_status.yml
@@ -5,7 +5,7 @@
     kind: '{{ hostvars["localhost"]["inventory_file"].split("/")[6]  }}'
 
 # The backup directory in this status can be referenced when restoring
-- name: Update Pulp Backup status
+- name: Update backup directory status
   operator_sdk.util.k8s_status:
     api_version: '{{ api_version }}'
     kind: "{{ kind }}"
@@ -15,8 +15,8 @@
       pulpBackupDirectory: "{{ _backup_dir }}"
   when: pulp_backup_complete is defined
 
-# The backup directory in this status can be referenced when restoring
-- name: Update Pulp Backup status
+# The backup PVC in this status can be referenced when restoring
+- name: Update backup PVC status
   operator_sdk.util.k8s_status:
     api_version: '{{ api_version }}'
     kind: "{{ kind }}"
@@ -25,3 +25,14 @@
     status:
       pulpBackupClaim: "{{ backup_pvc }}"
   when: pulp_backup_complete is defined
+
+# The backup around storage type in this status can be referenced when restoring
+- name: Update deployment storage type status
+  operator_sdk.util.k8s_status:
+    api_version: '{{ api_version }}'
+    kind: "{{ kind }}"
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.namespace }}"
+    status:
+      pulpDeploymentStorageType: "{{ pulp_storage_type }}"
+  when: pulp_storage_type is defined

--- a/roles/backup/templates/admin_password_secret.yaml.j2
+++ b/roles/backup/templates/admin_password_secret.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
 {% raw %}
-  name: '{{ meta.name }}'
+  name: '{{ pulp_name }}-admin-password'
   namespace: '{{ meta.namespace }}'
 {% endraw %}
 stringData:

--- a/roles/backup/templates/azure_secret.yaml.j2
+++ b/roles/backup/templates/azure_secret.yaml.j2
@@ -1,0 +1,14 @@
+# Azure Secret.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+{% raw %}
+  name: '{{ pulp_name }}-objectstorage-configuration'
+  namespace: '{{ meta.namespace }}'
+{% endraw %}
+stringData:
+  azure-account-name: '{{ azure_account_name }}'
+  azure-account-key: '{{ azure_account_key }}'
+  azure-container: '{{ azure_container }}'
+  azure-container-path: '{{ azure_container_path }}'

--- a/roles/backup/templates/management-pod.yaml.j2
+++ b/roles/backup/templates/management-pod.yaml.j2
@@ -14,9 +14,19 @@ spec:
     - name: {{ meta.name }}-backup
       mountPath: /backups
       readOnly: false
+{% if pulp_storage_claim is defined %}
+    - name: pulp-file-storage
+      readOnly: false
+      mountPath: "/var/lib/pulp"
+{% endif %}
   volumes:
     - name: {{ meta.name }}-backup
       persistentVolumeClaim:
         claimName: {{ backup_pvc }}
         readOnly: false
+{% if pulp_storage_claim is defined %}
+    - name: pulp-file-storage
+      persistentVolumeClaim:
+        claimName: {{ pulp_storage_claim }}
+{% endif %}
   restartPolicy: Never

--- a/roles/backup/templates/postgres_secret.yaml.j2
+++ b/roles/backup/templates/postgres_secret.yaml.j2
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
 {% raw %}
-  name: '{{ meta.name }}-postgres-configuration'
+  name: '{{ pulp_name }}-postgres-configuration'
   namespace: '{{ meta.namespace }}'
 {% endraw %}
 stringData:

--- a/roles/backup/templates/pulp_object.yaml.j2
+++ b/roles/backup/templates/pulp_object.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: '{{ pulp_api_version }}'
 kind: Pulp
 metadata:
 {% raw %}
-  name: '{{ meta.name }}'
+  name: '{{ pulp_name }}'
   namespace: '{{ meta.namespace }}'
 {% endraw %}
 spec: {{ pulp_spec }}

--- a/roles/backup/templates/s3_secret.yaml.j2
+++ b/roles/backup/templates/s3_secret.yaml.j2
@@ -1,0 +1,19 @@
+# S3 Secret.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+{% raw %}
+  name: '{{ pulp_name }}-objectstorage-configuration'
+  namespace: '{{ meta.namespace }}'
+{% endraw %}
+stringData:
+  s3-access-key-id: '{{ s3_access_key_id }}'
+  s3-secret-access-key: '{{ s3_secret_access_key }}'
+  s3-bucket-name: '{{ s3_bucket_name }}'
+{% if s3_region is defined%}
+  s3-region: '{{ s3_region }}'
+{% endif %}
+{% if s3_endpoint is defined %}
+  s3-endpoint: '{{ s3_endpoint }}'
+{% endif %}

--- a/roles/postgres/tasks/migrate_data.yml
+++ b/roles/postgres/tasks/migrate_data.yml
@@ -53,7 +53,7 @@
       -p {{ postgres_port }}
 
 - name: Stream backup from pg_dump to the new postgresql container
-  community.kubernetes.k8s_exec:
+  k8s_exec:
     namespace: "{{ meta.namespace }}"
     pod: "{{ postgres_pod_name }}"
     command: |

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -3,12 +3,22 @@
     secret_key: "{{ lookup('password', '/dev/null length=50 chars=ascii_letters') }}"
 
 - set_fact:
+    object_storage_secret: "{{ pulp_object_storage_s3_secret }}"
+  when:
+    - pulp_object_storage_s3_secret is defined
+
+- set_fact:
+    object_storage_secret: "{{ pulp_object_storage_azure_secret }}"
+  when:
+    - pulp_object_storage_azure_secret is defined
+
+- set_fact:
     file_storage: false
   when:
-    - pulp_object_storage_s3_secret is defined or pulp_object_storage_azure_secret is defined
+    - object_storage_secret is defined
 
 - name: pulp-file-storage persistent volume claim
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.pvc.yaml.j2') | from_yaml }}"
   with_items:
@@ -55,7 +65,7 @@
     pulp_combined_settings: "{{ pulp_default_settings|combine(raw_pulp_settings, recursive=True) if pulp_settings is defined and pulp_settings is not none else pulp_default_settings }}"
 
 - name: pulp-server secret
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.secret.yaml.j2') | from_yaml }}"
   with_items:
@@ -65,7 +75,7 @@
     file: admin_password_configuration.yml
 
 - name: pulp-api service
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.service.yaml.j2') | from_yaml }}"
   with_items:
@@ -96,7 +106,7 @@
   - not is_k8s
 
 - name: pulp-api deployment
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
   with_items:

--- a/roles/pulp-content/tasks/main.yml
+++ b/roles/pulp-content/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: pulp-content service
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.service.yaml.j2') | from_yaml }}"
   with_items:
     - pulp-content
 
 - name: pulp-content deployment
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
   with_items:

--- a/roles/pulp-resource-manager/tasks/main.yml
+++ b/roles/pulp-resource-manager/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: pulp-resource-manager deployment
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
   with_items:

--- a/roles/pulp-routes/tasks/main.yml
+++ b/roles/pulp-routes/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: pulp routes
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.ingress.yaml.j2') | from_yaml }}"
   with_items:

--- a/roles/pulp-status/tasks/main.yml
+++ b/roles/pulp-status/tasks/main.yml
@@ -56,6 +56,35 @@
     status:
       databaseConfigruationSecret: "{{ _pg_config['resources'][0]['metadata']['name'] }}"
 
+- name: Update storage type status
+  operator_sdk.util.k8s_status:
+    api_version: '{{ api_version }}'
+    kind: "{{ kind }}"
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.namespace }}"
+    status:
+      storageType: "{{ pulp_storage_type | capitalize }}"
+
+- name: Update file storage pvc name status
+  operator_sdk.util.k8s_status:
+    api_version: '{{ api_version }}'
+    kind: "{{ kind }}"
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.namespace }}"
+    status:
+      storagePersistentVolumeClaim: "{{ meta.name }}-pulp-file-storage"
+  when: file_storage
+
+- name: Update object storage secret name status
+  operator_sdk.util.k8s_status:
+    api_version: '{{ api_version }}'
+    kind: "{{ kind }}"
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.namespace }}"
+    status:
+      storageSecret: "{{ object_storage_secret }}"
+  when: not file_storage
+
 - name: Update version status
   operator_sdk.util.k8s_status:
     api_version: '{{ api_version }}'
@@ -76,7 +105,7 @@
 
 - block:
     - name: Retrieve route URL
-      community.kubernetes.k8s_info:
+      k8s_info:
         kind: Route
         namespace: '{{ meta.namespace }}'
         name: '{{ meta.name }}'

--- a/roles/pulp-web/tasks/load_route_tls_secret.yml
+++ b/roles/pulp-web/tasks/load_route_tls_secret.yml
@@ -1,6 +1,6 @@
 ---
 - name: Retrieve Route TLS Secret
-  community.kubernetes.k8s_info:
+  k8s_info:
     kind: Secret
     namespace: '{{ meta.namespace }}'
     name: '{{ route_tls_secret }}'

--- a/roles/pulp-web/tasks/main.yml
+++ b/roles/pulp-web/tasks/main.yml
@@ -7,21 +7,21 @@
     - route_tls_secret != ''
 
 - name: pulp-web configmap
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.configmap.yaml.j2') | from_yaml }}"
   with_items:
     - pulp-web
 
 - name: pulp-web deployment
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
   with_items:
     - pulp-web
 
 - name: pulp-web service
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.service.yaml.j2') | from_yaml }}"
   with_items:

--- a/roles/pulp-worker/tasks/main.yml
+++ b/roles/pulp-worker/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: pulp-worker deployment
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
   with_items:

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -1,20 +1,20 @@
 ---
 - name: redis persistent volume claim
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.pvc.yaml.j2') | from_yaml }}"
   with_items:
     - redis
 
 - name: redis service
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.service.yaml.j2') | from_yaml }}"
   with_items:
     - redis
 
 - name: redis deployment
-  community.kubernetes.k8s:
+  k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
   with_items:


### PR DESCRIPTION
* Add storage information to pulp status in CRD to enable backup
* Add storage type to pulpbackup status in CRD to enable restore
* Update CSV with new status items
* Gather storage type from pulp CRD
* Collect objectstorage secret or PVC name depending on storage type
* Check PVC for RWM accessMode
* Create management pod with mounted PVC if storage type is RWM file system
* Write objectstorage secret to backup PVC
* Add templated secrets
* Add storage tasks to copy file contents when file storage is used
* Update backup status with storage type
* Don't use fqcn

fixes #8474
https://pulp.plan.io/issues/8474