### PR TITLE
Enable stackrox linter

### DIFF
--- a/.ci/assets/kubernetes/.kube-linter.yaml
+++ b/.ci/assets/kubernetes/.kube-linter.yaml
@@ -1,12 +1,2 @@
 checks:
   addAllBuiltIn: true
-  exclude:
-   - "latest-tag"
-   - "no-read-only-root-fs"
-   - "run-as-non-root"
-   - "minimum-three-replicas"
-   - "use-namespace"
-   - "no-rolling-update-strategy"
-   - "wildcard-in-rules"
-   - "access-to-create-pods"
-   - "access-to-secrets"

--- a/.ci/assets/kubernetes/.kube-linter.yaml
+++ b/.ci/assets/kubernetes/.kube-linter.yaml
@@ -1,2 +1,4 @@
 checks:
   addAllBuiltIn: true
+  exclude:
+    - "dangling-service"

--- a/.ci/scripts/linting.py
+++ b/.ci/scripts/linting.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+import glob
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import yaml
+
+from ansible.plugins.filter.core import FilterModule
+from jinja2 import Environment, FileSystemLoader
+
+
+DEFAULT_SETTINGS = {
+    "ansible_operator_meta": {"namespace": "lint", "name": "test"},
+    "deployment_type": "pulp",
+}
+
+
+def lookup(*args, **kwargs):
+    return "pulp_lookup"
+
+
+def main():
+    operator_root_dir = os.getcwd()
+    crs = glob.glob(f"{operator_root_dir}/config/samples/p*.yaml")
+    roles = glob.glob(f"{operator_root_dir}/roles/*")
+    for cr in crs:
+        with open(cr) as config_file:
+            try:
+                config_in_file = yaml.safe_load(config_file)
+                if not config_in_file.get("spec"):
+                    continue
+                config = config_in_file["spec"]
+                # Add any missing value from the list of defaults
+                for key, value in DEFAULT_SETTINGS.items():
+                    if key not in config:
+                        config[key] = value
+                print("\nLoaded vars from " "{path}\n".format(path=cr))
+            except yaml.YAMLError as exc:
+                print(exc)
+                exit()
+
+        for role in roles:
+            write_template_section(config, cr, role, operator_root_dir)
+
+
+def to_nice_yaml(data):
+    """Implement a filter for Jinja 2 templates to render human readable YAML."""
+    return yaml.dump(data, indent=2, allow_unicode=True, default_flow_style=False)
+
+
+def write_template_section(config, cr, role_dir, operator_root_dir, verbose=False):
+    """
+    Template or copy all files for the section.
+    """
+    env = Environment(
+        loader=FileSystemLoader(
+            [
+                role_dir,  # The scpecified role folder
+                "templates",  # The default templates folder
+            ]
+        )
+    )
+    ansible_filters = FilterModule().filters()
+    env.filters.update(ansible_filters)
+    env.globals["lookup"] = lookup
+    files_templated = 0
+    files_copied = 0
+    with open(f"{role_dir}/defaults/main.yml") as default_file:
+        default_vars = yaml.safe_load(default_file)
+        for key, value in default_vars.items():
+            config[key] = value
+    if os.path.exists(f"{role_dir}/vars/main.yml"):
+        with open(f"{role_dir}/vars/main.yml") as vars_file:
+            _vars = yaml.safe_load(vars_file)
+            for key, value in _vars.items():
+                config[key] = value
+    with open(f"{operator_root_dir}/playbooks/pulp.yml") as playbook_file:
+        playbook_vars = yaml.safe_load(playbook_file)[0]["vars"]
+        for key, value in playbook_vars.items():
+            config[key] = value
+    config["pulp_combined_settings"] = config["default_settings"]
+
+    for relative_path in generate_relative_path_set(role_dir):
+        cr_name = cr.split("/")[-1].replace(".yaml", "")
+        role_name = role_dir.split("/")[-1]
+        filename = relative_path.split("/")[-1]
+        destination_relative_path = f"lint/{cr_name}/{role_name}/{filename}"
+        necessary_dir_structure = os.path.dirname(
+            os.path.join(operator_root_dir, destination_relative_path)
+        )
+
+        if not os.path.exists(necessary_dir_structure):
+            os.makedirs(necessary_dir_structure)
+
+        if relative_path.endswith(".j2"):
+            env.filters["to_yaml"] = to_nice_yaml
+            template = env.get_template(relative_path)
+            destination = destination_relative_path[: -len(".j2")]
+            write_template_to_file(
+                template,
+                operator_root_dir,
+                destination,
+                config,
+            )
+            files_templated += 1
+            if verbose:
+                print(f"Templated file: {relative_path}")
+        else:
+            if destination_relative_path.endswith(".copy"):
+                destination_relative_path = destination_relative_path[: -len(".copy")]
+            shutil.copyfile(
+                os.path.join(role_dir, relative_path),
+                os.path.join(operator_root_dir, destination_relative_path),
+            )
+            files_copied += 1
+            if verbose:
+                print(f"Copied file: {relative_path}")
+
+    return 0
+
+
+def generate_relative_path_set(root_dir):
+    """
+    Create a set of relative paths within the specified directory.
+    """
+    applicable_paths = set()
+    for root, dirs, files in os.walk(root_dir, topdown=False):
+        for file_name in files:
+            template_abs_path = os.path.join(root, file_name)
+            template_relative_path = os.path.relpath(template_abs_path, root_dir)
+            if template_relative_path.startswith("template"):
+                applicable_paths.add(template_relative_path)
+    return applicable_paths
+
+
+def write_template_to_file(template, operator_root_dir, relative_path, config):
+    """
+    Render template with values from the config and write it to the target plugin directory.
+    """
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", dir=operator_root_dir, delete=False
+    ) as fd_out:
+        tempfile_path = fd_out.name
+        fd_out.write(template.render(**config))
+        fd_out.write("\n")
+
+        destination_path = os.path.normpath(
+            os.path.join(operator_root_dir, relative_path)
+        )
+        os.rename(tempfile_path, destination_path)
+
+        mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH
+        os.chmod(destination_path, mode)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         shell: bash
       - name: Build Operator
         run: |
