### PR TITLE
Restructure operator restore variable presentation

### DIFF
--- a/deploy/crds/pulpproject_v1beta1_pulpbackup_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulpbackup_crd.yaml
@@ -44,8 +44,8 @@ spec:
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for executing migration
                   type: string
-              oneOf:
-                - required: ["deployment_name"]
+              required:
+                - deployment_name
             status:
               properties:
                 deploymentName:

--- a/deploy/crds/pulpproject_v1beta1_pulprestore_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulprestore_crd.yaml
@@ -26,6 +26,12 @@ spec:
             spec:
               type: object
               properties:
+                backup_source:
+                  description: backup source
+                  type: string
+                  enum:
+                    - CR
+                    - PVC
                 deployment_name:
                   description: Name of the deployment to be restored to
                   type: string

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -430,43 +430,48 @@ spec:
       version: v1beta1
       displayName: Pulp Restore
       specDescriptors:
+      - displayName: Backup source to restore ?
+        path: backup_source
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:select:CR
+          - urn:alm:descriptor:com.tectonic.ui:select:PVC
       - displayName: Backup name
         path: backup_name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backup_source:CR
       - displayName: Deployment name
         path: deployment_name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backup_source:PVC
       - displayName: Backup persistent volume claim
         path: backup_pvc
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backup_source:PVC
       - displayName: Backup persistent volume claim namespace
         path: backup_pvc_namespace
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backup_source:PVC
       - displayName: Backup directory in the persistent volume claim
         path: backup_dir
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backup_source:PVC
       - displayName: Configuration for the storage type utilized in the backup
         path: storage_type
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backup_source:PVC
       - displayName: Database restore label selector
         path: postgres_label_selector
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Custom Resource Key
         path: custom_resource_key
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
       statusDescriptors:
       - displayName: Restore status

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulpbackups_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulpbackups_crd.yml
@@ -46,8 +46,8 @@ spec:
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for executing migration
                   type: string
-              oneOf:
-                - required: ["deployment_name"]
+              required:
+                - deployment_name
             status:
               properties:
                 deploymentName:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulprestores_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulprestores_crd.yml
@@ -26,6 +26,12 @@ spec:
             spec:
               type: object
               properties:
+                backup_source:
+                  description: backup source
+                  type: string
+                  enum:
+                    - CR
+                    - PVC
                 custom_resource_key:
                   description: custom_resource_key
                   type: string


### PR DESCRIPTION
Both backup and restore are currently using the oneOf spec in the CRD in
an invalid way, leading to invalid UI.

On the backup crd just using required is enough to accomplish original
goal.

On the restore crd its a bit tricky as more business logic is embeded.

[noissue]