### PR TITLE
Allow user to specify empty string storage class for postgres PVC.

### DIFF
--- a/CHANGES/8733.bugfix
+++ b/CHANGES/8733.bugfix
@@ -1,0 +1,1 @@
+Allow user to specify empty string for PostgreSQL PVC storage class

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -6,7 +6,7 @@ postgres_image: postgres:12
 postgres_resource_requirements:
   requests:
     storage: 8Gi
-postgres_storage_class: ''
+
 postgres_data_path: '/var/lib/postgresql/data/pgdata'
 
 # Secret to lookup that provide the PostgreSQL configuration

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -95,7 +95,7 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
-{% if postgres_storage_class != '' %}
+{% if postgres_storage_class is defined %}
         storageClassName: '{{ postgres_storage_class }}'
 {% endif %}
         resources: {{ postgres_resource_requirements }}


### PR DESCRIPTION
* Update defaults
* Update jinja2 condition in template

fixes #8733
https://pulp.plan.io/issues/8733