### PR TITLE
Add additional backup and restore flexibility to allow for restore from only a PVC

### DIFF
--- a/CHANGES/8630.feature
+++ b/CHANGES/8630.feature
@@ -1,0 +1,1 @@
+Add additional backup and restore flexibility to allow for restore from only a PVC

--- a/deploy/crds/pulpproject_v1beta1_pulpbackup_cr.default.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulpbackup_cr.default.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   deployment_name: ''
   backup_pvc: ''
-  backup_size: ''
+  backup_storage_requirements: ''
   backup_storage_class: ''
   postgres_label_selector: ''

--- a/deploy/crds/pulpproject_v1beta1_pulpbackup_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulpbackup_crd.yaml
@@ -32,8 +32,11 @@ spec:
                 backup_pvc:
                   description: Name of the PVC to be used for storing the backup
                   type: string
-                backup_size:
-                  description: Size of PVC
+                backup_pvc_namespace:
+                  description: Namespace PVC is in
+                  type: string
+                backup_storage_requirements:
+                  description: Storage requirements for the backup
                   type: string
                 backup_storage_class:
                   description: Storage class to use when creating PVC for backup
@@ -50,6 +53,9 @@ spec:
                   type: string
                 backupClaim:
                   description: The PVC name used for the backup
+                  type: string
+                backupNamespace:
+                  description: The namespace used for the backup claim
                   type: string
                 backupDirectory:
                   description: The directory data is backed up to on the PVC

--- a/deploy/crds/pulpproject_v1beta1_pulprestore_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulprestore_crd.yaml
@@ -26,14 +26,27 @@ spec:
             spec:
               type: object
               properties:
+                deployment_name:
+                  description: Name of the deployment to be restored to
+                  type: string
                 backup_name:
                   description: Name of the backup custom resource
+                  type: string
+                backup_pvc:
+                  description: Name of the PVC to be restored from, set as a status found on the backup object (backupClaim)
+                  type: string
+                backup_pvc_namespace:
+                  description: Namespace the PVC is in
+                  type: string
+                backup_dir:
+                  description: Backup directory name, set as a status found on the backup object (backupDirectory)
+                  type: string
+                storage_type:
+                  description: Configuration for the storage type utilized in the backup
                   type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for executing migration
                   type: string
-              oneOf:
-                - required: ["backup_name"]
             status:
               properties:
                 restoreComplete:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -353,8 +353,13 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - displayName: Backup PVC size
-        path: backup_size
+      - displayName: Backup persistent volume claim namespace
+        path: backup_pvc_namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Backup PVC storage requirements
+        path: backup_storage_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
@@ -382,6 +387,11 @@ spec:
       - displayName: Backup claim
         description: The persistent volume claim name used during backup
         path: backupClaim
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Backup claim namespace
+        description: The persistent volume claim namespace used during backup
+        path: backupNamespace
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Backup directory
@@ -424,6 +434,30 @@ spec:
         path: backup_name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Deployment name
+        path: deployment_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Backup persistent volume claim
+        path: backup_pvc
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Backup persistent volume claim namespace
+        path: backup_pvc_namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Backup directory in the persistent volume claim
+        path: backup_dir
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Configuration for the storage type utilized in the backup
+        path: storage_type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Database restore label selector
         path: postgres_label_selector
         x-descriptors:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulpbackups_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulpbackups_crd.yml
@@ -34,8 +34,11 @@ spec:
                 backup_pvc:
                   description: Name of the PVC to be used for storing the backup
                   type: string
-                backup_size:
-                  description: Size of PVC
+                backup_pvc_namespace:
+                  description: Namespace PVC is in
+                  type: string
+                backup_storage_requirements:
+                  description: Storage requirements for the backup
                   type: string
                 backup_storage_class:
                   description: Storage class to use when creating PVC for backup
@@ -52,6 +55,9 @@ spec:
                   type: string
                 backupClaim:
                   description: The PVC name used for the backup