-          sudo -E make docker-build IMG=quay.io/pulp/pulp-operator:latest
+          sudo -E make docker-build IMG=quay.io/pulp/pulp-operator:devel
           sudo -E docker images
         shell: bash
       - name: Deploy pulp-operator to K8s

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,6 +44,19 @@ jobs:
             fi
           done
         shell: bash
+      - name: Get K8S objects
+        run: |
+          pip install ansible
+          python3 .ci/scripts/linting.py
+          mkdir -p ./lint/operator
+          kustomize build config/default > ./lint/operator/all.yml
+          tree lint
+        shell: bash
+      - name: Scan repo with kube-linter
+        uses: stackrox/kube-linter-action@v1.0.2
+        with:
+          directory: "lint"
+          config: .ci/assets/kubernetes/.kube-linter.yaml
 
   insta:
     runs-on: ubuntu-latest

--- a/CHANGES/209.misc
+++ b/CHANGES/209.misc
@@ -1,0 +1,1 @@
+Enable stackrox linter

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -5,6 +5,12 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  annotations: # About kube-linter checks: https://docs.kubelinter.io/#/generated/checks
+    ignore-check.kube-linter.io/no-liveness-probe: "Not linting kubebuilder"
+    ignore-check.kube-linter.io/no-readiness-probe: "Not linting kubebuilder"
+    ignore-check.kube-linter.io/run-as-non-root: "Not linting kubebuilder"
+    ignore-check.kube-linter.io/unset-cpu-requirements: "Not linting kubebuilder"
+    ignore-check.kube-linter.io/unset-memory-requirements: "Not linting kubebuilder"
 spec:
   template:
     spec:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -10,18 +10,30 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  annotations: # About kube-linter checks: https://docs.kubelinter.io/#/generated/checks
