### PR TITLE
Container registry capabilities will be disable by default in Galaxy

### DIFF
--- a/CHANGES/8598.misc
+++ b/CHANGES/8598.misc
@@ -1,0 +1,1 @@
+Container registry capabilities will be disable by default in Galaxy when running on Kubernetes/OpenShift

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.galaxy.container.ci.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.galaxy.container.ci.yaml
@@ -1,0 +1,38 @@
+apiVersion: pulp.pulpproject.org/v1beta1
+kind: Pulp
+metadata:
+  name: example-pulp
+spec:
+  ingress_type: Ingress
+  image: galaxy
+  image_web: "galaxy-web"
+  tag: "latest"
+  admin_password_secret: "example-pulp-admin-password"
+  container_token_secret: "container-auth"
+  pulp_settings:
+    GALAXY_FEATURE_FLAGS:
+      execution_environments: "True"
+  storage_type: File
+  file_storage:
+    # k3s local-path requires this
+    access_mode: "ReadWriteOnce"
+    # We have a little over 10GB free on GHA VMs/instances
+    size: "10Gi"
+  content:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+  worker:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+  web:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 100m
+        memory: 256Mi

--- a/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
@@ -52,6 +52,11 @@ spec:
                 properties:
                   debug:
                     type: string
+                  GALAXY_FEATURE_FLAGS:
+                    properties:
+                      execution_environments:
+                        type: string
+                    type: object
                 type: object
               admin_password_secret:
                   description: Secret where the administrator password can be found
@@ -164,6 +169,9 @@ spec:
                   - passthrough
               route_tls_secret:
                 description: Secret where the TLS related credentials are stored
+                type: string
+              container_token_secret:
+                description: Secret where the container token certificates are stored
                 type: string
               redis_resource_requirements:
                 description: Resource requirements for the Redis container
@@ -390,7 +398,10 @@ spec:
                 description: URL of the image used for the deployed instance
                 type: string
               migrantDatabaseConfigurationSecret:
-                description: The configuration secret used for migrating an old deployment.
+                description: The configuration secret used for migrating an old deployment
+                type: string
+              containerTokenSecret:
+                description: The name of the secret used for container token authentication
                 type: string
               conditions:
                 description: The resulting conditions when a Service Telemetry is instantiated

--- a/deploy/crds/pulpproject_v1beta1_pulpbackup_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulpbackup_crd.yaml
@@ -66,6 +66,9 @@ spec:
                 objectStorageConfigurationSecret:
                   description: Objectstorage configuration secret used by the deployed instance
                   type: string
+                containerTokenSecret:
+                  description: Container token configuration secret used by the deployed instance
+                  type: string
                 conditions:
                   description: The resulting conditions when a Service Telemetry is instantiated
                   items:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -301,6 +301,11 @@ spec:
         path: migrantDatabaseConfigurationSecret
         x-descriptors:
           - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Container token configuration
+        description: Configuration secret for container token authentication
+        path: containerTokenSecret
+        x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
     - description: A Pulp Backup Instance
       kind: PulpBackup
       name: pulpbackups.pulp.pulpproject.org
@@ -365,6 +370,11 @@ spec:
       - displayName: Objectstorage configuration
         description: Configuration secret for current deployed objectstorage
         path: objectStorageConfigurationSecret
+        x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Container token configuration
+        description: Configuration secret for container token authentication
+        path: containerTokenSecret
         x-descriptors:
           - urn:alm:descriptor:io.kubernetes:Secret
     - description: A Pulp Restore Instance

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulpbackups_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulpbackups_crd.yml
@@ -65,6 +65,9 @@ spec:
                 objectStorageConfigurationSecret:
                   description: Objectstorage configuration secret used by the deployed instance
                   type: string
+                containerTokenSecret:
+                  description: Container token configuration secret used by the deployed instance
+                  type: string
                 conditions:
                   description: The resulting conditions when a Service Telemetry is instantiated
                   items:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
@@ -52,6 +52,11 @@ spec:
                 properties:
                   debug:
                     type: string
+                  GALAXY_FEATURE_FLAGS:
+                    properties:
+                      execution_environments:
+                        type: string
+                    type: object
                 type: object
               admin_password_secret:
                   description: Secret where the administrator password can be found
