### PR TITLE
Enable nightly expiring container builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,21 @@ jobs:
           git clone --depth=1 https://github.com/pulp/pulp_file.git
           .ci/scripts/deploy.sh -m
         shell: bash
+      - id: latest_release
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: ${{ github.repository }}
+          excludes: draft
+      - name: Define QUAY_IMAGE_TAG environment variable
+        run: |
+          echo "QUAY_IMAGE_TAG=${{steps.latest_release.outputs.release}}-$(date +%j)" >> $GITHUB_ENV
+          echo "QUAY_EXPIRE=14" >> $GITHUB_ENV
+        shell: bash
+      - name: Deploy tagged nightly build
+        run: |
+          git clone --depth=1 https://github.com/pulp/pulp_file.git
+          .ci/scripts/deploy.sh -m
+        shell: bash
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/CHANGES/8530.misc
+++ b/CHANGES/8530.misc
@@ -1,0 +1,1 @@
+Enable additional container builds based on latest tag plus the day of the year along with an expiration

--- a/containers/images/pulp/Containerfile.core.j2
+++ b/containers/images/pulp/Containerfile.core.j2
@@ -1,5 +1,9 @@
 FROM registry.fedoraproject.org/fedora:33
 
+{% if quay_expire is defined %}
+LABEL quay.expires-after={{ quay_expire }}d
+{% endif %}
+
 # https://superuser.com/questions/959380/how-do-i-install-generate-all-locales-on-fedora
 # This may not be necessary anymore because Fedora 30, unlike CentOS 7, has
 # glibc subpackages like glibc-langpack-en.

--- a/containers/images/pulp/Containerfile.web.j2
+++ b/containers/images/pulp/Containerfile.web.j2
@@ -13,6 +13,10 @@ RUN cp -fr /usr/local/lib/python{{ item.value.python_version }}/site-packages/ga
 
 FROM centos/nginx-116-centos7:1.16
 
+{% if quay_expire is defined %}
+LABEL quay.expires-after={{ quay_expire }}d
+{% endif %}
+
 {% if item.value.base_image_name == "galaxy" %}
 COPY --from=builder /www/data .
 {% endif %}


### PR DESCRIPTION
* Add optional label to each of the images that allows quay to automatically prune images.
* Add ci step to get the latest release tag
* Set QUAY_IMAGE_TAG to latest release tag + the day of the year
* Set QUAY_EXPIRE to 14 to keep images for 2 weeks initially
* Run publish again where new environment variables should publish expiring images

fixes #8530
https://pulp.plan.io/issues/8530

Reference: https://docs.projectquay.io/use_quay.html#tag-expiration