### PR TITLE
Provide image pull policy or node affinity for deployment

### DIFF
--- a/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
@@ -48,6 +48,7 @@ spec:
                 type: string
                 default: stable
               pulp_settings:
+                x-kubernetes-preserve-unknown-fields: true
                 description: The pulp settings.
                 properties:
                   debug:
@@ -173,6 +174,22 @@ spec:
               container_token_secret:
                 description: Secret where the container token certificates are stored
                 type: string
+              image_pull_policy:
+                description: Image pull policy for container image
+                type: string
+                default: IfNotPresent
+                enum:
+                  - IfNotPresent
+                  - Always
+                  - Never
+              affinity:
+                description: Defines various deployment affinities
+                properties:
+                  node_affinity:
+                    x-kubernetes-preserve-unknown-fields: true
+                    description: Defines the node affinity for the deployment
+                    type: object
+                type: object
               redis_resource_requirements:
                 description: Resource requirements for the Redis container
                 properties:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -155,6 +155,23 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:storage_type:Azure
+      - displayName: Image pull policy
+        description: Image pull policy for container image
+        path: image_pull_policy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Deployment Affinity
+        description: The deployment affinity
+        path: affinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Node Affinity
+        description: Node affinity is a group of node affinity scheduling
+        path: affinity.node_affinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Pulp settings
         path: pulp_settings
         x-descriptors:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
@@ -48,6 +48,7 @@ spec:
                 type: string
                 default: stable
               pulp_settings:
+                x-kubernetes-preserve-unknown-fields: true
                 description: The pulp settings.
                 properties:
                   debug:
@@ -173,6 +174,22 @@ spec:
               container_token_secret:
                 description: Secret where the container token certificates are stored
                 type: string
+              image_pull_policy:
+                description: Image pull policy for container image
+                type: string
+                default: IfNotPresent
+                enum:
+                  - IfNotPresent
+                  - Always
+                  - Never
+              affinity:
+                description: Defines various deployment affinities
+                properties:
+                  node_affinity:
+                    x-kubernetes-preserve-unknown-fields: true
+                    description: Defines the node affinity for the deployment
+                    type: object
+                type: object
               redis_resource_requirements:
                 description: Resource requirements for the Redis container
                 properties:

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -35,6 +35,10 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
+{% if affinity is defined and affinity.node_affinity is defined %}
+      affinity:
+        nodeAffinity: {{ affinity.node_affinity }}
+{% endif %}
       containers:
         - image: '{{ postgres_image }}'
           name: postgres

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -28,6 +28,10 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
+{% if affinity is defined and affinity.node_affinity is defined %}
+      affinity:
+        nodeAffinity: {{ affinity.node_affinity }}
+{% endif %}
 {% if is_k8s %}
       securityContext:
         runAsUser: 0
@@ -69,7 +73,7 @@ spec:
       containers:
         - name: api
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
-          imagePullPolicy: "IfNotPresent"
+          imagePullPolicy: "{{ image_pull_policy }}"
           # We set args, not command, so as to not override the entrypoint script
           args: ["pulp-api"]
           env:

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -28,6 +28,10 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
+{% if affinity is defined and affinity.node_affinity is defined %}
+      affinity:
+        nodeAffinity: {{ affinity.node_affinity }}
+{% endif %}
 {% if is_k8s %}
       securityContext:
         runAsUser: 0
@@ -48,7 +52,7 @@ spec:
       containers:
         - name: content
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
-          imagePullPolicy: "IfNotPresent"
+          imagePullPolicy: "{{ image_pull_policy }}"
           # We set args, not command, so as to not override the entrypoint script
           args: ["pulp-content"]
 {% if content.resource_requirements is defined %}

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -28,6 +28,10 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
+{% if affinity is defined and affinity.node_affinity is defined %}
+      affinity:
+        nodeAffinity: {{ affinity.node_affinity }}
+{% endif %}
 {% if is_k8s %}
       securityContext:
         runAsUser: 0
@@ -51,7 +55,7 @@ spec:
       containers:
         - name: resource-manager
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
-          imagePullPolicy: "IfNotPresent"
+          imagePullPolicy: "{{ image_pull_policy }}"
           # We set args, not command, so as to not override the entrypoint script
           args: ["pulp-resource-manager"]
           env:

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -28,10 +28,14 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
+{% if affinity is defined and affinity.node_affinity is defined %}
+      affinity:
+        nodeAffinity: {{ affinity.node_affinity }}
+{% endif %}
       containers:
         - name: web
           image: "{{ registry }}/{{ project }}/{{ image_web }}:{{ tag }}"
-          imagePullPolicy: "IfNotPresent"
+          imagePullPolicy: "{{ image_pull_policy }}"
           volumeMounts:
             - name: {{ meta.name }}-nginx-conf
               mountPath: /etc/nginx/nginx.conf

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -28,6 +28,10 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
+{% if affinity is defined and affinity.node_affinity is defined %}
+      affinity:
+        nodeAffinity: {{ affinity.node_affinity }}
+{% endif %}
 {% if is_k8s %}
       securityContext:
         runAsUser: 0
@@ -53,7 +57,7 @@ spec:
       containers:
         - name: worker
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"
-          imagePullPolicy: "IfNotPresent"
+          imagePullPolicy: "{{ image_pull_policy }}"
           # We set args, not command, so as to not override the entrypoint script
           args: ["pulp-worker"]
           env:

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -28,6 +28,10 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
+{% if affinity is defined and affinity.node_affinity is defined %}
+      affinity:
+        nodeAffinity: {{ affinity.node_affinity }}
+{% endif %}
       containers:
         - name: redis
           image: "{{ redis_image }}"


### PR DESCRIPTION
* Update CRD to allow for pull policy and node affinity
* Update deployments for pull policy and node affinity

[noissue]


This work allows an user to select `Always` as a pull policy to obtain the latest container image on pod deployment (meant to enable testing more easily).

The [node affinity capability ](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)allows a user to specify a node of the deployments to run on. This could allow users to target nodes with specific disk storage capabilities or specify node labels like infra nodes for subscription related reasons down stream.