### PR TITLE
Remove unnecessary prefixes for labeled pulp components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,12 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo -E kubectl logs -l app=pulp-api --tail=10000
-          sudo -E kubectl logs -l app=pulp-content --tail=10000
-          sudo -E kubectl logs -l app=pulp-worker --tail=10000
-          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo -E kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-api --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-content --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
 
   components:
@@ -123,12 +123,12 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo -E kubectl logs -l app=pulp-api --tail=10000
-          sudo -E kubectl logs -l app=pulp-content --tail=10000
-          sudo -E kubectl logs -l app=pulp-worker --tail=10000
-          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo -E kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-api --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-content --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
 
   galaxy:
@@ -186,12 +186,12 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo -E kubectl logs -l app=pulp-api --tail=10000
-          sudo -E kubectl logs -l app=pulp-content --tail=10000
-          sudo -E kubectl logs -l app=pulp-worker --tail=10000
-          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo -E kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-api --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-content --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
 
   molecule:
@@ -300,10 +300,10 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo -E kubectl logs -l app=pulp-api --tail=10000
-          sudo -E kubectl logs -l app=pulp-content --tail=10000
-          sudo -E kubectl logs -l app=pulp-worker --tail=10000
-          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo -E kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-api --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-content --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,12 +101,12 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo -E kubectl logs -l app=pulp-api --tail=10000
-          sudo -E kubectl logs -l app=pulp-content --tail=10000
-          sudo -E kubectl logs -l app=pulp-worker --tail=10000
-          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo -E kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-api --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-content --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
       # - name: Debugging example (uncomment when needed)
       #   if: failure()
@@ -177,12 +177,12 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo -E kubectl logs -l app=pulp-api --tail=10000
-          sudo -E kubectl logs -l app=pulp-content --tail=10000
-          sudo -E kubectl logs -l app=pulp-worker --tail=10000
-          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo -E kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-api --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-content --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
       # - name: Debugging example (uncomment when needed)
       #   if: failure()
@@ -244,12 +244,12 @@ jobs:
         if: failure()
         run: |
           sudo docker images
-          sudo -E kubectl logs -l name=pulp-operator -c pulp-operator --tail=10000
-          sudo -E kubectl logs -l app=pulp-api --tail=10000
-          sudo -E kubectl logs -l app=pulp-content --tail=10000
-          sudo -E kubectl logs -l app=pulp-worker --tail=10000
-          sudo -E kubectl logs -l app=pulp-resource-manager --tail=10000
-          sudo -E kubectl logs -l app=pulp-web --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-operator -c pulp-operator --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-api --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-content --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-worker --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-resource-manager --tail=10000
+          sudo -E kubectl logs -l app.kubernetes.io/name=pulp-web --tail=10000
           http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
       # - name: Debugging example (uncomment when needed)
       #   if: failure()

--- a/CHANGES/8563.misc
+++ b/CHANGES/8563.misc
@@ -1,0 +1,1 @@
+Remove unnecessary prefixes for labeled pulp components that add complexity to downstream productization

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.ci.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.ci.yaml
@@ -5,26 +5,26 @@ metadata:
 spec:
   # image: pulp
   tag: "latest"
-  pulp_admin_password_secret: "example-pulp-admin-password"
-  pulp_storage_type: File
-  pulp_file_storage:
+  admin_password_secret: "example-pulp-admin-password"
+  storage_type: File
+  file_storage:
     # k3s local-path requires this
     access_mode: "ReadWriteOnce"
     # We have a little over 10GB free on GHA VMs/instances
     size: "10Gi"
-  pulp_content:
+  content:
     replicas: 1
     resource_requirements:
       requests:
         cpu: 150m
         memory: 256Mi
-  pulp_worker:
+  worker:
     replicas: 1
     resource_requirements:
       requests:
         cpu: 150m
         memory: 256Mi
-  pulp_web:
+  web:
     replicas: 1
     resource_requirements:
       requests:

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.default.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.default.yaml
@@ -15,13 +15,13 @@ metadata:
 # pulp_settings:
 #    debug: "True"
   # The pulp adminstrator password secret.
-# pulp_admin_password_secret:
+# admin_password_secret:
   # PostgreSQL container settings secret.
 # postgres_configuration_secret: pg_secret_name
   # Configuration for the persistentVolumeClaim for /var/lib/pulp
-# pulp_storage_type: File
+# storage_type: File
   # Select storage type: File, S3, Azure
-# pulp_file_storage:
+# file_storage:
       # If your K8s cluster is only 1 node, and its StorageClass /
     # provisioner does not support ReadWriteMany, then you must change
     # this to "ReadWriteOnce".
@@ -41,20 +41,20 @@ metadata:
     # should be sufficient for a test deployment with only the RPM
     # content plugin.
 #   size: "100Gi"
-# pulp_object_storage_s3_secret: example-pulp-object-storage
+# object_storage_s3_secret: example-pulp-object-storage
   # Configuration for S3 credentals
-# pulp_object_storage_azure_secret: example-pulp-object-storage
+# object_storage_azure_secret: example-pulp-object-storage
   # Configuration for Azure credentals
   # Values below are set in roles rather than in playbook.yaml
-# pulp_api:
+# api:
 #   replicas: 1
 #   log_level: INFO
-# pulp_content:
+# content:
 #   replicas: 2
 #   log_level: INFO
-# pulp_worker:
+# worker:
 #   replicas: 2
-# pulp_resource_manager:
+# resource_manager:
     # Waiting on this to be implemented:
     # https://pulp.plan.io/issues/3707
 #   replicas: 1

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.galaxy.ci.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.galaxy.ci.yaml
@@ -6,26 +6,26 @@ spec:
   image: galaxy
   image_web: "galaxy-web"
   tag: "latest"
-  pulp_admin_password_secret: "example-pulp-admin-password"
-  pulp_storage_type: File
-  pulp_file_storage:
+  admin_password_secret: "example-pulp-admin-password"
+  storage_type: File
+  file_storage:
     # k3s local-path requires this
     access_mode: "ReadWriteOnce"
     # We have a little over 10GB free on GHA VMs/instances
     size: "10Gi"
-  pulp_content:
+  content:
     replicas: 1
     resource_requirements:
       requests:
         cpu: 150m
         memory: 256Mi
-  pulp_worker:
+  worker:
     replicas: 1
     resource_requirements:
       requests:
         cpu: 150m
         memory: 256Mi
-  pulp_web:
+  web:
     replicas: 1
     resource_requirements:
       requests:

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.object_storage.aws.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.object_storage.aws.yaml
@@ -5,24 +5,24 @@ metadata:
 spec:
   tag: "latest"
   ingress_type: Ingress
-  pulp_admin_password_secret: "example-pulp-admin-password"
-  pulp_settings:
+  admin_password_secret: "example-pulp-admin-password"
+  settings:
     debug: "True"
-  pulp_storage_type: S3
-  pulp_object_storage_s3_secret: example-pulp-object-storage
-  pulp_content:
+  storage_type: S3
+  object_storage_s3_secret: example-pulp-object-storage
+  content:
     replicas: 1
     resource_requirements:
       requests:
         cpu: 150m
         memory: 256Mi
-  pulp_worker:
+  worker:
     replicas: 1
     resource_requirements:
       requests:
         cpu: 150m
         memory: 256Mi
-  pulp_web:
+  web:
     replicas: 1
     resource_requirements:
       requests:

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.object_storage.azure.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.object_storage.azure.yaml
@@ -5,24 +5,24 @@ metadata:
 spec:
   tag: "latest"
   ingress_type: Ingress
-  pulp_admin_password_secret: "example-pulp-admin-password"
-  pulp_settings:
+  admin_password_secret: "example-pulp-admin-password"
+  settings:
     debug: "True"
-  pulp_storage_type: Azure
-  pulp_object_storage_azure_secret: example-pulp-object-storage
-  pulp_content:
+  storage_type: Azure
+  object_storage_azure_secret: example-pulp-object-storage
+  content:
     replicas: 1
     resource_requirements:
       requests:
         cpu: 150m
         memory: 256Mi
