### PR TITLE
Use nodeport flow only when defined, otherwise supply svc.cluster.local option

### DIFF
--- a/.ci/scripts/galaxy_ng-tests.sh
+++ b/.ci/scripts/galaxy_ng-tests.sh
@@ -16,8 +16,10 @@ BASE_ADDR="http://$SERVER:24817"
 REPOS=( "published" "staging" "rejected" "community" "rh-certified" )
 REPO_RESULTS=()
 
+sleep 10
+
 TOKEN=$(curl --location --request POST "$BASE_ADDR/api/galaxy/v3/auth/token/" --header 'Authorization: Basic YWRtaW46cGFzc3dvcmQ=' --silent | python3 -c "import sys, json; print(json.load(sys.stdin)['token'])")
-# echo $TOKEN
+echo $TOKEN
 
 for repo in "${REPOS[@]}"
 do

--- a/.ci/scripts/pulp-operator-check-and-wait.sh
+++ b/.ci/scripts/pulp-operator-check-and-wait.sh
@@ -52,11 +52,11 @@ echo "Waiting for services to come up ..."
 # So check for the services being up 1st.
 for tries in {0..90}; do
   services=$(sudo -E $KUBECTL get services)
-  if [[ $(echo "$services" | grep -c NodePort) > 1 ]]; then
+  if [[ $(echo "$services" | grep -c NodePort) > 0 ]]; then
     # parse string like this. 30805 is the external port
     # pulp-api-svc     NodePort    10.43.170.79   <none>        24817:30805/TCP   0s
-    API_PORT=$( echo "$services" | awk -F '[ :/]+' '/pulp-api/{print $6}')
-    SVC_NAME=$( echo "$services" | awk -F '[ :/]+' '/pulp-api/{print $1}')
+    API_PORT=$( echo "$services" | awk -F '[ :/]+' '/pulp-web/{print $5}')
+    SVC_NAME=$( echo "$services" | awk -F '[ :/]+' '/pulp-web/{print $1}')
     echo "SERVICES:"
     echo "$services"
     break

--- a/CHANGES/8833.bugfix
+++ b/CHANGES/8833.bugfix
@@ -1,0 +1,1 @@
+Fix Nodeport flow to create ports in standard range and only on the web service. Also allows node_ip discover based on where the pod is running.

--- a/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
+++ b/deploy/crds/pulpproject_v1beta1_pulp_crd.yaml
@@ -195,6 +195,9 @@ spec:
               route_tls_secret:
                 description: Secret where the TLS related credentials are stored
                 type: string
+              nodeport_port:
+                description: Provide requested port value
+                type: string
               container_token_secret:
                 description: Secret where the container token certificates are stored
                 type: string

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp-operator.clusterserviceversion.yaml
@@ -167,6 +167,12 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Route
+      - displayName: Nodeport port
+        path: nodeport_port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:NodePort
       - displayName: Storage type
         path: storage_type
         x-descriptors:

--- a/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
+++ b/deploy/olm-catalog/pulp-operator/manifests/pulp.pulpproject.org_pulps_crd.yml
@@ -198,6 +198,9 @@ spec:
               route_tls_secret:
                 description: Secret where the TLS related credentials are stored
                 type: string
+              nodeport_port:
+                description: Provide requested port value
+                type: string
               container_token_secret:
                 description: Secret where the container token certificates are stored
                 type: string

--- a/playbook.yml
+++ b/playbook.yml
@@ -36,9 +36,9 @@
     - postgres
     - redis
     - pulp-routes
+    - pulp-web
     - pulp-api
     - pulp-content
     - pulp-resource-manager
     - pulp-worker
-    - pulp-web
     - pulp-status

--- a/roles/pulp-api/tasks/get_node_ip.yml
+++ b/roles/pulp-api/tasks/get_node_ip.yml
@@ -31,7 +31,7 @@
         name: '{{ meta.name }}'
       register: route_url
 
-    - name: Update URL status
+    - name: Capture web URL
       set_fact:
         web_url: "https://{{ route_url['resources'][0]['status']['ingress'][0]['host'] }}"
 
@@ -46,19 +46,56 @@
   when:
     - ingress_type|lower == "route"
 
-- name: Look up the 1st address of the 1st node
-  k8s_info:
-    api_version: v1
-    kind: Node
-  register: k8s_nodes
-  when:
-    - content_origin is not defined
+- block:
+    - name: Retrieve service node port
+      k8s_info:
+        kind: Service
+        namespace: '{{ meta.namespace }}'
+        name: '{{ meta.name }}-web-svc'
+      register: web_service
+      when:
+        - nodeport_port is not defined
 