@@ -164,6 +169,9 @@ spec:
                   - passthrough
               route_tls_secret:
                 description: Secret where the TLS related credentials are stored
+                type: string
+              container_token_secret:
+                description: Secret where the container token certificates are stored
                 type: string
               redis_resource_requirements:
                 description: Resource requirements for the Redis container
@@ -390,7 +398,10 @@ spec:
                 description: URL of the image used for the deployed instance
                 type: string
               migrantDatabaseConfigurationSecret:
-                description: The configuration secret used for migrating an old deployment.
+                description: The configuration secret used for migrating an old deployment
+                type: string
+              containerTokenSecret:
+                description: The name of the secret used for container token authentication
                 type: string
               conditions:
                 description: The resulting conditions when a Service Telemetry is instantiated

--- a/playbook.yml
+++ b/playbook.yml
@@ -19,7 +19,12 @@
       debug: "True"
       redis_host: "{{ meta.name }}-redis"
       redis_port: 6379
-      redis_password: ''
+      redis_password: ""
+      TOKEN_SIGNATURE_ALGORITHM: "ES256"
+      PUBLIC_KEY_PATH: "/etc/pulp/keys/container_auth_public_key.pem"
+      PRIVATE_KEY_PATH: "/etc/pulp/keys/container_auth_private_key.pem"
+      GALAXY_FEATURE_FLAGS:
+        execution_environments: ""
     deployment_state: present
     registry: quay.io
     project: pulp

--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -115,6 +115,13 @@
     - status['storageSecret'] is defined
     - status['storageSecret'] | length
 
+- name: Set container token secret if found
+  set_fact:
+    container_token_secret: "{{ status['containerTokenSecret'] }}"
+  when:
+    - status['containerTokenSecret'] is defined
+    - status['containerTokenSecret'] | length
+
 - name: Get PVC information
   k8s_info:
     kind: PersistentVolumeClaim

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -63,6 +63,48 @@
     command: >-
       bash -c "echo '{{ default_secret_template }}' > {{ _backup_dir }}/secrets.yaml"
 
+- name: Get container token configuration
+  k8s_info:
+    kind: Secret
+    namespace: '{{ meta.namespace }}'
+    name: '{{ container_token_secret }}'
+  register: _container_token_configuration
+  when: container_token_secret is defined
+
+- name: Set container token configuration
+  set_fact:
+    container_auth_private_key: "{{ _container_token_configuration['resources'][0]['data']['container_auth_private_key.pem'] | b64decode }}"
+    container_auth_public_key: "{{ _container_token_configuration['resources'][0]['data']['container_auth_public_key.pem'] | b64decode }}"
+  when:
+    - _container_token_configuration is defined
+    - _container_token_configuration['resources'][0]['data']['container_auth_private_key.pem'] is defined
+    - _container_token_configuration['resources'][0]['data']['container_auth_private_key.pem'] | length
+    - _container_token_configuration['resources'][0]['data']['container_auth_public_key.pem'] is defined
+    - _container_token_configuration['resources'][0]['data']['container_auth_public_key.pem'] | length
+
+- name: Template container token configuration definition
+  template:
+    src: container_token_secret.yaml.j2
+    dest: "{{ secrets_dir.path }}/container_token_secret.yaml"
+    mode: '0600'
+  when:
+    - container_token_secret is defined
+
+- name: Set container token configuration
+  set_fact:
+    container_token_secret_template: "{{ lookup('file', '{{ secrets_dir.path }}/container_token_secret.yaml') }}"
+  when:
+    - container_token_secret is defined
+
+- name: Write container token secret to pvc
+  k8s_exec:
+    namespace: "{{ meta.namespace }}"
+    pod: "{{ meta.name }}-backup-manager"
+    command: >-
+      bash -c "echo '{{ container_token_secret_template }}' > {{ _backup_dir }}/container_token_secret.yaml"
+  when:
+    - container_token_secret is defined
+
 - name: Get objectstorage configuration
   k8s_info:
     kind: Secret

--- a/roles/backup/tasks/update_status.yml
+++ b/roles/backup/tasks/update_status.yml
@@ -71,6 +71,17 @@
       databaseConfigurationSecret: "{{ postgres_configuration_secret }}"
   when: postgres_configuration_secret is defined
 