-  pulp_worker:
+  worker:
     replicas: 1
     resource_requirements:
       requests:
         cpu: 150m
         memory: 256Mi
-  pulp_web:
+  web:
     replicas: 1
     resource_requirements:
       requests:

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.pulp-demo.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.pulp-demo.yaml
@@ -3,8 +3,8 @@ kind: Pulp
 metadata:
   name: example-pulp
 spec:
-  pulp_storage_type: File
-  pulp_file_storage:
+  storage_type: File
+  file_storage:
     # This doesn't really matter for minikube. Single node by design,
     # but the storage provisioner allows for ReadWriteMany. So let's
     # stick to our default.

--- a/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
@@ -53,7 +53,7 @@ spec:
                   debug:
                     type: string
                 type: object
-              pulp_admin_password_secret:
+              admin_password_secret:
                   description: Secret where the administrator password can be found
                   type: string
               postgres_configuration_secret:
@@ -102,7 +102,7 @@ spec:
               postgres_label_selector:
                 description: Label selector used to identify postgres pod for executing migration
                 type: string
-              pulp_storage_type:
+              storage_type:
                 description: Configuration for the storage type to be utilized
                 type: string
                 enum:
@@ -112,7 +112,7 @@ spec:
                   - S3
                   - azure
                   - Azure
-              pulp_file_storage:
+              file_storage:
                 description: Configuration for the persistentVolumeClaim for /var/lib/pulp.
                 properties:
                   access_mode:
@@ -126,13 +126,13 @@ spec:
                     description: The size of the file storage; for example 100Gi.
                     type: string
                 type: object
-              pulp_object_storage_s3_secret:
+              object_storage_s3_secret:
                 description: The secret for S3 compliant object storage configuration.
                 type: string
-              pulp_object_storage_azure_secret:
+              object_storage_azure_secret:
                 description: The secret for Azure blob storage configuration.
                 type: string
-              pulp_hostname:
+              hostname:
                 description: The hostname of the instance
                 type: string
               ingress_type:
@@ -187,7 +187,7 @@ spec:
                         type: string
                     type: object
                 type: object
-              pulp_web:
+              web:
                 description: The pulp web deployment.
                 properties:
                   replicas:
@@ -218,7 +218,7 @@ spec:
                         type: object
                     type: object
                 type: object
-              pulp_api:
+              api:
                 description: The pulp api deployment.
                 properties:
                   replicas:
@@ -259,7 +259,7 @@ spec:
                         type: object
                     type: object
                 type: object
-              pulp_content:
+              content:
                 description: The pulp content deployment.
                 properties:
                   replicas:
@@ -300,7 +300,7 @@ spec:
                         type: object
                     type: object
                 type: object
-              pulp_worker:
+              worker:
                 description: The pulp worker deployment.
                 properties:
                   replicas:
@@ -331,7 +331,7 @@ spec:
                         type: object
                     type: object
                 type: object
-              pulp_resource_manager:
+              resource_manager:
                 description: The pulp resource manager deployment.
                 properties:
                   replicas:

--- a/deploy/crds/pulpproject_v1beta1_pulpbackup_cr.ci.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulpbackup_cr.ci.yaml
@@ -4,4 +4,4 @@ kind: PulpBackup
 metadata:
   name: example-pulpbackup
 spec:
-  pulp_name: example-pulp
+  deployment_name: example-pulp

--- a/deploy/crds/pulpproject_v1beta1_pulpbackup_cr.default.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulpbackup_cr.default.yaml
@@ -4,8 +4,8 @@ kind: PulpBackup
 metadata:
   name: example-pulpbackup
 spec:
-  pulp_name: ''
-  pulp_backup_pvc: ''
-  pulp_backup_size: ''
-  pulp_backup_storage_class: ''
+  deployment_name: ''
+  backup_pvc: ''
+  backup_size: ''
+  backup_storage_class: ''
   postgres_label_selector: ''

--- a/deploy/crds/pulpproject_v1beta1_pulpbackup_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulpbackup_crd.yaml
@@ -26,32 +26,32 @@ spec:
             spec:
               type: object
               properties:
-                pulp_name:
+                deployment_name:
                   description: Name of the deployment to be backed up
                   type: string
-                pulp_backup_pvc:
+                backup_pvc:
                   description: Name of the PVC to be used for storing the backup
                   type: string
-                pulp_backup_size:
+                backup_size:
                   description: Size of PVC
                   type: string
-                pulp_backup_storage_class:
+                backup_storage_class:
                   description: Storage class to use when creating PVC for backup
                   type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for executing migration
                   type: string
               oneOf:
-                - required: ["pulp_name"]
+                - required: ["deployment_name"]
             status:
               properties:
-                pulpBackupClaim:
+                backupClaim:
                   description: The PVC name used for the backup
                   type: string
-                pulpBackupDirectory:
+                backupDirectory:
                   description: The directory data is backed up to on the PVC
                   type: string