+    email: pulp-dev@redhat.com
+    ignore-check.kube-linter.io/minimum-three-replicas: "Operator should be unique"
+    ignore-check.kube-linter.io/no-read-only-root-fs: "Operator needs to generate files"
   labels:
     control-plane: controller-manager
+    app.kubernetes.io/name: pulp-operator
+    app.kubernetes.io/component: operator
+    owner: pulp-dev
 spec:
   selector:
     matchLabels:
       control-plane: controller-manager
   replicas: 1
+  strategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/name: pulp-operator
+        app.kubernetes.io/component: operator
     spec:
+      serviceAccountName: sa
       containers:
         - name: manager
           args:
@@ -38,6 +50,16 @@ spec:
             - name: ANSIBLE_DEBUG_LOGS
               value: 'false'
           image: controller:latest
+          securityContext:
+            runAsUser: 1001
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: 800m
+              memory: 256Mi
+            requests:
+              cpu: 1m
+              memory: 6Mi
           livenessProbe:
             httpGet:
               path: /readyz

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: pulp-operator-sa
+  namespace: pulp-operator-system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: pulp-operator-sa
+  namespace: pulp-operator-system

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,12 +8,18 @@ rules:
   ## Base operator rules
   ##
   - apiGroups:
-    - route.openshift.io
+      - route.openshift.io
     resources:
-    - routes
-    - routes/custom-host
+      - routes
+      - routes/custom-host
     verbs:
-    - '*'
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - ""
     resources:
@@ -53,14 +59,14 @@ rules:
       - update
       - watch
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - nodes
+      - nodes
     verbs:
-    - get
-    - list
+      - get
+      - list
   - apiGroups:
-    - apps
+      - apps
     resources:
       - deployments/scale
     verbs:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -3,11 +3,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: manager-rolebinding
+  annotations: # About kube-linter checks: https://docs.kubelinter.io/#/generated/checks
+    ignore-check.kube-linter.io/access-to-create-pods: "Operator needs to create pods"
+    ignore-check.kube-linter.io/access-to-secrets: "Operator needs to create secrets"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: pulp-operator-sa
+  namespace: pulp-operator-system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa

--- a/config/testing/kustomization.yaml
+++ b/config/testing/kustomization.yaml
@@ -7,6 +7,32 @@ namePrefix: osdk-
 #commonLabels:
 #  someName: someValue
 
+patches:
+  - patch: |-
+      - op: replace
+        path: /subjects/0/namespace
+        value: osdk-test
+    target:
+      kind: RoleBinding
+  - patch: |-
+      - op: replace
+        path: /subjects/0/namespace
+        value: osdk-test
+    target:
+      kind: ClusterRoleBinding
+  - patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osdk-sa
+    target:
+      kind: RoleBinding
+  - patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osdk-sa
+    target:
+      kind: ClusterRoleBinding
+
 patchesStrategicMerge:
 - manager_image.yaml
 - debug_logs_patch.yaml

--- a/molecule/default/tasks/pulp_test.yml
+++ b/molecule/default/tasks/pulp_test.yml
@@ -7,7 +7,7 @@
   vars:
     cr_file: 'pulpproject_v1beta1_pulp_cr.ci.yaml'
 
-- name: Wait 5m for reconciliation to run
+- name: Wait 10m for reconciliation to run
   k8s_info:
     api_version: '{{ custom_resource.apiVersion }}'
     kind: '{{ custom_resource.kind }}'
@@ -17,7 +17,7 @@
   until:
     - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
   delay: 6