+                  type: string
+                backupNamespace:
+                  description: The namespace used for the backup claim
                   type: string
                 backupDirectory:
                   description: The directory data is backed up to on the PVC

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulprestores_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulprestores_crd.yml
@@ -29,14 +29,29 @@ spec:
                 custom_resource_key:
                   description: custom_resource_key
                   type: string
+                deployment_name:
+                  description: Name of the deployment to be restored to
+                  type: string
                 backup_name:
                   description: Name of the backup custom resource
+                  type: string
+                backup_pvc:
+                  description: Name of the PVC to be restored from, set as a status found on the backup object (backupClaim)
+                  type: string
+                backup_pvc_namespace:
+                  description: Namespace the PVC is in
+                  type: string
+                backup_dir:
+                  description: Backup directory name, set as a status found on the backup object (backupDirectory)
+                  type: string
+                storage_type:
+                  description: Configuration for the storage type utilized in the backup
                   type: string
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for executing migration
                   type: string
               oneOf:
-                - required: ["backup_name"]
+                - required: ["backup_name", "backup_pvc"]
             status:
               properties:
                 restoreComplete:

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -15,7 +15,7 @@ Role Variables
 
 * `deployment_name`: The name of the pulp custom resource to backup
 * `backup_pvc`: The name of the PVC to uses for backup
-* `backup_size`: The size of storage for the PVC created by operator if one is not supplied
+* `backup_storage_requirements`: The size of storage for the PVC created by operator if one is not supplied
 * `backup_storage_class`: The storage class to be used for the backup PVC
 * `postgres_configuration_secret`: The postgres_configuration_secret
 

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -4,9 +4,10 @@ deployment_name: ''
 
 # Specify a pre-created PVC (name) to backup to
 backup_pvc: ''
+backup_pvc_namespace: "{{ meta.namespace }}"
 
 # Size of backup PVC if created dynamically
-backup_size: ''
+backup_storage_requirements: ''
 
 # Specify storage class to determine how to dynamically create PVC's with
 backup_storage_class: ''

--- a/roles/backup/tasks/cleanup.yml
+++ b/roles/backup/tasks/cleanup.yml
@@ -10,6 +10,6 @@
   k8s:
     name: "{{ meta.name }}-backup-manager"
     kind: Pod
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     state: absent
     force: true

--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -4,7 +4,7 @@
   k8s:
     name: "{{ meta.name }}-backup-manager"
     kind: Pod
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     state: absent
     force: true
     wait: true
@@ -14,7 +14,7 @@
   k8s_info:
     name: "{{ backup_pvc }}"
     kind: PersistentVolumeClaim
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
   register: provided_pvc
   when:
     - backup_pvc != ''
@@ -38,14 +38,12 @@
 # If backup_pvc is defined, use in management-pod.yml.j2
 - name: Set default pvc name
   set_fact:
-    _default_backup_pvc: "{{ meta.name }}-backup-claim"
+    _default_backup_pvc: "{{ deployment_name }}-backup-claim"
 
 # by default, it will re-use the old pvc if already created (unless pvc is provided)
 - name: Set PVC to use for backup
   set_fact:
     backup_claim: "{{ backup_pvc | default(_default_backup_pvc, true) }}"
-  when:
-    - backup_pvc == '' or backup_pvc is not defined
 
 - name: Create persistent volume claim for backup
   k8s:

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -57,21 +57,21 @@
 
 - name: Create directory for backup
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       mkdir -p {{ _backup_dir }}
 
 - name: Precreate file for database dump
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace}}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       touch {{ _backup_dir }}/pulp.db
 
 - name: Set permissions on file for database dump
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       chmod 0600 {{ _backup_dir }}/pulp.db
@@ -87,7 +87,7 @@
 
 - name: Write pg_dump to backup on PVC
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "PGPASSWORD={{ postgres_pass }} {{ pgdump }} > {{ _backup_dir }}/pulp.db"

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -2,7 +2,7 @@
 
 - name: Write pulp object to pvc
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "echo '{{ cr_spec }}' > {{ _backup_dir }}/cr_object"
@@ -58,7 +58,7 @@
 
 - name: Write default secret to pvc
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "echo '{{ default_secret_template }}' > {{ _backup_dir }}/secrets.yaml"
@@ -98,7 +98,7 @@
 
 - name: Write container token secret to pvc
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "echo '{{ container_token_secret_template }}' > {{ _backup_dir }}/container_token_secret.yaml"
@@ -159,7 +159,7 @@
 
 - name: Write s3 secret to pvc
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "echo '{{ s3_secret_template }}' > {{ _backup_dir }}/objectstorage_secret.yaml"
@@ -204,7 +204,7 @@
 
 - name: Write azure secret to pvc
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "echo '{{ azure_secret_template }}' > {{ _backup_dir }}/objectstorage_secret.yaml"

