### PR TITLE
Improve user experience in OperatorHub when choosing File Storage.

### DIFF
--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.ci.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.ci.yaml
@@ -8,11 +8,10 @@ spec:
   admin_password_secret: "example-pulp-admin-password"
   storage_type: File
   ingress_type: nodeport
-  file_storage:
-    # k3s local-path requires this
-    access_mode: "ReadWriteOnce"
-    # We have a little over 10GB free on GHA VMs/instances
-    size: "10Gi"
+  # k3s local-path requires this
+  file_storage_access_mode: "ReadWriteOnce"
+  # We have a little over 10GB free on GHA VMs/instances
+  file_storage_size: "10Gi"
   content:
     replicas: 1
     resource_requirements:

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.default.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.default.yaml
@@ -21,26 +21,25 @@ metadata:
   # Configuration for the persistentVolumeClaim for /var/lib/pulp
 # storage_type: File
   # Select storage type: File, S3, Azure
-# file_storage:
-      # If your K8s cluster is only 1 node, and its StorageClass /
-    # provisioner does not support ReadWriteMany, then you must change
-    # this to "ReadWriteOnce".
-    #
-    # If your K8s cluster is multiple nodes, and does not support
-    # ReadWriteMany, then pulp-operator is currently incompatible.
-    #
-    # Reference on which support ReadWriteMany:
-    # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
-#   access_mode: "ReadWriteMany"
+  # If your K8s cluster is only 1 node, and its StorageClass /
+  # provisioner does not support ReadWriteMany, then you must change
+  # this to "ReadWriteOnce".
+  #
+  # If your K8s cluster is multiple nodes, and does not support
+  # ReadWriteMany, then pulp-operator is currently incompatible.
+  #
+  # Reference on which support ReadWriteMany:
+  # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
+# file_storage_access_mode: "ReadWriteMany"
 
-    # How much space do you want to give Pulp for storing content under
-    # /var/lib/pulp ?
-    # https://docs.pulpproject.org/en/3.0/nightly/installation/configuration.html#media-root
+  # How much space do you want to give Pulp for storing content under
+  # /var/lib/pulp ?
+  # https://docs.pulpproject.org/en/3.0/nightly/installation/configuration.html#media-root
 
-    # For reference, epel7 x86_64 is currently (2019-07) 30G. So 100G
-    # should be sufficient for a test deployment with only the RPM
-    # content plugin.
-#   size: "100Gi"
+  # For reference, epel7 x86_64 is currently (2019-07) 30G. So 100G
+  # should be sufficient for a test deployment with only the RPM
+  # content plugin.
+# file_storage_size: "100Gi"
 # object_storage_s3_secret: example-pulp-object-storage
   # Configuration for S3 credentals
 # object_storage_azure_secret: example-pulp-object-storage

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.galaxy.ci.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.galaxy.ci.yaml
@@ -9,11 +9,10 @@ spec:
   admin_password_secret: "example-pulp-admin-password"
   storage_type: File
   ingress_type: nodeport
-  file_storage:
-    # k3s local-path requires this
-    access_mode: "ReadWriteOnce"
-    # We have a little over 10GB free on GHA VMs/instances
-    size: "10Gi"
+  # k3s local-path requires this
+  file_storage_access_mode: "ReadWriteOnce"
+  # We have a little over 10GB free on GHA VMs/instances
+  file_storage_size: "10Gi"
   content:
     replicas: 1
     resource_requirements:

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.galaxy.container.ci.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.galaxy.container.ci.yaml
@@ -13,11 +13,10 @@ spec:
     GALAXY_FEATURE_FLAGS:
       execution_environments: "True"
   storage_type: File
-  file_storage:
-    # k3s local-path requires this
-    access_mode: "ReadWriteOnce"
-    # We have a little over 10GB free on GHA VMs/instances
-    size: "10Gi"
+  # k3s local-path requires this
+  file_storage_access_mode: "ReadWriteOnce"
+  # We have a little over 10GB free on GHA VMs/instances
+  file_storage_size: "10Gi"
   content:
     replicas: 1
     resource_requirements:

--- a/deploy/crds/pulpproject_v1beta1_pulp_cr.pulp-demo.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_cr.pulp-demo.yaml
@@ -4,10 +4,9 @@ metadata:
   name: example-pulp
 spec:
   storage_type: File
-  file_storage:
-    # This doesn't really matter for minikube. Single node by design,
-    # but the storage provisioner allows for ReadWriteMany. So let's
-    # stick to our default.
-    access_mode: "ReadWriteMany"
-    # The minikube VM won't go any larger.
-    size: "375Gi"
+  # This doesn't really matter for minikube. Single node by design,
+  # but the storage provisioner allows for ReadWriteMany. So let's
+  # stick to our default.
+  file_storage_access_mode: "ReadWriteMany"
+  # The minikube VM won't go any larger.
+  file_storage_size: "375Gi"

--- a/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
@@ -124,24 +124,20 @@ spec:
                   - S3
                   - azure
                   - Azure
