### PR TITLE
Only add container registry settings if container secret is provided.

### DIFF
--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -277,6 +277,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Container token configuration
+        path: container_token_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       statusDescriptors:
       - displayName: URL
         description: Route to access the instance deployed

--- a/playbook.yml
+++ b/playbook.yml
@@ -20,9 +20,6 @@
       redis_host: "{{ meta.name }}-redis"
       redis_port: 6379
       redis_password: ""
-      TOKEN_SIGNATURE_ALGORITHM: "ES256"
-      PUBLIC_KEY_PATH: "/etc/pulp/keys/container_auth_public_key.pem"
-      PRIVATE_KEY_PATH: "/etc/pulp/keys/container_auth_private_key.pem"
       GALAXY_FEATURE_FLAGS:
         execution_environments: ""
     deployment_state: present

--- a/roles/pulp-api/tasks/get_node_ip.yml
+++ b/roles/pulp-api/tasks/get_node_ip.yml
@@ -54,7 +54,12 @@
 
 - name: Set content_origin
   set_fact:
-    content_origin_dict: "{'content_origin': '{{ content_origin }}', 'token_server': '{{ token_server }}' }"
+    content_origin_dict: "{ 'content_origin': '{{ content_origin }}' }"
+
+- name: Set token_server and other container default settings
+  set_fact:
+    token_server_dict: "{ 'token_server': '{{ token_server }}', 'token_auth_disable': 'False', 'token_signature_algorithm': 'ES256','public_key_path': '/etc/pulp/keys/container_auth_public_key.pem', 'private_key_path': '/etc/pulp/keys/container_auth_private_key.pem', 'galaxy_feature_flags': { 'execution_environments': 'True' }  }"
+  when: container_token_secret is defined
 
 - name: DEBUG Show content_origin_dict
   debug:
@@ -63,6 +68,11 @@
 - name: merge content_origin with settings
   set_fact:
     default_settings: "{{ default_settings|combine(content_origin_dict) }}"
+
+- name: merge token_server with settings
+  set_fact:
+    default_settings: "{{ default_settings|combine(token_server_dict) }}"
+  when: container_token_secret is defined
 
 - name: DEBUG Show content_origin
   debug:


### PR DESCRIPTION
* Update CSV to hide field by default
* Remove container registry settings from defaults
* Add container registry settings when secret is provided

[noissue]