--- a/roles/backup/tasks/storage.yml
+++ b/roles/backup/tasks/storage.yml
@@ -2,7 +2,7 @@
 
 - name: Create directory for backup content files
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       mkdir -p {{ _backup_dir }}/pulp/
@@ -14,7 +14,7 @@
 
 - name: Write content files to backup on PVC
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "{{ copy_cmd }}"

--- a/roles/backup/tasks/update_status.yml
+++ b/roles/backup/tasks/update_status.yml
@@ -15,7 +15,6 @@
       deploymentName: "{{ deployment_name }}"
   when: backup_complete is defined
 
-
 # The backup directory in this status can be referenced when restoring
 - name: Update deployment name status
   operator_sdk.util.k8s_status:
@@ -36,6 +35,17 @@
     namespace: "{{ meta.namespace }}"
     status:
       backupClaim: "{{ backup_claim }}"
+  when: backup_complete is defined
+
+# The backup PVC namespace in this status can be referenced when restoring
+- name: Update backup PVC namespace status
+  operator_sdk.util.k8s_status:
+    api_version: '{{ api_version }}'
+    kind: "{{ kind }}"
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.namespace }}"
+    status:
+      backupNamespace: "{{ backup_pvc_namespace }}"
   when: backup_complete is defined
 
 # The backup  storage type in this status can be referenced when restoring

--- a/roles/backup/templates/azure_secret.yaml.j2
+++ b/roles/backup/templates/azure_secret.yaml.j2
@@ -1,5 +1,6 @@
 # Azure Secret.
 ---
+storage_secret: '{{ storage_secret }}'
 azure_account_name: '{{ azure_account_name }}'
 azure_account_key: '{{ azure_account_key }}'
 azure_container: '{{ azure_container }}'

--- a/roles/backup/templates/backup.pvc.yaml.j2
+++ b/roles/backup/templates/backup.pvc.yaml.j2
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ meta.name }}-backup-claim
-  namespace: {{ meta.namespace }}
+  name: {{ deployment_name }}-backup-claim
+  namespace: {{ backup_pvc_namespace }}
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-backup-storage'
     app.kubernetes.io/instance: '{{ deployment_type }}-backup-storage-{{ meta.name }}'
@@ -18,4 +18,4 @@ spec:
 {% endif %}
   resources:
     requests:
-      storage: {{ backup_size | default('5Gi', true) }}
+      storage: {{ backup_storage_requirements | default('5Gi', true) }}

--- a/roles/backup/templates/container_token_secret.yaml.j2
+++ b/roles/backup/templates/container_token_secret.yaml.j2
@@ -1,4 +1,5 @@
 # Container Token Secret.
 ---
+container_token_secret: '{{ container_token_secret }}'
 container_auth_private_key: '{{ container_auth_private_key }}'
 container_auth_public_key: '{{ container_auth_public_key }}'

--- a/roles/backup/templates/management-pod.yaml.j2
+++ b/roles/backup/templates/management-pod.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ meta.name }}-backup-manager
-  namespace: {{ meta.namespace }}
+  namespace: {{ backup_pvc_namespace }}
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-backup-manager'
     app.kubernetes.io/instance: '{{ deployment_type }}-backup-manager-{{ meta.name }}'

--- a/roles/backup/templates/s3_secret.yaml.j2
+++ b/roles/backup/templates/s3_secret.yaml.j2
@@ -1,5 +1,6 @@
 # S3 Secret.
 ---
