### PR TITLE
Explicity defined ANSIBLE_DEBUG_LOGS environment variable

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -39,6 +39,8 @@ spec:
               value: "pulp-operator"
             - name: ANSIBLE_GATHERING
               value: explicit
+            - name: ANSIBLE_DEBUG_LOGS
+              value: 'false'
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
Created this PR so people using it can have visibility into changing the logs to debug when deploying if they wish.  This functionally changes nothing, just lets the user be aware of an environment var they cause use in order to get more detailed logging.