-              file_storage:
-                description: Configuration for the persistentVolumeClaim for /var/lib/pulp.
-                properties:
-                  access_mode:
-                    description: The file storage access mode.
-                    type: string
-                    default: ReadWriteMany
-                    enum:
-                      - ReadWriteMany
-                      - ReadWriteOnce
-                  size:
-                    description: The size of the file storage; for example 100Gi.
-                    default: 100Gi
-                    type: string
-                  storage_class:
-                    description: Storage class to use for the file persistentVolumeClaim
-                    type: string
-                type: object
+              file_storage_access_mode:
+                description: The file storage access mode.
+                type: string
+                default: ReadWriteMany
+                enum:
+                  - ReadWriteMany
+                  - ReadWriteOnce
+              file_storage_size:
+                description: The size of the file storage; for example 100Gi.
+                default: 100Gi
+                type: string
+              file_storage_storage_class:
+                description: Storage class to use for the file persistentVolumeClaim
+                type: string
               object_storage_s3_secret:
                 description: The secret for S3 compliant object storage configuration.
                 type: string

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -15,9 +15,8 @@ metadata:
           "spec": {
             "tag": "latest",
             "storage_type": "File",
-            "file_storage": {
-              "size": "50Gi"
-            }
+            "file_storage_size": "50Gi",
+            "file_storage_access_mode": "ReadWriteMany",
           }
         },
         {
@@ -174,21 +173,17 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:select:File
         - urn:alm:descriptor:com.tectonic.ui:select:S3
         - urn:alm:descriptor:com.tectonic.ui:select:Azure
-      - displayName: File storage configuration
-        path: file_storage
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:storage_type:File
       - displayName: File storage access mode
-        path: file_storage.access_mode
+        path: file_storage_access_mode
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:storage_type:File
         - urn:alm:descriptor:com.tectonic.ui:select:ReadWriteMany
       - displayName: File storage size
-        path: file_storage.size
+        path: file_storage_size
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:storage_type:File
       - displayName: File storage class
-        path: file_storage.storage_class
+        path: file_storage_storage_class
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:storage_type:File
       - displayName: S3 storage secret

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
@@ -127,24 +127,20 @@ spec:
                   - S3
                   - azure
                   - Azure
-              file_storage:
-                description: Configuration for the persistentVolumeClaim for /var/lib/pulp.
-                properties:
-                  access_mode:
-                    description: The file storage access mode.
-                    type: string
-                    default: ReadWriteMany
-                    enum:
-                      - ReadWriteMany
-                      - ReadWriteOnce
-                  size:
-                    description: The size of the file storage; for example 100Gi.
-                    default: 100Gi
-                    type: string
-                  storage_class:
-                    description: Storage class to use for the file persistentVolumeClaim
-                    type: string
-                type: object
+              file_storage_access_mode:
+                description: The file storage access mode.
+                type: string
+                default: ReadWriteMany
+                enum:
+                  - ReadWriteMany
+                  - ReadWriteOnce
+              file_storage_size:
+                description: The size of the file storage; for example 100Gi.
+                default: 100Gi
+                type: string
+              file_storage_storage_class:
+                description: Storage class to use for the file persistentVolumeClaim
+                type: string
               object_storage_s3_secret:
                 description: The secret for S3 compliant object storage configuration.
                 type: string

--- a/playbook.yml
+++ b/playbook.yml
@@ -30,9 +30,8 @@
     image_pull_secret: ""
     tag: stable
     storage_type: File
-    file_storage:
-      access_mode: "ReadWriteMany"
-      size: "100Gi"
+    file_storage_access_mode: "ReadWriteMany"
+    file_storage_size: "100Gi"
   roles:
     - postgres
     - redis

--- a/roles/pulp-api/README.md
+++ b/roles/pulp-api/README.md
@@ -25,9 +25,8 @@ Role Variables
 * `image`: The image name.
 * `tag`: The tag name.
 * `storage_type`: A string for specifying storage configuration type.
-* `file_storage`: A dict for specifying a persistent volume claim for pulp-file.
-    * `access_mode`: The access mode for the volume.
-    * `size`: The storage size.
+* `file_storage_access_mode`: The access mode for the volume.
+* `file_storage_size`: The storage size.
 * `object_storage_s3_secret`:The kubernetes secret with s3 storage configuration information.
 * `object_storage_azure_secret`:The kubernetes secret with Azure blob storage configuration information.
 

--- a/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
+++ b/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
@@ -11,13 +11,13 @@ metadata:
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
 spec:
-{% if file_storage.size is defined %}
+{% if file_storage_size is defined %}
   resources:
     requests:
-      storage: "{{ file_storage.size }}"
+      storage: "{{ file_storage_size }}"
 {% endif %}
   accessModes:
-    - "{{ file_storage.access_mode }}"
-{% if file_storage.storage_class is defined %}
-  storageClassName: '{{ file_storage.storage_class }}'
+    - "{{ file_storage_access_mode }}"
+{% if file_storage_storage_class is defined %}
+  storageClassName: '{{ file_storage_storage_class }}'
 {% endif %}

--- a/roles/pulp-status/tasks/main.yml
+++ b/roles/pulp-status/tasks/main.yml
@@ -81,7 +81,7 @@
     namespace: "{{ meta.namespace }}"
     status:
       storagePersistentVolumeClaim: "{{ meta.name }}-file-storage"
-  when: file_storage
+  when: is_file_storage
 
 - name: Update object storage secret name status
   operator_sdk.util.k8s_status:
@@ -91,7 +91,7 @@
     namespace: "{{ meta.namespace }}"
     status:
       storageSecret: "{{ object_storage_secret }}"
-  when: not file_storage
+  when: not is_file_storage
 
 - name: Update container token secret name status
   operator_sdk.util.k8s_status:


### PR DESCRIPTION
* No longer using an object for file_storage
* Access mode, size and storage class are all top level options

[noissue]

Previous experience may lead users to miss additional configuration:
![old_file_storage_options](https://user-images.githubusercontent.com/29379759/124172107-6b3c2800-da77-11eb-9c10-436770881459.gif)

New experience presents options more clearly to users:
![file_storage_options](https://user-images.githubusercontent.com/29379759/124172150-7b540780-da77-11eb-95b2-07fbf23a46e0.gif)