+storage_secret: '{{ storage_secret }}'
 s3_access_key_id: '{{ s3_access_key_id }}'
 s3_secret_access_key: '{{ s3_secret_access_key }}'
 s3_bucket_name: '{{ s3_bucket_name }}'

--- a/roles/backup/templates/secrets.yaml.j2
+++ b/roles/backup/templates/secrets.yaml.j2
@@ -1,8 +1,12 @@
 ---
+admin_password_name: {{ admin_password_secret }}
 admin_password: {{ admin_password }}
+{% if database_type == 'unmanaged' %}
+db_secret_name: {{ postgres_configuration_secret }}
 database_password: {{ database_password }}
 database_username: {{ database_username }}
 database_name: {{ database_name }}
 database_port: {{ database_port }}
 database_host: {{ database_host }}
 database_type: {{ database_type }}
+{% endif %}

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -10,7 +10,8 @@ postgres_storage_class: ''
 postgres_data_path: '/var/lib/postgresql/data/pgdata'
 
 # Secret to lookup that provide the PostgreSQL configuration
-postgres_configuration_secret: ''
+postgres_configuration_secret: '{{ meta.name }}-postgres-configuration'
+
 
 # Secret to lookup that provide the PostgreSQL configuration for old database
 postgres_migrant_configuration_secret: ''

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -43,38 +43,38 @@ spec:
         - image: '{{ postgres_image }}'
           name: postgres
           env:
-            # For tower_postgres_image based on rhel8/postgresql-12
+            # For postgres_image based on rhel8/postgresql-12
             - name: POSTGRESQL_DATABASE
               valueFrom:
                 secretKeyRef:
-                  name: '{{ meta.name }}-postgres-configuration'
+                  name: '{{ postgres_configuration_secret }}'
                   key: database
             - name: POSTGRESQL_USER
               valueFrom:
                 secretKeyRef:
-                  name: '{{ meta.name }}-postgres-configuration'
+                  name: '{{ postgres_configuration_secret }}'
                   key: username
             - name: POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: '{{ meta.name }}-postgres-configuration'
+                  name: '{{ postgres_configuration_secret }}'
                   key: password
 
-            # For tower_postgres_image based on postgres
+            # For postgres_image based on postgres
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
-                  name: '{{ meta.name }}-postgres-configuration'
+                  name: '{{ postgres_configuration_secret }}'
                   key: database
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: '{{ meta.name }}-postgres-configuration'
+                  name: '{{ postgres_configuration_secret }}'
                   key: username
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: '{{ meta.name }}-postgres-configuration'
+                  name: '{{ postgres_configuration_secret }}'
                   key: password
             - name: PGDATA
               value: '{{ postgres_data_path }}'
@@ -83,7 +83,7 @@ spec:
             - name: POSTGRES_HOST_AUTH_METHOD
               value: '{{ postgres_host_auth_method }}'
           ports:
-            - containerPort: 5432
+            - containerPort: {{ postgres_port | default('5432')}}
               name: postgres
           volumeMounts:
             - name: postgres

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -46,7 +46,7 @@ spec:
                 key: settings.py
         - name: {{ meta.name }}-admin-password
           secret:
-            secretName: {{ meta.name }}-admin-password
+            secretName: {{ admin_password_name }}
             items:
               - path: admin-password
                 key: password

--- a/roles/pulp-web/tasks/main.yml
+++ b/roles/pulp-web/tasks/main.yml
@@ -17,6 +17,7 @@
   k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
+    wait: true
   with_items:
     - pulp-web
 

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -1,3 +1,18 @@
 ---
 # Required: specify name of pulp backup
 backup_name: ''
+
+# Required: specify name of pulp deployment to restore to
+deployment_name: ''
+
+# Required: specify a pre-created PVC (name) to restore from
+backup_pvc: ''
+backup_pvc_namespace: "{{ meta.namespace }}"
+
+# Required: backup name, found on the backup object
+backup_dir: ''
+
+admin_password_name: ''
+db_secret_name: ''
+storage_secret: ''
+container_token_secret: ''

