### PR TITLE
Lint k8s objects after applied

### DIFF
--- a/.ci/assets/kubernetes/.kube-linter.yaml
+++ b/.ci/assets/kubernetes/.kube-linter.yaml
@@ -1,12 +1,2 @@
 checks:
   addAllBuiltIn: true
-  exclude:
-   - "latest-tag"
-   - "no-read-only-root-fs"
-   - "run-as-non-root"
-   - "minimum-three-replicas"
-   - "use-namespace"
-   - "no-rolling-update-strategy"
-   - "wildcard-in-rules"
-   - "access-to-create-pods"
-   - "access-to-secrets"

--- a/.ci/assets/kubernetes/.kube-linter.yaml
+++ b/.ci/assets/kubernetes/.kube-linter.yaml
@@ -1,2 +1,9 @@
 checks:
   addAllBuiltIn: true
+  exclude:
+   - "latest-tag"
+   - "no-read-only-root-fs"
+   - "run-as-non-root"
+   - "minimum-three-replicas"
+   - "deprecated-service-account-field"
+   - "exposed-services"

--- a/.ci/scripts/kubelinter.sh
+++ b/.ci/scripts/kubelinter.sh
@@ -15,5 +15,5 @@ if [ ! -e $TARGET ]; then
   tar -xf $TARGET
 fi
 mkdir -p lint
-sudo -E kubectl get pvc,configmap,serviceaccount,secret,ingress,service,deployment,statefulset,hpa,job,cronjob -o yaml > ./lint/k8s-all.yaml
+sudo -E kubectl get pvc,configmap,serviceaccount,secret,networkpolicy,ingress,service,deployment,statefulset,hpa,job,cronjob -o yaml > ./lint/k8s-all.yaml
 ./kube-linter lint ./lint --config .ci/assets/kubernetes/.kube-linter.yaml

--- a/.ci/scripts/molecule.sh
+++ b/.ci/scripts/molecule.sh
@@ -14,5 +14,7 @@ sudo mv ./kind /usr/local/bin/kind
 make kustomize
 kustomize version
 