+# The backup container token secret in this status can be referenced when restoring
+- name: Update container token secret name status
+  operator_sdk.util.k8s_status:
+    api_version: '{{ api_version }}'
+    kind: "{{ kind }}"
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.namespace }}"
+    status:
+      containerTokenSecret: "{{ container_token_secret }}"
+  when: container_token_secret is defined
+
 # The backup objectstorage secret in this status can be referenced when restoring
 - name: Update objectstorage secret name status
   operator_sdk.util.k8s_status:

--- a/roles/backup/templates/container_token_secret.yaml.j2
+++ b/roles/backup/templates/container_token_secret.yaml.j2
@@ -1,0 +1,4 @@
+# Container Token Secret.
+---
+container_auth_private_key: '{{ container_auth_private_key }}'
+container_auth_public_key: '{{ container_auth_public_key }}'

--- a/roles/pulp-api/tasks/get_node_ip.yml
+++ b/roles/pulp-api/tasks/get_node_ip.yml
@@ -10,6 +10,7 @@
 - name: Set node address for ingress
   set_fact:
     content_origin: "{{ web_protocol }}://{{ hostname }}"
+    token_server: "{{ web_protocol }}://{{ hostname }}/token/"
   when:
     - ingress_type|lower == "ingress"
     - hostname is defined
@@ -24,6 +25,7 @@
 - name: Set node address for route
   set_fact:
     content_origin: "{{ web_protocol }}://{{ route_host }}"
+    token_server: "{{ web_protocol }}://{{ route_host }}/token/"
   when:
     - ingress_type|lower == "route"
     - route_host is defined
@@ -46,12 +48,13 @@
 - name: Set node address
   set_fact:
     content_origin: "http://{{ k8s_nodes.resources[0].status.addresses[0].address }}:24880"
+    token_server: "http://{{ k8s_nodes.resources[0].status.addresses[0].address }}:24880/token/"
   when:
     - content_origin is not defined
 
 - name: Set content_origin
   set_fact:
-    content_origin_dict: "{'content_origin': '{{ content_origin }}' }"
+    content_origin_dict: "{'content_origin': '{{ content_origin }}', 'token_server': '{{ token_server }}' }"
 
 - name: DEBUG Show content_origin_dict
   debug:

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -56,6 +56,16 @@ spec:
         - name: assets-file-storage
           emptyDir: {}
 {% endif %}
+{% if container_token_secret is defined %}
+        - name: {{ meta.name }}-container-auth-certs
+          secret:
+            secretName: {{ container_token_secret }}
+            items:
+              - path: container_auth_public_key.pem
+                key: container_auth_public_key.pem
+              - path: container_auth_private_key.pem
+                key: container_auth_private_key.pem
+{% endif %}
       containers:
         - name: api
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
@@ -113,4 +123,14 @@ spec:
               mountPath: "/var/lib/pulp/tmp"
             - name: assets-file-storage
               mountPath: "/var/lib/pulp/assets"
+{% endif %}
+{% if container_token_secret is defined %}
+            - name: {{ meta.name }}-container-auth-certs
+              mountPath: "/etc/pulp/keys/container_auth_private_key.pem"
+              subPath: container_auth_private_key.pem
+              readOnly: true
+            - name: {{ meta.name }}-container-auth-certs
+              mountPath: "/etc/pulp/keys/container_auth_public_key.pem"
+              subPath: container_auth_public_key.pem
+              readOnly: true
 {% endif %}

--- a/roles/pulp-status/tasks/main.yml
+++ b/roles/pulp-status/tasks/main.yml
@@ -85,6 +85,16 @@
       storageSecret: "{{ object_storage_secret }}"
   when: not file_storage
 
+- name: Update container token secret name status
+  operator_sdk.util.k8s_status:
+    api_version: '{{ api_version }}'
+    kind: "{{ kind }}"
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.namespace }}"
+    status:
+      containerTokenSecret: "{{ container_token_secret }}"
+  when: container_token_secret is defined
+
 - name: Update version status
   operator_sdk.util.k8s_status:
     api_version: '{{ api_version }}'

--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -40,11 +40,17 @@
     admin_passowrd_name: "{{ this_backup['resources'][0]['status']['adminPasswordSecret'] }}"
     db_secret_name: "{{ this_backup['resources'][0]['status']['databaseConfigurationSecret'] }}"
 