--- a/roles/restore/tasks/cleanup.yml
+++ b/roles/restore/tasks/cleanup.yml
@@ -4,6 +4,58 @@
   k8s:
     name: "{{ meta.name }}-backup-manager"
     kind: Pod
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     state: absent
     force: true
+
+- name: Remove ownerReferences from admin password secret to avoid garbage collection
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: '{{ admin_password_name }}'
+        namespace: '{{ meta.namespace }}'
+        ownerReferences: null
+  when:
+    - admin_password_name is defined
+    - admin_password_name | length
+
+- name: Remove ownerReferences from db secret to avoid garbage collection
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: '{{ db_secret_name }}'
+        namespace: '{{ meta.namespace }}'
+        ownerReferences: null
+  when:
+    - db_secret_name is defined
+    - db_secret_name | length
+
+- name: Remove ownerReferences from storage secret to avoid garbage collection
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: '{{ storage_secret }}'
+        namespace: '{{ meta.namespace }}'
+        ownerReferences: null
+  when:
+    - storage_secret is defined
+    - storage_secret | length
+
+- name: Remove ownerReferences from container token secret to avoid garbage collection
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: '{{ container_token_secret }}'
+        namespace: '{{ meta.namespace }}'
+        ownerReferences: null
+  when:
+    - container_token_secret is defined
+    - container_token_secret | length

--- a/roles/restore/tasks/deploy_pulp.yml
+++ b/roles/restore/tasks/deploy_pulp.yml
@@ -6,7 +6,7 @@
 
 - name: Get object definition from pvc
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "cat '{{ backup_dir }}/cr_object'"
@@ -15,6 +15,20 @@
 - name: Set custom resource spec variable from backup
   set_fact:
     cr_spec: "{{ cr_object.stdout }}"
+    cr_spec_strip: "{ "
+    admin_str: "admin_password_secret: {{ admin_password_name }}"
+
+- name: Strip end characters from spec
+  set_fact:
+    cr_spec_strip: "{{ cr_object.stdout[:-2] + ', '}}"
+  when:
+    - cr_object.stdout | length > 1
+    - not 'admin_password_secret' in cr_object.stdout
+
+- name: Set custom resource spec variable from backup
+  set_fact:
+    cr_spec: "{{ cr_spec_strip + admin_str + '}\n' }}"
+  when: not 'admin_password_secret' in cr_object.stdout
 
 - name: Deploy object
   k8s:
@@ -24,3 +38,13 @@
     wait_condition:
       type: "Running"
       status: "True"
+
+- name: Remove ownerReferences to prevent garbage collection of new CR
+  k8s:
+    definition:
+      apiVersion: '{{ api_version }}'
+      kind: Pulp
+      metadata:
+        name: '{{ deployment_name }}'
+        namespace: '{{ meta.namespace }}'
+        ownerReferences: null

--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -7,6 +7,9 @@
     name: "{{ backup_name }}"
     namespace: "{{ meta.namespace }}"
   register: this_backup
+  when:
+    - backup_name is defined
+    - backup_name | length
 
 - name: Surface error to user
   block:
@@ -21,12 +24,15 @@
       fail:
         msg: "{{ error_msg }}"
   when:
+    - backup_name is defined
+    - backup_name | length
     - this_backup['resources'] | length == 0
     - this_backup['resources'][0] is not defined
     - this_backup['resources'][0]['status'] is not defined
     - this_backup['resources'][0]['status']['deploymentName'] is not defined
     - this_backup['resources'][0]['status']['backupClaim'] is not defined
     - this_backup['resources'][0]['status']['backupDirectory'] is not defined
+    - this_backup['resources'][0]['status']['backupNamespace'] is not defined
     - this_backup['resources'][0]['status']['deploymentStorageType'] is not defined
     - this_backup['resources'][0]['status']['adminPasswordSecret'] is not defined
     - this_backup['resources'][0]['status']['databaseConfigurationSecret'] is not defined
@@ -35,29 +41,56 @@
   set_fact:
     deployment_name: "{{ this_backup['resources'][0]['status']['deploymentName'] }}"
     backup_pvc: "{{ this_backup['resources'][0]['status']['backupClaim'] }}"