-- name: Set node address
+    - name: Store nodeport from service
+      set_fact:
+        nodeport_port: "{{ web_service['resources'][0]['spec']['ports'][0]['nodePort'] }}"
+      when:
+        - nodeport_port is not defined
+
+    - name: DEBUG Show nodeport_port
+      debug:
+        msg: "{{ nodeport_port }}"
+
+    - name: Retrieve web pod
+      k8s_info:
+        kind: Pod
+        namespace: "{{ meta.namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/instance = nginx-{{ meta.name }}"
+      register: web_pod
+
+    - name: Store node ip from pod ENV
+      set_fact:
+        node_ip: "{{ web_pod['resources'][0]['status']['hostIP'] }}"
+
+    - name: DEBUG Show node_ip
+      debug:
+        msg: "{{ node_ip }}"
+
+    - name: Set node address
+      set_fact:
+        content_origin: "http://{{ node_ip }}:{{ nodeport_port }}"
+        ansible_api_hostname: "http://{{ node_ip }}:{{ nodeport_port }}"
+        token_server: "http://{{ node_ip }}:{{ nodeport_port }}/token/"
+
+  when:
+    - ingress_type | lower == 'nodeport'
+
+- name: Set svc.cluster.local address
   set_fact:
-    content_origin: "http://{{ k8s_nodes.resources[0].status.addresses[0].address }}:24880"
-    ansible_api_hostname: "http://{{ k8s_nodes.resources[0].status.addresses[0].address }}:24880"
-    token_server: "http://{{ k8s_nodes.resources[0].status.addresses[0].address }}:24880/token/"
+    content_origin: "http://{{ meta.name }}-web-svc.{{ meta.namespace }}.svc.cluster.local:24880"
+    ansible_api_hostname: "http://{{ meta.name }}-web-svc.{{ meta.namespace }}.svc.cluster.local:24880"
+    token_server: "http://{{ meta.name }}-web-svc.{{ meta.namespace }}.svc.cluster.local:24880/token/"
   when:
     - content_origin is not defined
 

--- a/roles/pulp-api/templates/pulp-api.service.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.service.yaml.j2
@@ -22,7 +22,3 @@ spec:
       targetPort: 24817
       name: api-24817
       port: 24817
-{% if ingress_type|lower == "nodeport" %}
-      nodePort: 24817
-  type: NodePort
-{% endif %}

--- a/roles/pulp-content/templates/pulp-content.service.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.service.yaml.j2
@@ -22,7 +22,3 @@ spec:
       targetPort: 24816
       name: content-24816
       port: 24816
-{% if ingress_type|lower == "nodeport" %}
-      nodePort: 24816
-  type: NodePort
-{% endif %}

--- a/roles/pulp-web/tasks/main.yml
+++ b/roles/pulp-web/tasks/main.yml
@@ -17,7 +17,6 @@
   k8s:
     state: "{{ deployment_state }}"
     definition: "{{ lookup('template', 'templates/' + item + '.deployment.yaml.j2') | from_yaml }}"
-    wait: true
   with_items:
     - pulp-web
 

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -40,6 +40,13 @@ spec:
         - name: web
           image: "{{ registry }}/{{ project }}/{{ image_web }}:{{ tag }}"
           imagePullPolicy: "{{ image_pull_policy }}"
+{% if ingress_type | lower == 'nodeport' %}
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+{% endif %}
           volumeMounts:
             - name: {{ meta.name }}-nginx-conf
               mountPath: /etc/nginx/nginx.conf
@@ -67,9 +74,9 @@ spec:
               scheme: HTTP
 {% endif %}
             failureThreshold: 5
-            initialDelaySeconds: 60
+            initialDelaySeconds: 90
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: pulp/api/v3/status/
@@ -81,9 +88,9 @@ spec:
               scheme: HTTP
 {% endif %}
             failureThreshold: 10
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 10
 {% if web.resource_requirements is defined %}
           resources: {{ web.resource_requirements }}
 {% endif %}

--- a/roles/pulp-web/templates/pulp-web.service.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.service.yaml.j2
@@ -48,7 +48,9 @@ spec:
 {% if ingress_type | lower == "loadbalancer" %}
   type: LoadBalancer
 {% elif ingress_type|lower == "nodeport" %}
-      nodePort: 24880
+{% if nodeport_port is defined %}
+      nodePort: {{ nodeport_port }}
+{% endif %}
   type: NodePort
 {% else %}
   type: ClusterIP


### PR DESCRIPTION
* Don't attempt nodeport settings if not selected
* Use status.hostIP from downward API to get node where web pod is running https://stackoverflow.com/a/52047845
* Only set nodeport for web service
* Allow user to specify nodeport or take cluster default in range

fixes #8833
https://pulp.plan.io/issues/8833