### PR TITLE
Fix galaxy image

### DIFF
--- a/.ci/ansible/galaxy/vars.yaml
+++ b/.ci/ansible/galaxy/vars.yaml
@@ -5,8 +5,6 @@ images:
       container_file: Containerfile.core
       pulpcore: git+https://github.com/pulp/pulpcore.git@3.11#egg=pulpcore
       plugins:
-        - "git+https://github.com/pulp/pulp_ansible.git"
-        - "git+https://github.com/pulp/pulp_container.git"
         - "git+https://github.com/ansible/galaxy_ng.git"
   - galaxy_web_master:
       image_name: galaxy-web

--- a/.ci/ansible/vars.yaml
+++ b/.ci/ansible/vars.yaml
@@ -25,8 +25,6 @@ images:
       container_file: Containerfile.core
       pulpcore: git+https://github.com/pulp/pulpcore.git@3.11#egg=pulpcore
       plugins:
-        - "git+https://github.com/pulp/pulp_ansible.git"
-        - "git+https://github.com/pulp/pulp_container.git"
         - "git+https://github.com/ansible/galaxy_ng.git"
 registry: quay.io
 project: pulp


### PR DESCRIPTION
Galaxy doesn't have an upper bound on pulp_container
https://github.com/ansible/galaxy_ng/blob/master/setup.py#L66
pulp_container@master requires pulpcore >= 3.12.1
https://github.com/pulp/pulp_container/blob/master/requirements.txt#L1