### PR TITLE
fix: CSV cluster role for nodes

### DIFF
--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -617,6 +617,13 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
         serviceAccountName: pulp-operator
       deployments:
       - name: pulp-operator


### PR DESCRIPTION
Operator seems to complain if installed via OLM. Your CSV seems to be missing some permissions from [`cluster_role.yaml`](https://github.com/pulp/pulp-operator/blob/main/deploy/cluster_role.yaml)

Pod logs:
```
E0518 14:15:23.426471       8 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.2/tools/cache/reflector.go:125: Failed to list /v1, Kind=Node: nodes is forbidden: User "system:serviceaccount:openshift-operators:pulp-operator" cannot list resource "nodes" in API group "" at the cluster scope
E0518 14:16:22.921909       8 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.2/tools/cache/reflector.go:125: Failed to list /v1, Kind=Node: nodes is forbidden: User "system:serviceaccount:openshift-operators:pulp-operator" cannot list resource "nodes" in API group "" at the cluster scope
```