-- name: Set optional backup facts
+- name: Set optional objectstorage backup fact
   set_fact:
     storage_secret: "{{ this_backup['resources'][0]['status']['objectStorageConfigurationSecret'] }}"
   when:
     - this_backup['resources'][0]['status']['objectStorageConfigurationSecret'] is defined
+
+- name: Set optional container token backup fact
+  set_fact:
+    container_token_secret: "{{ this_backup['resources'][0]['status']['containerTokenSecret'] }}"
+  when:
+    - this_backup['resources'][0]['status']['containerTokenSecret'] is defined
 
 # Check to make sure provided pvc exists, error loudly if not.  Otherwise, the management pod will just stay in pending state forever.
 - name: Check provided PVC exists

--- a/roles/restore/tasks/secrets.yml
+++ b/roles/restore/tasks/secrets.yml
@@ -78,3 +78,46 @@
         - storage_type | lower == 'azure'
   when:
     - objstorage_file in stat_backup_objectstorage.stdout
+
+- name: Set name of container token file name
+  set_fact:
+    container_token_file: 'container_token_secret.yaml'
+
+- name: Check to if container token secret exists in  backup directory on PVC
+  k8s_exec:
+    namespace: "{{ meta.namespace }}"
+    pod: "{{ meta.name }}-backup-manager"
+    command: >-
+      bash -c "stat {{ backup_dir }}/{{ container_token_file }}"
+  register: stat_backup_container_token
+
+- name: Create container token secret
+  block:
+    - name: Get secret definition from pvc
+      k8s_exec:
+        namespace: "{{ meta.namespace }}"
+        pod: "{{ meta.name }}-backup-manager"
+        command: >-
+          bash -c "cat '{{ backup_dir }}/{{ container_token_file }}'"
+      register: cont_token_secret
+
+    - name: Create temp vars file
+      tempfile:
+        prefix: secret_vars-
+      register: secret_vars_cont
+
+    - name: Write vars to file locally
+      copy:
+        dest: "{{ secret_vars_obj.path }}"
+        content: "{{ cont_token_secret.stdout }}"
+        mode: 0640
+
+    - name: Include secret vars from backup
+      include_vars: "{{ secret_vars_cont.path }}"
+
+    - name: Apply container token secret
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'templates/container_token_secret.yaml.j2') }}"
+  when:
+    - container_token_file in stat_backup_container_token.stdout

--- a/roles/restore/templates/container_token_secret.yaml.j2
+++ b/roles/restore/templates/container_token_secret.yaml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ container_token_secret }}'
+  namespace: '{{ meta.namespace }}'
+stringData:
+  container_auth_private_key.pem: '{{ container_auth_private_key }}'
+  container_auth_public_key.pem: '{{ container_auth_public_key }}'

--- a/up.sh
+++ b/up.sh
@@ -46,6 +46,10 @@ elif [[ "$CI_TEST" == "galaxy" ]]; then
   CUSTOM_RESOURCE=pulpproject_v1beta1_pulp_cr.galaxy.ci.yaml
   echo "Will deploy admin password secret for testing ..."
   $KUBECTL apply -f $KUBE_ASSETS_DIR/pulp-admin-password.secret.yaml
+elif [[ "$CI_TEST" == "galaxy-container" ]]; then
+  CUSTOM_RESOURCE=pulpproject_v1beta1_pulp_cr.galaxy.container.ci.yaml
+  echo "Will deploy admin password secret for testing ..."
+  $KUBECTL apply -f $KUBE_ASSETS_DIR/pulp-admin-password.secret.yaml
 elif [[ "$(hostname)" == "pulp-demo"* ]]; then
   CUSTOM_RESOURCE=pulpproject_v1beta1_pulp_cr.pulp-demo.yaml
 else


### PR DESCRIPTION
* Update CRD with container token secret
* Update CRD with settings
* Add playbook defaults
* Setup token server value
* Mount container auth keys when secret is provided
* Provide galaxy container CR for testing
* Add secret to status of Pulp and PulpBackup
* Write secret during backup
* Read/Create secret during restore

fixes #8598
https://pulp.plan.io/issues/8598