+    backup_pvc_namespace: "{{ this_backup['resources'][0]['status']['backupNamespace'] }}"
     backup_dir: "{{ this_backup['resources'][0]['status']['backupDirectory'] }}"
     storage_type: "{{ this_backup['resources'][0]['status']['deploymentStorageType'] }}"
-    admin_passowrd_name: "{{ this_backup['resources'][0]['status']['adminPasswordSecret'] }}"
+    admin_password_name: "{{ this_backup['resources'][0]['status']['adminPasswordSecret'] }}"
     db_secret_name: "{{ this_backup['resources'][0]['status']['databaseConfigurationSecret'] }}"
+  when:
+    - backup_name is defined
+    - backup_name | length
 
 - name: Set optional objectstorage backup fact
   set_fact:
     storage_secret: "{{ this_backup['resources'][0]['status']['objectStorageConfigurationSecret'] }}"
   when:
+    - backup_name is defined
+    - backup_name | length
     - this_backup['resources'][0]['status']['objectStorageConfigurationSecret'] is defined
 
 - name: Set optional container token backup fact
   set_fact:
     container_token_secret: "{{ this_backup['resources'][0]['status']['containerTokenSecret'] }}"
   when:
+    - backup_name is defined
+    - backup_name | length
     - this_backup['resources'][0]['status']['containerTokenSecret'] is defined
+
+- name: Surface error to user
+  block:
+    - name: Set error message
+      set_fact:
+        error_msg: "Cannot perform restore with the given specifications."
+
+    - name: Handle error
+      import_tasks: error_handling.yml
+
+    - name: Fail early if pvc is defined but does not exist
+      fail:
+        msg: "{{ error_msg }}"
+  when:
+    - deployment_name is not defined
+    - backup_pvc is not defined
+    - backup_pvc_namespace is not defined
+    - backup_dir is not defined
+    - storage_type is not defined
 
 # Check to make sure provided pvc exists, error loudly if not.  Otherwise, the management pod will just stay in pending state forever.
 - name: Check provided PVC exists
   k8s_info:
     name: "{{ backup_pvc }}"
     kind: PersistentVolumeClaim
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
   register: provided_pvc
   when:
     - backup_pvc != ''
@@ -82,7 +115,7 @@
   k8s:
     name: "{{ meta.name }}-backup-manager"
     kind: Pod
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     state: absent
     force: true
     wait: true
@@ -95,7 +128,7 @@
 
 - name: Check to make sure backup directory exists on PVC
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace}}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "stat {{ backup_dir }}"

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -6,7 +6,9 @@
     namespace: '{{ meta.namespace }}'
     name: '{{ db_secret_name }}'
   register: _custom_pg_config_resources
-  when: db_secret_name | length
+  when:
+    - db_secret_name is defined
+    - db_secret_name | length
 
 - name: Check for default PostgreSQL configuration
   k8s_info:
@@ -68,7 +70,7 @@
 
 - name: Restore database dump to the new postgresql container
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: |
       bash -c """

--- a/roles/restore/tasks/secrets.yml
+++ b/roles/restore/tasks/secrets.yml
@@ -2,7 +2,7 @@
 
 - name: Get secret definition from pvc
   k8s_exec:
-    namespace: "{{ meta.namespace  }}"
+    namespace: "{{ backup_pvc_namespace  }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "cat '{{ backup_dir }}/secrets.yaml'"
@@ -22,10 +22,19 @@
 - name: Include secret vars from backup
   include_vars: "{{ secret_vars.path }}"
 
-- name: Apply secret
+- name: Apply admin password secret
   k8s:
     state: present
-    definition: "{{ lookup('template', 'secrets.yaml.j2') }}"
+    definition: "{{ lookup('template', 'admin-password.secret.yaml.j2') }}"
+
+- name: Apply database configuration secret
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'postgres.secret.yaml.j2') }}"
+  when:
+    - db_secret_name is defined
+    - db_secret_name | length
+    - database_password is defined
 
 - name: Set name of objectstorage file name
   set_fact:
@@ -33,7 +42,7 @@
 
 - name: Check to if objectstorage secret exists in  backup directory on PVC
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "stat {{ backup_dir }}/{{ objstorage_file }}"
@@ -43,7 +52,7 @@
   block:
     - name: Get secret definition from pvc
       k8s_exec:
-        namespace: "{{ meta.namespace }}"
+        namespace: "{{ backup_pvc_namespace }}"
         pod: "{{ meta.name }}-backup-manager"
         command: >-
           bash -c "cat '{{ backup_dir }}/{{ objstorage_file }}'"
@@ -69,6 +78,8 @@
         definition: "{{ lookup('template', 'templates/s3_secret.yaml.j2') }}"
       when:
         - storage_type | lower == 's3'
+        - storage_secret is defined
+        - storage_secret | length
 
     - name: Apply azure secret
       k8s:
@@ -76,6 +87,8 @@
         definition: "{{ lookup('template', 'templates/azure_secret.yaml.j2') }}"
       when:
         - storage_type | lower == 'azure'
+        - storage_secret is defined
+        - storage_secret | length
   when:
     - objstorage_file in stat_backup_objectstorage.stdout
 
@@ -85,7 +98,7 @@
 
 - name: Check to if container token secret exists in  backup directory on PVC
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "stat {{ backup_dir }}/{{ container_token_file }}"
@@ -95,7 +108,7 @@
   block:
     - name: Get secret definition from pvc
       k8s_exec:
-        namespace: "{{ meta.namespace }}"
+        namespace: "{{ backup_pvc_namespace }}"
         pod: "{{ meta.name }}-backup-manager"
         command: >-
           bash -c "cat '{{ backup_dir }}/{{ container_token_file }}'"
@@ -119,5 +132,8 @@
       k8s:
         state: present
         definition: "{{ lookup('template', 'templates/container_token_secret.yaml.j2') }}"
+      when:
+        - container_token_secret is defined
+        - container_token_secret | length
   when:
     - container_token_file in stat_backup_container_token.stdout

--- a/roles/restore/tasks/storage.yml
+++ b/roles/restore/tasks/storage.yml
@@ -8,7 +8,7 @@
   k8s:
     name: "{{ meta.name }}-backup-manager"
     kind: Pod
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     state: absent
     force: true
     wait: true
@@ -26,7 +26,7 @@
 
 - name: Write content files from backup on PVC
   k8s_exec:
-    namespace: "{{ meta.namespace }}"
+    namespace: "{{ backup_pvc_namespace }}"
     pod: "{{ meta.name }}-backup-manager"
     command: >-
       bash -c "{{ copy_cmd }}"

--- a/roles/restore/templates/admin-password.secret.yaml.j2
+++ b/roles/restore/templates/admin-password.secret.yaml.j2
@@ -1,0 +1,9 @@
+# Admin Password Secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ admin_password_name }}'
+  namespace: '{{ meta.namespace }}'
+stringData:
+  password: '{{ admin_password }}'

--- a/roles/restore/templates/management-pod.yaml.j2
+++ b/roles/restore/templates/management-pod.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ meta.name }}-backup-manager
-  namespace: {{ meta.namespace }}
+  namespace: {{ backup_pvc_namespace }}
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-backup-manager'
     app.kubernetes.io/instance: '{{ deployment_type }}-backup-manager-{{ meta.name }}'

--- a/roles/restore/templates/postgres.secret.yaml.j2
+++ b/roles/restore/templates/postgres.secret.yaml.j2
@@ -12,13 +12,3 @@ stringData:
   port: '{{ database_port }}'
   host: '{{ database_host }}'
   type: '{{ database_type }}'
-
-# Admin Password Secret
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: '{{ admin_passowrd_name }}'
-  namespace: '{{ meta.namespace }}'
-stringData:
-  password: '{{ admin_password }}'


### PR DESCRIPTION

* Mirror awx-operator updates for flexibility
* Note restore across namespaces will not be available when using RWM File storage

fixes #8630
https://pulp.plan.io/issues/8630