### PR TITLE
file_storage.size: Specify it only when defined

### DIFF
--- a/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
+++ b/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
@@ -11,9 +11,11 @@ metadata:
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
 spec:
+{% if file_storage.size is defined %}
   resources:
     requests:
       storage: "{{ file_storage.size }}"
+{% endif %}
   accessModes:
     - "{{ file_storage.access_mode }}"
 {% if file_storage.storage_class is defined %}


### PR DESCRIPTION
By default this variable is not defined leading to deployment to fail if
not provided. This should be applied only if defined.

Issue raised

```
TASK [pulp-file-storage persistent volume claim] ******************************** 
[0;31mfatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'size'\n\nThe error appears to be in '/opt/ansible/roles/pulp-api/tasks/main.yml': line 20, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: pulp-file-storage persistent volume claim\n  ^ here\n"}[0m
```

[noissue]