-  retries: 50
+  retries: 100
   vars:
     cr_file: 'pulpproject_v1beta1_pulp_cr.ci.yaml'
     custom_resource: "{{ lookup('template', '/'.join([samples_dir, cr_file])) | from_yaml }}"

--- a/playbooks/pulp.yml
+++ b/playbooks/pulp.yml
@@ -5,7 +5,6 @@
     - community.kubernetes
     - operator_sdk.util
   vars:
-    project_name: "{{ ansible_operator_meta.namespace }}"
     default_settings:
       db_encryption_key: "/etc/pulp/keys/database_fields.symmetric.key"
       databases:

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -21,7 +21,7 @@ spec:
       app.kubernetes.io/version: '{{ postgres_version }}'
       app.kubernetes.io/part-of: '{{ deployment_type }}'
       app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
-  serviceName: '{{ ansible_operator_meta.name }}'
+  serviceName: '{{ ansible_operator_meta.name }}-postgres'
   replicas: 1
   updateStrategy:
     type: RollingUpdate

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-api"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-api'
     app.kubernetes.io/instance: '{{ deployment_type }}-api-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-api/templates/pulp-api.service.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.service.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ ansible_operator_meta.name }}-api-svc"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-api'
     app.kubernetes.io/instance: '{{ deployment_type }}-api-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-api/templates/pulp-db-fields-encryption.secret.yaml.j2
+++ b/roles/pulp-api/templates/pulp-db-fields-encryption.secret.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: '{{ ansible_operator_meta.name }}-db-fields-encryption'
-  namespace: '{{ project_name }}'
+  namespace: '{{ ansible_operator_meta.namespace }}'
 stringData:
   database_fields.symmetric.key: |
     {{ db_fields_encryption_key }}

--- a/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
+++ b/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: "{{ ansible_operator_meta.name }}-file-storage"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-storage'
     app.kubernetes.io/instance: '{{ deployment_type }}-storage-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-api/templates/pulp-server.secret.yaml.j2
+++ b/roles/pulp-api/templates/pulp-server.secret.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ ansible_operator_meta.name }}-server"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
 stringData:
   settings.py: |
     {% for setting, value in pulp_combined_settings.items() %}

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-content"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-content'
     app.kubernetes.io/instance: '{{ deployment_type }}-content-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-content/templates/pulp-content.service.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.service.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ ansible_operator_meta.name }}-content-svc"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-content'
     app.kubernetes.io/instance: '{{ deployment_type }}-content-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-resource-manager"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-resource-manager'
     app.kubernetes.io/instance: '{{ deployment_type }}-resource-manager-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-web"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: 'nginx'
     app.kubernetes.io/instance: 'nginx-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-web/templates/pulp-web.service.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.service.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ ansible_operator_meta.name }}-web-svc"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: 'nginx'
     app.kubernetes.io/instance: 'nginx-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-worker"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-worker'
     app.kubernetes.io/instance: '{{ deployment_type }}-worker-{{ ansible_operator_meta.name }}'

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-redis"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: 'redis'
     app.kubernetes.io/instance: 'redis-{{ ansible_operator_meta.name }}'

--- a/roles/redis/templates/redis.pvc.yaml.j2
+++ b/roles/redis/templates/redis.pvc.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: '{{ ansible_operator_meta.name }}-redis-data'
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: 'redis'
     app.kubernetes.io/instance: 'redis-{{ ansible_operator_meta.name }}'

--- a/roles/redis/templates/redis.service.yaml.j2
+++ b/roles/redis/templates/redis.service.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ ansible_operator_meta.name }}-redis"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: 'redis'
     app.kubernetes.io/instance: 'redis-{{ ansible_operator_meta.name }}'


### PR DESCRIPTION
This PR attempts to lint all k8s objects **before** they are applied to the cluster,

Advantage: lint right at the beginning 
Disadvantage: script that converts templates to yaml may not reflect what will be really applied to the cluster

Alternative PR: https://github.com/pulp/pulp-operator/pull/198