-                pulpDeploymentStorageType:
+                deploymentStorageType:
                   description: The deployment storage type
                   type: string
                 conditions:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -14,8 +14,8 @@ metadata:
           },
           "spec": {
             "tag": "latest",
-            "pulp_storage_type": "File",
-            "pulp_file_storage": {
+            "storage_type": "File",
+            "file_storage": {
               "size": "50Gi"
             }
           }
@@ -37,12 +37,12 @@ spec:
       displayName: Pulp
       specDescriptors:
       - displayName: Hostname
-        path: pulp_hostname
+        path: hostname
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Admin password secret
-        path: pulp_admin_password_secret
+        path: admin_password_secret
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
@@ -130,33 +130,31 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Route
-      - displayName: Pulp Storage Configuration
-        path: pulp_storage
       - displayName: Pulp Storage Type
-        path: pulp_storage_type
+        path: storage_type
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:File
         - urn:alm:descriptor:com.tectonic.ui:select:S3
         - urn:alm:descriptor:com.tectonic.ui:select:Azure
       - displayName: Pulp File Storage Configuration
-        path: pulp_file_storage
+        path: file_storage
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:pulp_storage_type:File
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:storage_type:File
       - displayName: Pulp File Storage Configuration
-        path: pulp_file_storage.access_mode
+        path: file_storage.access_mode
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:pulp_storage_type:File
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:storage_type:File
         - urn:alm:descriptor:com.tectonic.ui:select:ReadWriteMany
       - displayName: Pulp S3 Storage Secret
-        path: pulp_object_storage_s3_secret
+        path: object_storage_s3_secret
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:pulp_storage_type:S3
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:storage_type:S3
       - displayName: Pulp Azure Storage Secret
-        path: pulp_object_storage_azure_secret
+        path: object_storage_azure_secret
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:pulp_storage_type:Azure
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:storage_type:Azure
       - displayName: Pulp Settings
         path: pulp_settings
         x-descriptors:
@@ -168,57 +166,57 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Pulp API Configuration
-        path: pulp_api
+        path: api
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Pulp API log level
-        path: pulp_api.log_level
+        path: api.log_level
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Pulp API resource requirements
-        path: pulp_api.resource_requirements
+        path: api.resource_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Pulp Content Configuration
-        path: pulp_content
+        path: content
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Pulp Content log level
-        path: pulp_content.log_level
+        path: content.log_level
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Pulp Content resource requirements
-        path: pulp_content.resource_requirements
+        path: content.resource_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Pulp Resource Manager Configuration
-        path: pulp_resource_manager
+        path: resource_manager
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Pulp Resource Manager resource requirements
-        path: pulp_resource_manager.resource_requirements
+        path: resource_manager.resource_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Pulp Worker Configuration
-        path: pulp_worker
+        path: worker
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Pulp Worker resource requirements
-        path: pulp_worker.resource_requirements
+        path: worker.resource_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Pulp Web Server Configuration
-        path: pulp_web
+        path: web
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Pulp Web Server resource requirements
-        path: pulp_web.resource_requirements
+        path: web.resource_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
@@ -310,21 +308,21 @@ spec:
       displayName: Pulp Backup
       specDescriptors:
       - displayName: Pulp Custom Resource Name
-        path: pulp_name
+        path: deployment_name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Pulp Backup Persistent Volume Claim
-        path: pulp_backup_pvc
+        path: backup_pvc
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Pulp Backup PVC Size
-        path: pulp_backup_size
+        path: backup_size
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Pulp Backup PVC Storage Class
-        path: pulp_backup_storage_class
+        path: backup_storage_class
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulpbackups_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulpbackups_crd.yml
@@ -25,32 +25,32 @@ spec:
             spec:
               type: object
               properties:
-                pulp_name:
+                deployment_name:
                   description: Name of the deployment to be backed up
                   type: string
-                pulp_backup_pvc:
+                backup_pvc:
                   description: Name of the PVC to be used for storing the backup
                   type: string
-                pulp_backup_size:
+                backup_size:
                   description: Size of PVC
                   type: string
-                pulp_backup_storage_class:
+                backup_storage_class:
                   description: Storage class to use when creating PVC for backup
                   type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for executing migration
                   type: string
               oneOf:
-                - required: ["pulp_name"]
+                - required: ["deployment_name"]
             status:
               properties:
-                pulpBackupClaim:
+                backupClaim:
                   description: The PVC name used for the backup
                   type: string
-                pulpBackupDirectory:
+                backupDirectory:
                   description: The directory data is backed up to on the PVC
                   type: string
-                pulpDeploymentStorageType:
+                deploymentStorageType:
                   description: The deployment storage type
                   type: string
                 conditions:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
@@ -53,7 +53,7 @@ spec:
                   debug:
                     type: string
                 type: object
-              pulp_admin_password_secret:
+              admin_password_secret:
                   description: Secret where the administrator password can be found
                   type: string
               postgres_configuration_secret:
@@ -102,7 +102,7 @@ spec:
               postgres_label_selector:
                 description: Label selector used to identify postgres pod for executing migration
                 type: string
-              pulp_storage_type:
+              storage_type:
                 description: Configuration for the storage type to be utilized
                 type: string
                 enum:
@@ -112,7 +112,7 @@ spec:
                   - S3
                   - azure
                   - Azure
-              pulp_file_storage:
+              file_storage:
                 description: Configuration for the persistentVolumeClaim for /var/lib/pulp.
                 properties:
                   access_mode:
@@ -126,13 +126,13 @@ spec:
                     description: The size of the file storage; for example 100Gi.
                     type: string
                 type: object
-              pulp_object_storage_s3_secret:
+              object_storage_s3_secret:
                 description: The secret for S3 compliant object storage configuration.
                 type: string
-              pulp_object_storage_azure_secret:
+              object_storage_azure_secret:
                 description: The secret for Azure blob storage configuration.
                 type: string
-              pulp_hostname:
+              hostname:
                 description: The hostname of the instance
                 type: string
               ingress_type:
@@ -187,7 +187,7 @@ spec:
                         type: string
                     type: object
                 type: object
-              pulp_web:
+              web:
                 description: The pulp web deployment.
                 properties:
                   replicas:
@@ -218,7 +218,7 @@ spec:
                         type: object
                     type: object
                 type: object
-              pulp_api:
+              api:
                 description: The pulp api deployment.
                 properties:
                   replicas:
@@ -259,7 +259,7 @@ spec:
                         type: object
                     type: object
                 type: object
-              pulp_content:
+              content:
                 description: The pulp content deployment.
                 properties:
                   replicas:
@@ -300,7 +300,7 @@ spec:
                         type: object
                     type: object
                 type: object
-              pulp_worker:
+              worker:
                 description: The pulp worker deployment.
                 properties:
                   replicas:
@@ -331,7 +331,7 @@ spec:
                         type: object
                     type: object
                 type: object
-              pulp_resource_manager:
+              resource_manager:
                 description: The pulp resource manager deployment.
                 properties:
                   replicas:

--- a/playbook.yml
+++ b/playbook.yml
@@ -6,7 +6,7 @@
     - operator_sdk.util
   vars:
     project_name: "{{ meta.namespace }}"
-    pulp_default_settings:
+    default_settings:
       databases:
         default:
           HOST: "{{ postgres_host }}"
@@ -26,8 +26,8 @@
     image: pulp
     image_web: pulp-web
     tag: stable
-    pulp_storage_type: File
-    pulp_file_storage:
+    storage_type: File
+    file_storage:
       access_mode: "ReadWriteMany"
       size: "100Gi"
   roles:

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -13,10 +13,10 @@ Requires the `openshift` Python library to interact with Kubernetes: `pip instal
 Role Variables
 --------------
 
-* `pulp_name`: The name of the pulp custom resource to backup
-* `pulp_backup_pvc`: The name of the PVC to uses for backup
-* `pulp_backup_size`: The size of storage for the PVC created by operator if one is not supplied
-* `pulp_backup_storage_class`: The storage class to be used for the backup PVC
+* `deployment_name`: The name of the pulp custom resource to backup
+* `backup_pvc`: The name of the PVC to uses for backup
+* `backup_size`: The size of storage for the PVC created by operator if one is not supplied
+* `backup_storage_class`: The storage class to be used for the backup PVC
 * `postgres_configuration_secret`: The postgres_configuration_secret
 
 

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -1,19 +1,19 @@
 ---
 # Required: specify name of pulp deployment to backup from
-pulp_name: ''
+deployment_name: ''
 
 # Specify a pre-created PVC (name) to backup to
-pulp_backup_pvc: ''
+backup_pvc: ''
 
 # Size of backup PVC if created dynamically
-pulp_backup_size: ''
+backup_size: ''
 
 # Specify storage class to determine how to dynamically create PVC's with
-pulp_backup_storage_class: ''
+backup_storage_class: ''
 
 # Secret Names
-pulp_admin_password_secret: "{{ pulp_name }}-admin-password"
-postgres_configuration_secret: "{{ pulp_name }}-postgres-configuration"
+admin_password_secret: "{{ deployment_name }}-admin-password"
+postgres_configuration_secret: "{{ deployment_name }}-postgres-configuration"
 
 custom_resource_key: '_pulp_pulpproject_org_pulpbackup'
 

--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -12,30 +12,30 @@
 # Check to make sure provided pvc exists, error loudly if not.  Otherwise, the management pod will just stay in pending state forever.
 - name: Check provided PVC exists
   k8s_info:
-    name: "{{ pulp_backup_pvc }}"
+    name: "{{ backup_pvc }}"
     kind: PersistentVolumeClaim
     namespace: "{{ meta.namespace }}"
   register: provided_pvc
   when:
-    - pulp_backup_pvc != ''
+    - backup_pvc != ''
 
 - name: Surface error to user
   block:
     - name: Set error message
       set_fact:
-        error_msg: "{{ pulp_backup_pvc }} does not exist, please create this pvc first."
+        error_msg: "{{ backup_pvc }} does not exist, please create this pvc first."
 
     - name: Handle error
       import_tasks: error_handling.yml
 
     - name: Fail early if pvc is defined but does not exist
       fail:
-        msg: "{{ pulp_backup_pvc }} does not exist, please create this pvc first."
+        msg: "{{ backup_pvc }} does not exist, please create this pvc first."
   when:
-    - pulp_backup_pvc != ''
+    - backup_pvc != ''
     - provided_pvc.resources | length == 0
 
-# If pulp_backup_pvc is defined, use in management-pod.yml.j2
+# If backup_pvc is defined, use in management-pod.yml.j2
 - name: Set default pvc name
   set_fact:
     _default_backup_pvc: "{{ meta.name }}-backup-claim"
@@ -43,7 +43,7 @@
 # by default, it will re-use the old pvc if already created (unless pvc is provided)
 - name: Set PVC to use for backup
   set_fact:
-    backup_pvc: "{{ pulp_backup_pvc | default(_default_backup_pvc, true) }}"
+    backup_pvc: "{{ backup_pvc | default(_default_backup_pvc, true) }}"
 
 - name: Create persistent volume claim for backup
   k8s:
@@ -52,74 +52,74 @@
   with_items:
     - backup
   when:
-    - pulp_backup_pvc == '' or pulp_backup_pvc is not defined
+    - backup_pvc == '' or backup_pvc is not defined
 
 - name: Get Pulp custom resource object
   k8s_info:
     version: v1beta1
     kind: Pulp
     namespace: '{{ meta.namespace }}'
-    name: '{{ pulp_name }}'
-  register: _pulp_cro
+    name: '{{ deployment_name }}'
+  register: _custom_resource
 
 - name: Set Pulp object
   set_fact:
-    _pulp: "{{ _pulp_cro['resources'][0] }}"
+    _pulp: "{{ _custom_resource['resources'][0] }}"
 
 - name: Set apiVersion
   set_fact:
-    pulp_api_version: "{{ _pulp['apiVersion'] }}"
+    api_version: "{{ _pulp['apiVersion'] }}"
 
 - name: Set user specified spec
   set_fact:
-    pulp_spec: "{{ _pulp['spec'] }}"
+    spec: "{{ _pulp['spec'] }}"
 
 - name: Set pulp status
   set_fact:
-    pulp_status: "{{ _pulp['status'] }}"
+    status: "{{ _pulp['status'] }}"
 
 - name: Set pulp admin secret if found
   set_fact:
-    pulp_admin_password_secret: "{{ pulp_status['adminPasswordSecret'] }}"
+    admin_password_secret: "{{ status['adminPasswordSecret'] }}"
   when:
-    - pulp_status['adminPasswordSecret'] is defined
-    - pulp_status['adminPasswordSecret'] | length
+    - status['adminPasswordSecret'] is defined
+    - status['adminPasswordSecret'] | length
 
 - name: Set pulp database configuration secret if found
   set_fact:
-    postgres_configuration_secret: "{{ pulp_status['databaseConfigruationSecret'] }}"
+    postgres_configuration_secret: "{{ status['databaseConfigruationSecret'] }}"
   when:
-    - pulp_status['databaseConfigruationSecret'] is defined
-    - pulp_status['databaseConfigruationSecret'] | length
+    - status['databaseConfigruationSecret'] is defined
+    - status['databaseConfigruationSecret'] | length
 
 - name: Set pulp storage type if found
   set_fact:
-    pulp_storage_type: "{{ pulp_status['storageType'] }}"
+    storage_type: "{{ status['storageType'] }}"
   when:
-    - pulp_status['storageType'] is defined
-    - pulp_status['storageType'] | length
+    - status['storageType'] is defined
+    - status['storageType'] | length
 
 - name: Set pulp file storage claim if found
   set_fact:
-    pulp_storage_claim: "{{ pulp_status['storagePersistentVolumeClaim'] }}"
+    storage_claim: "{{ status['storagePersistentVolumeClaim'] }}"
   when:
-    - pulp_status['storagePersistentVolumeClaim'] is defined
-    - pulp_status['storagePersistentVolumeClaim'] | length
+    - status['storagePersistentVolumeClaim'] is defined
+    - status['storagePersistentVolumeClaim'] | length
 
 - name: Set pulp object storage secret if found
   set_fact:
-    pulp_storage_secret: "{{ pulp_status['storageSecret'] }}"
+    storage_secret: "{{ status['storageSecret'] }}"
   when:
-    - pulp_status['storageSecret'] is defined
-    - pulp_status['storageSecret'] | length
+    - status['storageSecret'] is defined
+    - status['storageSecret'] | length
 
 - name: Get PVC information
   k8s_info:
     kind: PersistentVolumeClaim
     namespace: '{{ meta.namespace }}'
-    name: '{{ pulp_storage_claim }}'
+    name: '{{ storage_claim }}'
   register: _storage_claim
-  when: pulp_storage_claim is defined
+  when: storage_claim is defined
 
 - name: Set storage claim access mode
   set_fact:

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -13,16 +13,16 @@
     - include_tasks: secrets.yml
 
     - include_tasks: storage.yml
-      when: pulp_storage_type | lower == 'file'
+      when: storage_type | lower == 'file'
 
     - name: Set flag signifying this backup was successful
       set_fact:
-        pulp_backup_complete: "{{ _backup_dir }}"
+        backup_complete: "{{ _backup_dir }}"
 
     - include_tasks: cleanup.yml
 
   when:
-    - custom_resource_status['pulpBackupDirectory'] is not defined
+    - custom_resource_status['backupDirectory'] is not defined
 
 - name: Update status variables
   include_tasks: update_status.yml

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -12,7 +12,7 @@
   k8s_info:
     kind: Secret
     namespace: '{{ meta.namespace }}'
-    name: '{{ pulp_name }}-postgres-configuration'
+    name: '{{ deployment_name }}-postgres-configuration'
   register: _default_pg_config_resources
 
 - name: Set PostgreSQL configuration
@@ -29,7 +29,7 @@
 
 - name: Default label selector to custom resource generated postgres
   set_fact:
-    postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ pulp-name }}"
+    postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ deployment_name }}"
   when: postgres_label_selector is not defined
 
 - name: Get the postgres pod information
@@ -53,7 +53,7 @@
 
 - name: Set backup directory name
   set_fact:
-    _backup_dir: "/backups/pulp-openshift-backup-{{ now }}"
+    _backup_dir: "/backups/openshift-backup-{{ now }}"
 
 - name: Create directory for backup
   k8s_exec:

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -27,7 +27,7 @@
   k8s_info:
     kind: Secret
     namespace: '{{ meta.namespace }}'
-    name: '{{ pulp_admin_password_secret }}'
+    name: '{{ admin_password_secret }}'
   register: _admin_password
 
 - name: Set admin_password
@@ -94,9 +94,9 @@
   k8s_info:
     kind: Secret
     namespace: '{{ meta.namespace }}'
-    name: '{{ pulp_storage_secret }}'
+    name: '{{ storage_secret }}'
   register: _objectstorage_configuration
-  when: pulp_storage_secret is defined
+  when: storage_secret is defined
 
 - name: Set s3 common configuration values
   set_fact:
@@ -105,15 +105,15 @@
     s3_secret_access_key: "{{ _objectstorage_configuration['resources'][0]['data']['s3-secret-access-key'] | b64decode }}"
     s3_bucket_name: "{{ _objectstorage_configuration['resources'][0]['data']['s3-bucket-name'] | b64decode }}"
   when:
-    - pulp_storage_secret is defined
-    - pulp_storage_type | lower == 's3'
+    - storage_secret is defined
+    - storage_type | lower == 's3'
 
 - name: Set s3 region value if found
   set_fact:
     s3_region: "{{ s3_data_obj['s3-region'] | b64decode }}"
   when:
-    - pulp_storage_secret is defined
-    - pulp_storage_type | lower == 's3'
+    - storage_secret is defined
+    - storage_type | lower == 's3'
     - s3_data_obj['s3-region'] is defined
     - s3_data_obj['s3-region'] | length
 
@@ -121,8 +121,8 @@
   set_fact:
     s3_endpoint: "{{ s3_data_obj['s3-endpoint'] | b64decode }}"
   when:
-    - pulp_storage_secret is defined
-    - pulp_storage_type | lower == 's3'
+    - storage_secret is defined
+    - storage_type | lower == 's3'
     - s3_data_obj['s3-endpoint'] is defined
     - s3_data_obj['s3-endpoint'] | length
 
@@ -132,15 +132,15 @@
     dest: "{{ secrets_dir.path }}/objectstorage_secret.yaml"
     mode: '0600'
   when:
-    - pulp_storage_secret is defined
-    - pulp_storage_type | lower == 's3'
+    - storage_secret is defined
+    - storage_type | lower == 's3'
 
 - name: Set s3 configuration
   set_fact:
     s3_secret_template: "{{ lookup('file', '{{ secrets_dir.path }}/objectstorage_secret.yaml') }}"
   when:
-    - pulp_storage_secret is defined
-    - pulp_storage_type | lower == 's3'
+    - storage_secret is defined
+    - storage_type | lower == 's3'
 
 - name: Write s3 secret to pvc
   k8s_exec:
@@ -149,8 +149,8 @@
     command: >-
       bash -c "echo '{{ s3_secret_template }}' > {{ _backup_dir }}/objectstorage_secret.yaml"
   when:
-    - pulp_storage_secret is defined
-    - pulp_storage_type | lower == 's3'
+    - storage_secret is defined
+    - storage_type | lower == 's3'
 
 - name: Set azure common configuration values
   set_fact:
@@ -159,15 +159,15 @@
     azure-account-key: "{{ _objectstorage_configuration['resources'][0]['data']['azure-account-key'] | b64decode }}"
     azure-container: "{{ _objectstorage_configuration['resources'][0]['data']['azure-container'] | b64decode }}"
   when:
-    - pulp_storage_secret is defined
-    - pulp_storage_type | lower == 'azure'
+    - storage_secret is defined
+    - storage_type | lower == 'azure'
 
 - name: Set azure container path value if found
   set_fact:
     azure_container_path: "{{ azure_data_obj['azure-container-path'] | b64decode }}"
   when:
-    - pulp_storage_secret is defined
-    - pulp_storage_type | lower == 'azure'
+    - storage_secret is defined
+    - storage_type | lower == 'azure'
     - azure_data_obj['azure-container-path'] is defined
     - azure_data_obj['azure-container-path'] | length
 
@@ -177,15 +177,15 @@
     dest: "{{ secrets_dir.path }}/objectstorage_secret.yaml"
     mode: '0600'
   when:
-    - pulp_storage_secret is defined
-    - pulp_storage_type | lower == 'azure'
+    - storage_secret is defined
+    - storage_type | lower == 'azure'
 
 - name: Set azure configuration
   set_fact:
     azure_secret_template: "{{ lookup('file', '{{ secrets_dir.path }}/objectstorage_secret.yaml') }}"
   when:
-    - pulp_storage_secret is defined
-    - pulp_storage_type | lower == 'azure'
+    - storage_secret is defined
+    - storage_type | lower == 'azure'
 
 - name: Write azure secret to pvc
   k8s_exec:
@@ -194,5 +194,5 @@
     command: >-
       bash -c "echo '{{ azure_secret_template }}' > {{ _backup_dir }}/objectstorage_secret.yaml"
   when:
-    - pulp_storage_secret is defined
-    - pulp_storage_type | lower == 'azure'
+    - storage_secret is defined
+    - storage_type | lower == 'azure'

--- a/roles/backup/tasks/update_status.yml
+++ b/roles/backup/tasks/update_status.yml
@@ -12,8 +12,8 @@
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     status:
-      pulpBackupDirectory: "{{ _backup_dir }}"
-  when: pulp_backup_complete is defined
+      backupDirectory: "{{ _backup_dir }}"
+  when: backup_complete is defined
 
 # The backup PVC in this status can be referenced when restoring
 - name: Update backup PVC status
@@ -23,8 +23,8 @@
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     status:
-      pulpBackupClaim: "{{ backup_pvc }}"
-  when: pulp_backup_complete is defined
+      backupClaim: "{{ backup_pvc }}"
+  when: backup_complete is defined
 
 # The backup around storage type in this status can be referenced when restoring
 - name: Update deployment storage type status
@@ -34,5 +34,5 @@
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     status:
-      pulpDeploymentStorageType: "{{ pulp_storage_type }}"
-  when: pulp_storage_type is defined
+      deploymentStorageType: "{{ storage_type }}"
+  when: storage_type is defined

--- a/roles/backup/templates/admin_password_secret.yaml.j2
+++ b/roles/backup/templates/admin_password_secret.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
 {% raw %}
-  name: '{{ pulp_name }}-admin-password'
+  name: '{{ deployment_name }}-admin-password'
   namespace: '{{ meta.namespace }}'
 {% endraw %}
 stringData:

--- a/roles/backup/templates/azure_secret.yaml.j2
+++ b/roles/backup/templates/azure_secret.yaml.j2
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
 {% raw %}
-  name: '{{ pulp_name }}-objectstorage-configuration'
+  name: '{{ deployment_name }}-objectstorage-configuration'
   namespace: '{{ meta.namespace }}'
 {% endraw %}
 stringData:

--- a/roles/backup/templates/backup.pvc.yaml.j2
+++ b/roles/backup/templates/backup.pvc.yaml.j2
@@ -13,9 +13,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-{% if pulp_backup_storage_class != '' %}
-  storageClassName: {{ pulp_backup_storage_class }}
+{% if backup_storage_class != '' %}
+  storageClassName: {{ backup_storage_class }}
 {% endif %}
   resources:
     requests:
-      storage: {{ pulp_backup_size | default('5Gi', true) }}
+      storage: {{ backup_size | default('5Gi', true) }}

--- a/roles/backup/templates/management-pod.yaml.j2
+++ b/roles/backup/templates/management-pod.yaml.j2
@@ -20,8 +20,8 @@ spec:
     - name: {{ meta.name }}-backup
       mountPath: /backups
       readOnly: false
-{% if pulp_storage_claim is defined %}
-    - name: pulp-file-storage
+{% if storage_claim is defined %}
+    - name: file-storage
       readOnly: false
       mountPath: "/var/lib/pulp"
 {% endif %}
@@ -30,9 +30,9 @@ spec:
       persistentVolumeClaim:
         claimName: {{ backup_pvc }}
         readOnly: false
-{% if pulp_storage_claim is defined %}
-    - name: pulp-file-storage
+{% if storage_claim is defined %}
+    - name: file-storage
       persistentVolumeClaim:
-        claimName: {{ pulp_storage_claim }}
+        claimName: {{ storage_claim }}
 {% endif %}
   restartPolicy: Never

--- a/roles/backup/templates/postgres_secret.yaml.j2
+++ b/roles/backup/templates/postgres_secret.yaml.j2
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
 {% raw %}
-  name: '{{ pulp_name }}-postgres-configuration'
+  name: '{{ deployment_name }}-postgres-configuration'
   namespace: '{{ meta.namespace }}'
 {% endraw %}
 stringData:

--- a/roles/backup/templates/pulp_object.yaml.j2
+++ b/roles/backup/templates/pulp_object.yaml.j2
@@ -1,9 +1,9 @@
 ---
-apiVersion: '{{ pulp_api_version }}'
+apiVersion: '{{ api_version }}'
 kind: Pulp
 metadata:
 {% raw %}
-  name: '{{ pulp_name }}'
+  name: '{{ deployment_name }}'
   namespace: '{{ meta.namespace }}'
 {% endraw %}
-spec: {{ pulp_spec }}
+spec: {{ spec }}

--- a/roles/backup/templates/s3_secret.yaml.j2
+++ b/roles/backup/templates/s3_secret.yaml.j2
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
 {% raw %}
-  name: '{{ pulp_name }}-objectstorage-configuration'
+  name: '{{ deployment_name }}-objectstorage-configuration'
   namespace: '{{ meta.namespace }}'
 {% endraw %}
 stringData:

--- a/roles/postgres/tasks/migrate_data.yml
+++ b/roles/postgres/tasks/migrate_data.yml
@@ -10,7 +10,7 @@
 
 - name: Default label selector to custom resource generated postgres
   set_fact:
-    postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ pulp-name }}"
+    postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ meta.name }}"
   when: postgres_label_selector is not defined
 
 - name: Get the postgres pod information

--- a/roles/pulp-api/README.md
+++ b/roles/pulp-api/README.md
@@ -11,10 +11,10 @@ Requires the `openshift` Python library to interact with Kubernetes: `pip instal
 Role Variables
 --------------
 
-* `pulp_api`: A dictionary of pulp-api configuration
+* `api`: A dictionary of pulp-api configuration
     * `replicas`: Number of pod replicas.
     * `log_level`: The desired log level.
-* `pulp_default_settings`: A nested dictionary that will be combined with custom values from the user's
+* `default_settings`: A nested dictionary that will be combined with custom values from the user's
     `setting.py`. The keys of this dictionary are variable names, and the values should be expressed using the
     [Dynaconf syntax](https://dynaconf.readthedocs.io/en/latest/guides/environment_variables.html#precedence-and-type-casting)
     Please see [pulpcore configuration docs](https://docs.pulpproject.org/en/master/nightly/installation/configuration.html#id2)
@@ -24,12 +24,12 @@ Role Variables
 * `project`: The project name e.g. user or org name at the container registry.
 * `image`: The image name.
 * `tag`: The tag name.
-* `pulp_storage_type`: A string for specifying storage configuration type.
-* `pulp_file_storage`: A dict for specifying a persistent volume claim for pulp-file.
+* `storage_type`: A string for specifying storage configuration type.
+* `file_storage`: A dict for specifying a persistent volume claim for pulp-file.
     * `access_mode`: The access mode for the volume.
     * `size`: The storage size.
-* `pulp_object_storage_s3_secret`:The kubernetes secret with s3 storage configuration information.
-* `pulp_object_storage_azure_secret`:The kubernetes secret with Azure blob storage configuration information.
+* `object_storage_s3_secret`:The kubernetes secret with s3 storage configuration information.
+* `object_storage_azure_secret`:The kubernetes secret with Azure blob storage configuration information.
 
 Dependencies
 ------------

--- a/roles/pulp-api/defaults/main.yml
+++ b/roles/pulp-api/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-pulp_api:
+api:
   replicas: 1
   log_level: INFO
   resource_requirements:
@@ -13,14 +13,14 @@ raw_spec: "{{ vars['_pulp_pulpproject_org_pulp']['spec'] }}"
 
 # Secret to lookup that provide the admin password
 #
-pulp_admin_password_secret: ''
+admin_password_secret: ''
 
 # Host to create the root with.
 # If not specific will default to <instance-name>-<namespace>-<routerCanonicalHostname>
 #
 route_host: ''
 
-pulp_hostname: '{{ deployment_type }}.example.com'
+hostname: '{{ deployment_type }}.example.com'
 
 web_protocol: 'http'
 

--- a/roles/pulp-api/tasks/admin_password_configuration.yml
+++ b/roles/pulp-api/tasks/admin_password_configuration.yml
@@ -3,9 +3,9 @@
   k8s_info:
     kind: Secret
     namespace: '{{ meta.namespace }}'
-    name: '{{ pulp_admin_password_secret }}'
+    name: '{{ admin_password_secret }}'
   register: _custom_admin_password
-  when: pulp_admin_password_secret | length
+  when: admin_password_secret | length
 
 - name: Check for default admin password configuration
   k8s_info:
@@ -35,8 +35,8 @@
 
 - name: Set admin password secret
   set_fact:
-    pulp_admin_password_secret_obj: '{{ _generated_admin_password["resources"] | default([]) | length | ternary(_generated_admin_password, _admin_password_secret) }}'
+    admin_password_secret_obj: '{{ _generated_admin_password["resources"] | default([]) | length | ternary(_generated_admin_password, _admin_password_secret) }}'
 
 - name: Store admin password
   set_fact:
-    admin_password: "{{ pulp_admin_password_secret_obj['resources'][0]['data']['password'] | b64decode }}"
+    admin_password: "{{ admin_password_secret_obj['resources'][0]['data']['password'] | b64decode }}"

--- a/roles/pulp-api/tasks/azure-storage-configuration.yml
+++ b/roles/pulp-api/tasks/azure-storage-configuration.yml
@@ -3,7 +3,7 @@
   k8s_info:
     kind: Secret
     namespace: '{{ meta.namespace }}'
-    name: '{{ pulp_object_storage_azure_secret  }}'
+    name: '{{ object_storage_azure_secret  }}'
   register: _custom_azure_configuration
 
 - name: Check azure secret data format
@@ -17,7 +17,7 @@
 
 - name: Fail if azure secret object is an unexpected format
   fail:
-    msg: "Cannot read the data for secret {{ pulp_object_storage_azure_secret  }}"
+    msg: "Cannot read the data for secret {{ object_storage_azure_secret  }}"
   when:
     - not azure_secret_data_avaiable
 
@@ -47,7 +47,7 @@
 
 - name: Fail if required azure secret items are not present
   fail:
-    msg: "Secret {{ pulp_object_storage_azure_secret  }} is missing required configuration data."
+    msg: "Secret {{ object_storage_azure_secret  }} is missing required configuration data."
   when:
     - azure_secret_data_avaiable
     - not azure_account_name_available
@@ -108,4 +108,4 @@
 
 - name: merge default_azure_settings with settings
   set_fact:
-    pulp_default_settings: "{{ pulp_default_settings|combine(default_azure_settings) }}"
+    default_settings: "{{ default_settings|combine(default_azure_settings) }}"

--- a/roles/pulp-api/tasks/get_node_ip.yml
+++ b/roles/pulp-api/tasks/get_node_ip.yml
@@ -9,17 +9,17 @@
 
 - name: Set node address for ingress
   set_fact:
-    content_origin: "{{ web_protocol }}://{{ pulp_hostname }}"
+    content_origin: "{{ web_protocol }}://{{ hostname }}"
   when:
     - ingress_type|lower == "ingress"
-    - pulp_hostname is defined
+    - hostname is defined
 
-- name: Fail if pulp_hostname is not defined when ingress is specified
+- name: Fail if hostname is not defined when ingress is specified
   fail:
     msg: "The hostname must be specified when using ingress_type {{ ingress_type }}."
   when:
     - ingress_type|lower == "ingress"
-    - pulp_hostname is not defined
+    - hostname is not defined
 
 - name: Set node address for route
   set_fact:
@@ -65,8 +65,8 @@
 
 - name: merge content_origin with settings
   set_fact:
-    pulp_default_settings: "{{ pulp_default_settings|combine(content_origin_dict) }}"
+    default_settings: "{{ default_settings|combine(content_origin_dict) }}"
 
 - name: DEBUG Show content_origin
   debug:
-    msg: "{{ pulp_default_settings.content_origin }}"
+    msg: "{{ default_settings.content_origin }}"

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -3,14 +3,14 @@
     secret_key: "{{ lookup('password', '/dev/null length=50 chars=ascii_letters') }}"
 
 - set_fact:
-    object_storage_secret: "{{ pulp_object_storage_s3_secret }}"
+    object_storage_secret: "{{ object_storage_s3_secret }}"
   when:
-    - pulp_object_storage_s3_secret is defined
+    - object_storage_s3_secret is defined
 
 - set_fact:
-    object_storage_secret: "{{ pulp_object_storage_azure_secret }}"
+    object_storage_secret: "{{ object_storage_azure_secret }}"
   when:
-    - pulp_object_storage_azure_secret is defined
+    - object_storage_azure_secret is defined
 
 - set_fact:
     file_storage: false
@@ -29,15 +29,15 @@
     file: s3-storage-configuration.yml
   when:
     - not file_storage
-    - pulp_object_storage_s3_secret is defined
-    - pulp_object_storage_s3_secret | length
+    - object_storage_s3_secret is defined
+    - object_storage_s3_secret | length
 
 - include_tasks:
     file: azure-storage-configuration.yml
   when:
     - not file_storage
-    - pulp_object_storage_azure_secret is defined
-    - pulp_object_storage_azure_secret | length
+    - object_storage_azure_secret is defined
+    - object_storage_azure_secret | length
 
 # Workaround being unable to do the following, for the subsequent task:
 # when: (pulp_settings is not defined) or
@@ -62,7 +62,7 @@
 
 - name: Combining pulp_settings
   set_fact:
-    pulp_combined_settings: "{{ pulp_default_settings|combine(raw_pulp_settings, recursive=True) if pulp_settings is defined and pulp_settings is not none else pulp_default_settings }}"
+    pulp_combined_settings: "{{ default_settings|combine(raw_pulp_settings, recursive=True) if pulp_settings is defined and pulp_settings is not none else default_settings }}"
 
 - name: pulp-server secret
   k8s:

--- a/roles/pulp-api/tasks/s3-storage-configuration.yml
+++ b/roles/pulp-api/tasks/s3-storage-configuration.yml
@@ -3,7 +3,7 @@
   k8s_info:
     kind: Secret
     namespace: '{{ meta.namespace }}'
-    name: '{{ pulp_object_storage_s3_secret  }}'
+    name: '{{ object_storage_s3_secret  }}'
   register: _custom_s3_configuration
 
 - name: Check s3 secret data format
@@ -17,7 +17,7 @@
 
 - name: Fail if s3 secret object is an unexpected format
   fail:
-    msg: "Cannot read the data for secret {{ pulp_object_storage_s3_secret  }}"
+    msg: "Cannot read the data for secret {{ object_storage_s3_secret  }}"
   when:
     - not s3_secret_data_avaiable
 
@@ -63,7 +63,7 @@
 
 - name: Fail if required s3 secret items are not present
   fail:
-    msg: "Secret {{ pulp_object_storage_s3_secret  }} is missing required configuration data."
+    msg: "Secret {{ object_storage_s3_secret  }} is missing required configuration data."
   when:
     - s3_secret_data_avaiable
     - not s3_access_key_id_available
@@ -157,4 +157,4 @@
 
 - name: merge default_s3_settings with settings
   set_fact:
-    pulp_default_settings: "{{ pulp_default_settings|combine(default_s3_settings) }}"
+    default_settings: "{{ default_settings|combine(default_s3_settings) }}"

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
 spec:
-  replicas: {{ pulp_api.replicas }}
+  replicas: {{ api.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: '{{ deployment_type }}-api'
@@ -44,20 +44,20 @@ spec:
           secret:
             secretName: {{ meta.name }}-admin-password
             items:
-              - path: pulp-admin-password
+              - path: admin-password
                 key: password
 {% if file_storage %}
-        - name: pulp-file-storage
+        - name: file-storage
           persistentVolumeClaim:
             claimName: {{ meta.name }}-file-storage
 {% else %}
-        - name: pulp-tmp-file-storage
+        - name: tmp-file-storage
           emptyDir: {}
-        - name: pulp-assets-file-storage
+        - name: assets-file-storage
           emptyDir: {}
 {% endif %}
       containers:
-        - name: pulp-api
+        - name: api
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
           imagePullPolicy: "IfNotPresent"
           # We set args, not command, so as to not override the entrypoint script
@@ -70,7 +70,7 @@ spec:
             - name: REDIS_SERVICE_HOST
               value: "{{ meta.name }}-redis"
             - name: REDIS_SERVICE_PORT
-              value: "{{ pulp_default_settings.redis_port }}"
+              value: "{{ default_settings.redis_port }}"
           ports:
             - protocol: TCP
               containerPort: 24817
@@ -92,8 +92,8 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
-{% if pulp_api.resource_requirements is defined %}
-          resources: {{ pulp_api.resource_requirements }}
+{% if api.resource_requirements is defined %}
+          resources: {{ api.resource_requirements }}
 {% endif %}
           volumeMounts:
             - name: {{ meta.name }}-server
@@ -102,15 +102,15 @@ spec:
               readOnly: true
             - name: {{ meta.name }}-admin-password
               mountPath: "/etc/pulp/pulp-admin-password"
-              subPath: pulp-admin-password
+              subPath: admin-password
               readOnly: true
 {% if file_storage %}
-            - name: pulp-file-storage
+            - name: file-storage
               readOnly: false
               mountPath: "/var/lib/pulp"
 {% else %}
-            - name: pulp-tmp-file-storage
+            - name: tmp-file-storage
               mountPath: "/var/lib/pulp/tmp"
-            - name: pulp-assets-file-storage
+            - name: assets-file-storage
               mountPath: "/var/lib/pulp/assets"
 {% endif %}

--- a/roles/pulp-api/templates/pulp-api.service.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.service.yaml.j2
@@ -20,7 +20,7 @@ spec:
   ports:
     - protocol: TCP
       targetPort: 24817
-      name: pulp-api-24817
+      name: api-24817
       port: 24817
 {% if ingress_type|lower == "none" %}
       nodePort: 24817

--- a/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
+++ b/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
@@ -13,6 +13,6 @@ metadata:
 spec:
   resources:
     requests:
-      storage: "{{ pulp_file_storage.size }}"
+      storage: "{{ file_storage.size }}"
   accessModes:
-    - "{{ pulp_file_storage.access_mode }}"
+    - "{{ file_storage.access_mode }}"

--- a/roles/pulp-content/README.md
+++ b/roles/pulp-content/README.md
@@ -11,7 +11,7 @@ Requires the `openshift` Python library to interact with Kubernetes: `pip instal
 Role Variables
 --------------
 
-* `pulp_content`: A dictionary of pulp-content configuration
+* `content`: A dictionary of pulp-content configuration
     * `replicas`: Number of pod replicas.
     * `log_level`: The desired log level.
 * `registry`: The container registry.

--- a/roles/pulp-content/defaults/main.yml
+++ b/roles/pulp-content/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-pulp_content:
+content:
   replicas: 2
   log_level: INFO
   resource_requirements:

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
 spec:
-  replicas: {{ pulp_content.replicas }}
+  replicas: {{ content.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: '{{ deployment_type }}-content'
@@ -41,18 +41,18 @@ spec:
               - path: settings.py
                 key: settings.py
 {% if file_storage %}
-        - name: pulp-file-storage
+        - name: file-storage
           persistentVolumeClaim:
             claimName: {{ meta.name }}-file-storage
 {% endif %}
       containers:
-        - name: pulp-content
+        - name: content
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
           imagePullPolicy: "IfNotPresent"
           # We set args, not command, so as to not override the entrypoint script
           args: ["pulp-content"]
-{% if pulp_content.resource_requirements is defined %}
-          resources: {{ pulp_content.resource_requirements }}
+{% if content.resource_requirements is defined %}
+          resources: {{ content.resource_requirements }}
 {% endif %}
           env:
             - name: POSTGRES_SERVICE_HOST
@@ -62,7 +62,7 @@ spec:
             - name: REDIS_SERVICE_HOST
               value: "{{ meta.name }}-redis"
             - name: REDIS_SERVICE_PORT
-              value: "{{ pulp_default_settings.redis_port }}"
+              value: "{{ default_settings.redis_port }}"
           ports:
             - protocol: TCP
               containerPort: 24816
@@ -70,7 +70,7 @@ spec:
             - name: {{ meta.name }}-server
               mountPath: "/etc/pulp/"
 {% if file_storage %}
-            - name: pulp-file-storage
+            - name: file-storage
               readOnly: false
               mountPath: "/var/lib/pulp"
 {% endif %}

--- a/roles/pulp-resource-manager/README.md
+++ b/roles/pulp-resource-manager/README.md
@@ -11,7 +11,7 @@ Requires the `openshift` Python library to interact with Kubernetes: `pip instal
 Role Variables
 --------------
 
-* `pulp_resource_manager`: A dictionary of pulp-resource-manager configuration
+* `resource_manager`: A dictionary of pulp-resource-manager configuration
     * `replicas`: Number of pod replicas.
 * `registry`: The container registry.
 * `project`: The project name e.g. user or org name at the container registry.

--- a/roles/pulp-resource-manager/defaults/main.yml
+++ b/roles/pulp-resource-manager/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-pulp_resource_manager:
+resource_manager:
   # Waiting on this to be implemented:
   # https://pulp.plan.io/issues/3707
   replicas: 1

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
 spec:
-  replicas: {{ pulp_resource_manager.replicas }}
+  replicas: {{ resource_manager.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: '{{ deployment_type }}-resource-manager'
@@ -41,15 +41,15 @@ spec:
               - path: settings.py
                 key: settings.py
 {% if file_storage %}
-        - name: pulp-file-storage
+        - name: file-storage
           persistentVolumeClaim:
             claimName: {{ meta.name }}-file-storage
 {% else %}
-        - name: pulp-tmp-file-storage
+        - name: tmp-file-storage
           emptyDir: {}
 {% endif %}
       containers:
-        - name: pulp-resource-manager
+        - name: resource-manager
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
           imagePullPolicy: "IfNotPresent"
           # We set args, not command, so as to not override the entrypoint script
@@ -62,18 +62,18 @@ spec:
             - name: REDIS_SERVICE_HOST
               value: "{{ meta.name }}-redis"
             - name: REDIS_SERVICE_PORT
-              value: "{{ pulp_default_settings.redis_port }}"
+              value: "{{ default_settings.redis_port }}"
           volumeMounts:
             - name: {{ meta.name }}-server
               mountPath: "/etc/pulp/"
 {% if file_storage %}              
-            - name: pulp-file-storage
+            - name: file-storage
               readOnly: false
               mountPath: "/var/lib/pulp"
 {% else %}
-            - name: pulp-tmp-file-storage
+            - name: tmp-file-storage
               mountPath: "/var/lib/pulp/tmp"
 {% endif %}
-{% if pulp_resource_manager.resource_requirements is defined %}
-          resources: {{ pulp_resource_manager.resource_requirements }}
+{% if resource_manager.resource_requirements is defined %}
+          resources: {{ resource_manager.resource_requirements }}
 {% endif %}

--- a/roles/pulp-routes/defaults/main.yml
+++ b/roles/pulp-routes/defaults/main.yml
@@ -4,4 +4,4 @@
 #
 route_host: ''
 
-pulp_hostname: '{{ deployment_type }}.example.com'
+hostname: '{{ deployment_type }}.example.com'

--- a/roles/pulp-routes/templates/pulp.ingress.yaml.j2
+++ b/roles/pulp-routes/templates/pulp.ingress.yaml.j2
@@ -11,7 +11,7 @@ metadata:
 {% endif %}
 spec:
   rules:
-    - host: '{{ pulp_hostname }}'
+    - host: '{{ hostname }}'
       http:
         paths:
           - path: /
@@ -21,7 +21,7 @@ spec:
 {% if ingress_tls_secret %}
   tls:
     - hosts:
-        - {{ pulp_hostname }}
+        - {{ hostname }}
       secretName: {{ ingress_tls_secret }}
 {% endif %}
 {% endif %}
@@ -38,7 +38,7 @@ spec:
   host: {{ route_host }}
 {% endif %}
   port:
-    targetPort: '{{ (route_tls_termination_mechanism | lower == "passthrough") | ternary("pulp-web-8443", "pulp-web-8080") }}'
+    targetPort: '{{ (route_tls_termination_mechanism | lower == "passthrough") | ternary("web-8443", "web-8080") }}'
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: {{ route_tls_termination_mechanism | lower }}

--- a/roles/pulp-status/tasks/main.yml
+++ b/roles/pulp-status/tasks/main.yml
@@ -45,7 +45,7 @@
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     status:
-      adminPasswordSecret: "{{ pulp_admin_password_secret_obj['resources'][0]['metadata']['name'] }}"
+      adminPasswordSecret: "{{ admin_password_secret_obj['resources'][0]['metadata']['name'] }}"
 
 - name: Update database configuration status
   operator_sdk.util.k8s_status:
@@ -63,7 +63,7 @@
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     status:
-      storageType: "{{ pulp_storage_type | capitalize }}"
+      storageType: "{{ storage_type | capitalize }}"
 
 - name: Update file storage pvc name status
   operator_sdk.util.k8s_status:

--- a/roles/pulp-web/README.md
+++ b/roles/pulp-web/README.md
@@ -11,7 +11,7 @@ Requires the `openshift` Python library to interact with Kubernetes: `pip instal
 Role Variables
 --------------
 
-* `pulp_web`: A dictionary of pulp-web configuration
+* `web`: A dictionary of pulp-web configuration
     * `replicas`: Number of pod replicas.
 * `registry`: The container registry.
 * `project`: The project name e.g. user or org name at the container registry.

--- a/roles/pulp-web/defaults/main.yml
+++ b/roles/pulp-web/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-pulp_web:
+web:
   replicas: 1
   resource_requirements:
     requests:

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
 spec:
-  replicas: {{ pulp_web.replicas }}
+  replicas: {{ web.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: 'nginx'
@@ -29,7 +29,7 @@ spec:
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
       containers:
-        - name: pulp-web
+        - name: web
           image: "{{ registry }}/{{ project }}/{{ image_web }}:{{ tag }}"
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
@@ -66,8 +66,8 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
-{% if pulp_web.resource_requirements is defined %}
-          resources: {{ pulp_web.resource_requirements }}
+{% if web.resource_requirements is defined %}
+          resources: {{ web.resource_requirements }}
 {% endif %}
       volumes:
         - name: {{ meta.name }}-nginx-conf

--- a/roles/pulp-web/templates/pulp-web.service.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.service.yaml.j2
@@ -20,7 +20,7 @@ spec:
   ports:
     - protocol: TCP
       targetPort: 8080
-      name: pulp-web-8080
+      name: web-8080
       port: 24880
 {% if ingress_type|lower == "none" %}
       nodePort: 24880

--- a/roles/pulp-worker/README.md
+++ b/roles/pulp-worker/README.md
@@ -11,7 +11,7 @@ Requires the `openshift` Python library to interact with Kubernetes: `pip instal
 Role Variables
 --------------
 
-* `pulp_worker`: A dictionary of pulp-worker configuration
+* `worker`: A dictionary of pulp-worker configuration
     * `replicas`: Number of pod replicas.
 * `registry`: The container registry.
 * `project`: The project name e.g. user or org name at the container registry.

--- a/roles/pulp-worker/defaults/main.yml
+++ b/roles/pulp-worker/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
-pulp_worker:
+deployment_type: pulp
+
+worker:
   replicas: 2
   resource_requirements:
     requests:

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
 spec:
-  replicas: {{ pulp_worker.replicas }}
+  replicas: {{ worker.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: '{{ deployment_type }}-worker'
@@ -41,17 +41,17 @@ spec:
               - path: settings.py
                 key: settings.py
 {% if file_storage %}
-        - name: pulp-file-storage
+        - name: file-storage
           persistentVolumeClaim:
             claimName: {{ meta.name }}-file-storage
 {% else %}
-        - name: pulp-tmp-file-storage
+        - name: tmp-file-storage
           emptyDir: {}
 {% endif %}
         - name: {{ meta.name }}-ansible-tmp
           emptyDir: {}
       containers:
-        - name: pulp-worker
+        - name: worker
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
           imagePullPolicy: "IfNotPresent"
           # We set args, not command, so as to not override the entrypoint script
@@ -64,20 +64,20 @@ spec:
             - name: REDIS_SERVICE_HOST
               value: "{{ meta.name }}-redis"
             - name: REDIS_SERVICE_PORT
-              value: "{{ pulp_default_settings.redis_port }}"
+              value: "{{ default_settings.redis_port }}"
           volumeMounts:
             - name: {{ meta.name }}-ansible-tmp
               mountPath: "/.ansible/tmp/"
             - name: {{ meta.name }}-server
               mountPath: "/etc/pulp/"
 {% if file_storage %}
-            - name: pulp-file-storage
+            - name: file-storage
               readOnly: false
               mountPath: "/var/lib/pulp"
 {% else %}
-            - name: pulp-tmp-file-storage
+            - name: tmp-file-storage
               mountPath: "/var/lib/pulp/tmp"
 {% endif %}
-{% if pulp_worker.resource_requirements is defined %}
-          resources: {{ pulp_worker.resource_requirements }}
+{% if worker.resource_requirements is defined %}
+          resources: {{ worker.resource_requirements }}
 {% endif %}


### PR DESCRIPTION
* Clean up prefixes from CRD and CRs
* Clean up prefixes from roles
* Fix failure log capture from previous label changes.

fixes #8563
https://pulp.plan.io/issues/8563