### PR TITLE
Use v1 extensions because v1beta1 is being removed

### DIFF
--- a/roles/pulp-routes/templates/pulp.ingress.yaml.j2
+++ b/roles/pulp-routes/templates/pulp.ingress.yaml.j2
@@ -1,6 +1,6 @@
 {% if 'ingress' == ingress_type|lower %}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Ingress
 metadata:
   name: '{{ meta.name }}-ingress'


### PR DESCRIPTION
To remain compatible with Kubernetes 1.22 and Openshift 4.9, we need to start using the `extensions/v1` API as the `extensions/v1beta1` is being removed.  


> All beta Ingress APIs (the extensions/v1beta1 and networking.k8s.io/v1beta1 API versions)

>The beta CustomResourceDefinition API (apiextensions.k8s.io/v1beta1)

Context: https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/