+find ./roles/*/templates/*.yaml.j2 -exec sed -i 's/pulp-operator-sa/osdk-sa/g' {} \;
+
 echo "Starting molecule test"
 molecule -v test -s kind --destroy never

--- a/.ci/scripts/stackrox.sh
+++ b/.ci/scripts/stackrox.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# coding=utf-8
+
+set -euo pipefail
+
+RELEASE_INFO=$(curl --silent --show-error --fail https://api.github.com/repos/stackrox/kube-linter/releases/latest)
+RELEASE_NAME=$(echo "${RELEASE_INFO}" | jq --raw-output ".name")
+LOCATION=$(echo "${RELEASE_INFO}" \
+  | jq --raw-output ".assets[].browser_download_url" \
+  | grep --fixed-strings kube-linter-linux.tar.gz)
+TARGET=kube-linter-linux-${RELEASE_NAME}.tar.gz
+# Skip downloading release if downloaded already, e.g. when the action is used multiple times.
+if [ ! -e $TARGET ]; then
+  curl --silent --show-error --fail --location --output $TARGET "$LOCATION"
+  tar -xf $TARGET
+fi
+mkdir -p lint
+sudo -E kubectl get pvc,configmap,serviceaccount,secret,ingress,service,deployment,statefulset,hpa,job,cronjob -o yaml > ./lint/k8s-all.yaml
+./kube-linter lint ./lint --config .ci/assets/kubernetes/.kube-linter.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         shell: bash
       - name: Build Operator
         run: |
-          sudo -E make docker-build IMG=quay.io/pulp/pulp-operator:latest
+          sudo -E make docker-build IMG=quay.io/pulp/pulp-operator:devel
           sudo -E docker images
         shell: bash
       - name: Deploy pulp-operator to K8s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,11 +261,16 @@ jobs:
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_VERBOSITY: 2
       - name: Logs
         if: always()
         run: |
           kind export kubeconfig --name osdk-test
-          kubectl logs deployment.apps/osdk-controller-manager -n osdk-test -c manager --tail=10000
+          sudo -E kubectl config set-context --current --namespace=osdk-test
+          sudo -E kubectl port-forward service/example-pulp-web-svc 24880:24880 &
+          sudo -E docker images
+          .github/workflows/scripts/show_logs.sh -k
+          http --timeout 30 --check-status --pretty format --print hb http://localhost:24880/pulp/api/v3/status/
         shell: bash
       - name: Molecule destroy
         if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -103,8 +103,8 @@ jobs:
           FORKED_REPOSITORY: ${{ steps.head_repo_name.outputs.repo }}
         run: sudo -E insta-demo/pulp-insta-demo.sh -m
         shell: bash
-      - name: Stackrox
-        run: .ci/scripts/stackrox.sh
+      - name: KubeLinter
+        run: .ci/scripts/kubelinter.sh
         shell: bash
       - name: Popeye
         run: |
@@ -154,10 +154,7 @@ jobs:
           minikube addons enable metrics-server
         # now you can run kubectl to see the pods in the cluster
       - name: Try the cluster !
-        run: |
-          kubectl config view > $PWD/kubeconfig
-          kubectl get pods -A
-          echo "KUBECONFIG=$PWD/kubeconfig" >> $GITHUB_ENV
+        run: kubectl get pods -A
       - name: Setup a minikube docker env
         run: minikube -p minikube docker-env | grep "export" | sed 's/export //' | sed 's/"//g' >> $GITHUB_ENV
       - name: Uninstalling GHA kustomize
@@ -174,16 +171,13 @@ jobs:
           sudo -E docker images
         shell: bash
       - name: Deploy pulp-operator to K8s
-        run: |
-          echo $KUBECONFIG
-          cat $KUBECONFIG
-          sudo -E ./up.sh
+        run: sudo -E ./up.sh
         shell: bash
       - name: Check and wait pulp-operator deploy
         run: .ci/scripts/pulp-operator-check-and-wait.sh -m
         shell: bash
-      - name: Stackrox
-        run: .ci/scripts/stackrox.sh
+      - name: KubeLinter
+        run: .ci/scripts/kubelinter.sh
         shell: bash
       - name: Popeye
         run: |
@@ -262,8 +256,8 @@ jobs:
       - name: Check and wait pulp-operator deploy
         run: .ci/scripts/pulp-operator-check-and-wait.sh -m
         shell: bash
-      - name: Stackrox
-        run: .ci/scripts/stackrox.sh
+      - name: KubeLinter
+        run: .ci/scripts/kubelinter.sh
         shell: bash
       - name: Popeye
         run: |
@@ -332,11 +326,16 @@ jobs:
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_VERBOSITY: 2
       - name: Logs
         if: always()
         run: |
           kind export kubeconfig --name osdk-test
-          kubectl logs deployment.apps/osdk-controller-manager -n osdk-test -c manager --tail=10000
+          sudo -E kubectl config set-context --current --namespace=osdk-test
+          sudo -E kubectl port-forward service/example-pulp-web-svc 24880:24880 &
+          sudo -E docker images
+          .github/workflows/scripts/show_logs.sh -k
+          http --timeout 30 --check-status --pretty format --print hb http://localhost:24880/pulp/api/v3/status/
         shell: bash
       - name: Molecule destroy
         if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -103,6 +103,9 @@ jobs:
           FORKED_REPOSITORY: ${{ steps.head_repo_name.outputs.repo }}
         run: sudo -E insta-demo/pulp-insta-demo.sh -m
         shell: bash
+      - name: Stackrox
+        run: .ci/scripts/stackrox.sh
+        shell: bash
       - name: Popeye
         run: |
           echo ::group::POPEYE
@@ -178,6 +181,9 @@ jobs:
         shell: bash
       - name: Check and wait pulp-operator deploy
         run: .ci/scripts/pulp-operator-check-and-wait.sh -m
+        shell: bash
+      - name: Stackrox
+        run: .ci/scripts/stackrox.sh
         shell: bash
       - name: Popeye
         run: |
@@ -255,6 +261,9 @@ jobs:
         shell: bash
       - name: Check and wait pulp-operator deploy
         run: .ci/scripts/pulp-operator-check-and-wait.sh -m
+        shell: bash
+      - name: Stackrox
+        run: .ci/scripts/stackrox.sh
         shell: bash
       - name: Popeye
         run: |

--- a/.github/workflows/scripts/show_logs.sh
+++ b/.github/workflows/scripts/show_logs.sh
@@ -1,13 +1,23 @@
 #!/bin/bash -e
 #!/usr/bin/env bash
 
-echo ::group::METRICS
-sudo -E kubectl top pods
-sudo -E kubectl describe node minikube
-echo ::endgroup::
+KUBE="minikube"
+if [[ "$1" == "--kind" ]] || [[ "$1" == "-k" ]]; then
+  KUBE="kind"
+  echo "Running $KUBE"
+fi
+
+sudo -E kubectl get pods -o wide
+
+if [[ "$KUBE" == "minikube" ]]; then
+  echo ::group::METRICS
+  sudo -E kubectl top pods
+  sudo -E kubectl describe node minikube
+  echo ::endgroup::
+fi
 
 echo ::group::OPERATOR_LOGS
-sudo -E kubectl logs deployment.apps/pulp-operator-controller-manager -n pulp-operator-system -c manager --tail=10000
+sudo -E kubectl logs -l app.kubernetes.io/name=pulp-operator -c manager --tail=10000
 echo ::endgroup::
 
 echo ::group::PULP_API_LOGS
@@ -27,5 +37,5 @@ sudo -E kubectl logs -l app.kubernetes.io/name=pulp-resource-manager --tail=1000
 echo ::endgroup::
 
 echo ::group::PULP_WEB_LOGS
-sudo -E kubectl logs -l app.kubernetes.io/name=pulp-web --tail=10000
+sudo -E kubectl logs -l app.kubernetes.io/name=nginx --tail=10000
 echo ::endgroup::

--- a/CHANGES/209.misc
+++ b/CHANGES/209.misc
@@ -1,1 +1,1 @@
-Enable stackrox linter
+Enable KubeLinter

--- a/CHANGES/209.misc
+++ b/CHANGES/209.misc
@@ -1,0 +1,1 @@
+Enable stackrox linter

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -5,6 +5,12 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  annotations: # About kube-linter checks: https://docs.kubelinter.io/#/generated/checks
+    ignore-check.kube-linter.io/no-liveness-probe: "Not linting kubebuilder"
+    ignore-check.kube-linter.io/no-readiness-probe: "Not linting kubebuilder"
+    ignore-check.kube-linter.io/run-as-non-root: "Not linting kubebuilder"
+    ignore-check.kube-linter.io/unset-cpu-requirements: "Not linting kubebuilder"
+    ignore-check.kube-linter.io/unset-memory-requirements: "Not linting kubebuilder"
 spec:
   template:
     spec:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -10,18 +10,30 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  annotations: # About kube-linter checks: https://docs.kubelinter.io/#/generated/checks
+    email: pulp-dev@redhat.com
+    ignore-check.kube-linter.io/minimum-three-replicas: "Operator should be unique"
+    ignore-check.kube-linter.io/no-read-only-root-fs: "Operator needs to generate files"
   labels:
     control-plane: controller-manager
+    app.kubernetes.io/name: pulp-operator
+    app.kubernetes.io/component: operator
+    owner: pulp-dev
 spec:
   selector:
     matchLabels:
       control-plane: controller-manager
   replicas: 1
+  strategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/name: pulp-operator
+        app.kubernetes.io/component: operator
     spec:
+      serviceAccountName: sa
       containers:
         - name: manager
           args:
@@ -38,6 +50,16 @@ spec:
             - name: ANSIBLE_DEBUG_LOGS
               value: 'false'
           image: controller:latest
+          securityContext:
+            runAsUser: 1001
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: 800m
+              memory: 256Mi
+            requests:
+              cpu: 1m
+              memory: 6Mi
           livenessProbe:
             httpGet:
               path: /readyz

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: pulp-operator-sa
+  namespace: pulp-operator-system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml
@@ -10,3 +11,4 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_role.yaml
+- network_policy.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: pulp-operator-sa
+  namespace: pulp-operator-system

--- a/config/rbac/network_policy.yaml
+++ b/config/rbac/network_policy.yaml
@@ -1,0 +1,12 @@
+# https://cloud.redhat.com/blog/guide-to-kubernetes-ingress-network-policies
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,12 +8,18 @@ rules:
   ## Base operator rules
   ##
   - apiGroups:
-    - route.openshift.io
+      - route.openshift.io
     resources:
-    - routes
-    - routes/custom-host
+      - routes
+      - routes/custom-host
     verbs:
-    - '*'
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - ""
     resources:
@@ -53,14 +59,14 @@ rules:
       - update
       - watch
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - nodes
+      - nodes
     verbs:
-    - get
-    - list
+      - get
+      - list
   - apiGroups:
-    - apps
+      - apps
     resources:
       - deployments/scale
     verbs:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -3,11 +3,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: manager-rolebinding
+  annotations: # About kube-linter checks: https://docs.kubelinter.io/#/generated/checks
+    ignore-check.kube-linter.io/access-to-create-pods: "Operator needs to create pods"
+    ignore-check.kube-linter.io/access-to-secrets: "Operator needs to create secrets"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: pulp-operator-sa
+  namespace: pulp-operator-system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa

--- a/config/samples/pulpproject_v1beta1_pulp_cr.ci.yaml
+++ b/config/samples/pulpproject_v1beta1_pulp_cr.ci.yaml
@@ -18,15 +18,24 @@ spec:
       requests:
         cpu: 150m
         memory: 256Mi
+      limits:
+        cpu: 800m
+        memory: 1Gi
   worker:
     replicas: 1
     resource_requirements:
       requests:
         cpu: 150m
         memory: 256Mi
+      limits:
+        cpu: 800m
+        memory: 1Gi
   web:
     replicas: 1
     resource_requirements:
       requests:
         cpu: 100m
         memory: 256Mi
+      limits:
+        cpu: 800m
+        memory: 1Gi

--- a/config/samples/pulpproject_v1beta1_pulp_cr.galaxy.ci.yaml
+++ b/config/samples/pulpproject_v1beta1_pulp_cr.galaxy.ci.yaml
@@ -19,15 +19,24 @@ spec:
       requests:
         cpu: 150m
         memory: 256Mi
+      limits:
+        cpu: 800m
+        memory: 1Gi
   worker:
     replicas: 1
     resource_requirements:
       requests:
         cpu: 150m
         memory: 256Mi
+      limits:
+        cpu: 800m
+        memory: 1Gi
   web:
     replicas: 1
     resource_requirements:
       requests:
         cpu: 100m
         memory: 256Mi
+      limits:
+        cpu: 800m
+        memory: 1Gi

--- a/config/testing/kustomization.yaml
+++ b/config/testing/kustomization.yaml
@@ -7,6 +7,32 @@ namePrefix: osdk-
 #commonLabels:
 #  someName: someValue
 
+patches:
+  - patch: |-
+      - op: replace
+        path: /subjects/0/namespace
+        value: osdk-test
+    target:
+      kind: RoleBinding
+  - patch: |-
+      - op: replace
+        path: /subjects/0/namespace
+        value: osdk-test
+    target:
+      kind: ClusterRoleBinding
+  - patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osdk-sa
+    target:
+      kind: RoleBinding
+  - patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osdk-sa
+    target:
+      kind: ClusterRoleBinding
+
 patchesStrategicMerge:
 - manager_image.yaml
 - debug_logs_patch.yaml

--- a/molecule/default/tasks/pulp_test.yml
+++ b/molecule/default/tasks/pulp_test.yml
@@ -7,7 +7,7 @@
   vars:
     cr_file: 'pulpproject_v1beta1_pulp_cr.ci.yaml'
 
-- name: Wait 5m for reconciliation to run
+- name: Wait 15m for reconciliation to run
   k8s_info:
     api_version: '{{ custom_resource.apiVersion }}'
     kind: '{{ custom_resource.kind }}'
@@ -17,7 +17,7 @@
   until:
     - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
   delay: 6
-  retries: 50
+  retries: 150
   vars:
     cr_file: 'pulpproject_v1beta1_pulp_cr.ci.yaml'
     custom_resource: "{{ lookup('template', '/'.join([samples_dir, cr_file])) | from_yaml }}"

--- a/playbooks/pulp.yml
+++ b/playbooks/pulp.yml
@@ -5,7 +5,6 @@
     - community.kubernetes
     - operator_sdk.util
   vars:
-    project_name: "{{ ansible_operator_meta.namespace }}"
     default_settings:
       db_encryption_key: "/etc/pulp/keys/database_fields.symmetric.key"
       databases:

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -5,6 +5,11 @@ kind: StatefulSet
 metadata:
   name: '{{ ansible_operator_meta.name }}-postgres'
   namespace: '{{ ansible_operator_meta.namespace }}'
+  annotations: # About kube-linter checks: https://docs.kubelinter.io/#/generated/checks
+    email: pulp-dev@redhat.com
+    ignore-check.kube-linter.io/unset-cpu-requirements: "Temporarily disabled"
+    ignore-check.kube-linter.io/unset-memory-requirements: "Temporarily disabled"
+    ignore-check.kube-linter.io/read-secret-from-env-var: "Temporarily disabled"
   labels:
     app.kubernetes.io/name: 'postgres'
     app.kubernetes.io/instance: 'postgres-{{ ansible_operator_meta.name }}'
@@ -12,6 +17,7 @@ metadata:
     app.kubernetes.io/version: '{{ postgres_version }}'
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    owner: pulp-dev
 spec:
   selector:
     matchLabels:
@@ -21,7 +27,7 @@ spec:
       app.kubernetes.io/version: '{{ postgres_version }}'
       app.kubernetes.io/part-of: '{{ deployment_type }}'
       app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
-  serviceName: '{{ ansible_operator_meta.name }}'
+  serviceName: '{{ ansible_operator_meta.name }}-postgres'
   replicas: 1
   updateStrategy:
     type: RollingUpdate
@@ -43,6 +49,7 @@ spec:
       affinity:
         nodeAffinity: {{ affinity.node_affinity }}
 {% endif %}
+      serviceAccountName: pulp-operator-sa
       containers:
         - image: '{{ postgres_image }}'
           name: postgres
@@ -89,6 +96,32 @@ spec:
           ports:
             - containerPort: {{ postgres_port | default('5432')}}
               name: postgres
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - pg_isready -h 127.0.0.1 -p 5432
+            enabled: true
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+            successThreshold: 1
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - pg_isready -h 127.0.0.1 -p 5432
+            enabled: true
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+            successThreshold: 1
           volumeMounts:
             - name: postgres
               mountPath: '{{ postgres_data_path | dirname }}'

--- a/roles/pulp-api/defaults/main.yml
+++ b/roles/pulp-api/defaults/main.yml
@@ -6,6 +6,9 @@ api:
     requests:
       cpu: 200m
       memory: 512Mi
+    limits:
+      cpu: 800m
+      memory: 1Gi
 
 # Here we use  _pulpproject_org_pulp to get un-modified cr
 # see: https://github.com/operator-framework/operator-sdk/issues/1770

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -4,12 +4,15 @@ kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-api"
   namespace: "{{ ansible_operator_meta.namespace }}"
+  annotations:
+    email: pulp-dev@redhat.com
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-api'
     app.kubernetes.io/instance: '{{ deployment_type }}-api-{{ ansible_operator_meta.name }}'
     app.kubernetes.io/component: api
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    owner: pulp-dev
 spec:
   replicas: {{ api.replicas }}
   selector:
@@ -80,6 +83,7 @@ spec:
               - path: container_auth_private_key.pem
                 key: container_auth_private_key.pem
 {% endif %}
+      serviceAccountName: pulp-operator-sa
       containers:
         - name: api
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-api"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-api'
     app.kubernetes.io/instance: '{{ deployment_type }}-api-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-api/templates/pulp-api.service.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.service.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ ansible_operator_meta.name }}-api-svc"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-api'
     app.kubernetes.io/instance: '{{ deployment_type }}-api-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-api/templates/pulp-db-fields-encryption.secret.yaml.j2
+++ b/roles/pulp-api/templates/pulp-db-fields-encryption.secret.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: '{{ ansible_operator_meta.name }}-db-fields-encryption'
-  namespace: '{{ project_name }}'
+  namespace: '{{ ansible_operator_meta.namespace }}'
 stringData:
   database_fields.symmetric.key: |
     {{ db_fields_encryption_key }}

--- a/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
+++ b/roles/pulp-api/templates/pulp-file-storage.pvc.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: "{{ ansible_operator_meta.name }}-file-storage"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-storage'
     app.kubernetes.io/instance: '{{ deployment_type }}-storage-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-api/templates/pulp-server.secret.yaml.j2
+++ b/roles/pulp-api/templates/pulp-server.secret.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ ansible_operator_meta.name }}-server"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
 stringData:
   settings.py: |
     {% for setting, value in pulp_combined_settings.items() %}

--- a/roles/pulp-content/defaults/main.yml
+++ b/roles/pulp-content/defaults/main.yml
@@ -6,6 +6,9 @@ content:
     requests:
       cpu: 200m
       memory: 512Mi
+    limits:
+      cpu: 800m
+      memory: 1Gi
 
 ingress_type: none
 is_file_storage: true

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -4,12 +4,17 @@ kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-content"
   namespace: "{{ ansible_operator_meta.namespace }}"
+  annotations:
+    email: pulp-dev@redhat.com
+    ignore-check.kube-linter.io/no-liveness-probe: "Temporarily disabled"
+    ignore-check.kube-linter.io/no-readiness-probe: "Temporarily disabled"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-content'
     app.kubernetes.io/instance: '{{ deployment_type }}-content-{{ ansible_operator_meta.name }}'
     app.kubernetes.io/component: content-server
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    owner: pulp-dev
 spec:
   replicas: {{ content.replicas }}
   selector:
@@ -59,6 +64,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ ansible_operator_meta.name }}-file-storage
 {% endif %}
+      serviceAccountName: pulp-operator-sa
       containers:
         - name: content
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-content"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-content'
     app.kubernetes.io/instance: '{{ deployment_type }}-content-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-content/templates/pulp-content.service.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.service.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ ansible_operator_meta.name }}-content-svc"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-content'
     app.kubernetes.io/instance: '{{ deployment_type }}-content-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-resource-manager/defaults/main.yml
+++ b/roles/pulp-resource-manager/defaults/main.yml
@@ -7,5 +7,8 @@ resource_manager:
     requests:
       cpu: 200m
       memory: 512Mi
+    limits:
+      cpu: 800m
+      memory: 1Gi
 
 is_file_storage: true

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-resource-manager"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-resource-manager'
     app.kubernetes.io/instance: '{{ deployment_type }}-resource-manager-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -4,12 +4,17 @@ kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-resource-manager"
   namespace: "{{ ansible_operator_meta.namespace }}"
+  annotations:
+    email: pulp-dev@redhat.com
+    ignore-check.kube-linter.io/no-liveness-probe: "Port isn't exposed"
+    ignore-check.kube-linter.io/no-readiness-probe: "Port isn't exposed"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-resource-manager'
     app.kubernetes.io/instance: '{{ deployment_type }}-resource-manager-{{ ansible_operator_meta.name }}'
     app.kubernetes.io/component: resource-manager
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    owner: pulp-dev
 spec:
   replicas: {{ resource_manager.replicas }}
   selector:
@@ -62,6 +67,7 @@ spec:
         - name: tmp-file-storage
           emptyDir: {}
 {% endif %}
+      serviceAccountName: pulp-operator-sa
       containers:
         - name: resource-manager
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"

--- a/roles/pulp-web/defaults/main.yml
+++ b/roles/pulp-web/defaults/main.yml
@@ -5,6 +5,9 @@ web:
     requests:
       cpu: 200m
       memory: 512Mi
+    limits:
+      cpu: 800m
+      memory: 1Gi
 
 ingress_type: none
 

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-web"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: 'nginx'
     app.kubernetes.io/instance: 'nginx-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -4,12 +4,15 @@ kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-web"
   namespace: "{{ ansible_operator_meta.namespace }}"
+  annotations:
+    email: pulp-dev@redhat.com
   labels:
     app.kubernetes.io/name: 'nginx'
     app.kubernetes.io/instance: 'nginx-{{ ansible_operator_meta.name }}'
     app.kubernetes.io/component: webserver
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    owner: pulp-dev
 spec:
   replicas: {{ web.replicas }}
   selector:
@@ -36,6 +39,7 @@ spec:
       affinity:
         nodeAffinity: {{ affinity.node_affinity }}
 {% endif %}
+      serviceAccountName: pulp-operator-sa
       containers:
         - name: web
           image: "{{ registry }}/{{ project }}/{{ image_web }}:{{ tag }}"

--- a/roles/pulp-web/templates/pulp-web.service.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.service.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ ansible_operator_meta.name }}-web-svc"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: 'nginx'
     app.kubernetes.io/instance: 'nginx-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-worker/defaults/main.yml
+++ b/roles/pulp-worker/defaults/main.yml
@@ -7,5 +7,8 @@ worker:
     requests:
       cpu: 200m
       memory: 512Mi
+    limits:
+      cpu: 800m
+      memory: 1Gi
 
 is_file_storage: true

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-worker"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-worker'
     app.kubernetes.io/instance: '{{ deployment_type }}-worker-{{ ansible_operator_meta.name }}'

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -4,12 +4,17 @@ kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-worker"
   namespace: "{{ ansible_operator_meta.namespace }}"
+  annotations:
+    email: pulp-dev@redhat.com
+    ignore-check.kube-linter.io/no-liveness-probe: "Port isn't exposed"
+    ignore-check.kube-linter.io/no-readiness-probe: "Port isn't exposed"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-worker'
     app.kubernetes.io/instance: '{{ deployment_type }}-worker-{{ ansible_operator_meta.name }}'
     app.kubernetes.io/component: worker
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    owner: pulp-dev
 spec:
   replicas: {{ worker.replicas }}
   selector:
@@ -64,6 +69,7 @@ spec:
 {% endif %}
         - name: {{ ansible_operator_meta.name }}-ansible-tmp
           emptyDir: {}
+      serviceAccountName: pulp-operator-sa
       containers:
         - name: worker
           image: "{{ registry }}/{{ project }}/{{ image }}:{{ tag }}"

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -4,12 +4,17 @@ kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-redis"
   namespace: "{{ ansible_operator_meta.namespace }}"
+  annotations: # About kube-linter checks: https://docs.kubelinter.io/#/generated/checks
+    email: pulp-dev@redhat.com
+    ignore-check.kube-linter.io/unset-cpu-requirements: "Temporarily disabled"
+    ignore-check.kube-linter.io/unset-memory-requirements: "Temporarily disabled"
   labels:
     app.kubernetes.io/name: 'redis'
     app.kubernetes.io/instance: 'redis-{{ ansible_operator_meta.name }}'
     app.kubernetes.io/component: cache
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    owner: pulp-dev
 spec:
   replicas: 1
   selector:
@@ -36,6 +41,7 @@ spec:
       affinity:
         nodeAffinity: {{ affinity.node_affinity }}
 {% endif %}
+      serviceAccountName: pulp-operator-sa
       containers:
         - name: redis
           image: "{{ redis_image }}"
@@ -47,6 +53,32 @@ spec:
           ports:
             - protocol: TCP
               containerPort: 6379
+          livenessProbe:
+            enabled: true
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 5
+            successThreshold: 1
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - redis-cli -h 127.0.0.1 -p 6379
+          readinessProbe:
+            enabled: true
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 5
+            successThreshold: 1
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - redis-cli -h 127.0.0.1 -p 6379
 {% if redis_resource_requirements is defined %}
           resources: {{ redis_resource_requirements }}
 {% endif %}

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-redis"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: 'redis'
     app.kubernetes.io/instance: 'redis-{{ ansible_operator_meta.name }}'

--- a/roles/redis/templates/redis.pvc.yaml.j2
+++ b/roles/redis/templates/redis.pvc.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: '{{ ansible_operator_meta.name }}-redis-data'
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: 'redis'
     app.kubernetes.io/instance: 'redis-{{ ansible_operator_meta.name }}'

--- a/roles/redis/templates/redis.service.yaml.j2
+++ b/roles/redis/templates/redis.service.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ ansible_operator_meta.name }}-redis"
-  namespace: "{{ project_name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     app.kubernetes.io/name: 'redis'
     app.kubernetes.io/instance: 'redis-{{ ansible_operator_meta.name }}'

--- a/roles/restore/templates/management-pod.yaml.j2
+++ b/roles/restore/templates/management-pod.yaml.j2
@@ -4,13 +4,17 @@ kind: Pod
 metadata:
   name: {{ ansible_operator_meta.name }}-backup-manager
   namespace: {{ backup_pvc_namespace }}
+  annotations:
+    email: pulp-dev@redhat.com
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-backup-manager'
     app.kubernetes.io/instance: '{{ deployment_type }}-backup-manager-{{ ansible_operator_meta.name }}'
     app.kubernetes.io/component: backup-manager
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    owner: pulp-dev
 spec:
+  serviceAccountName: pulp-operator-sa
   containers:
   - name: {{ ansible_operator_meta.name }}-backup-manager
     image: "{{ postgres_image }}"


### PR DESCRIPTION
This PR attempts to lint all k8s objects **after** they are applied to the cluster,

Advantage: lints what is really applied to the cluster
Disadvantage: does lots of steps before linting, therefore it is slower to lint

Alternative PR: https://github.com/pulp/pulp-operator/pull/196