### PR TITLE
Clarify RWM/O check during backups

### DIFF
--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -148,7 +148,7 @@
   block:
     - name: Set error message
       set_fact:
-        error_msg: "PersistentVolumeClaim accessMode {{ pvc_access_mode }} is not supported for backup, must be ReadWriteMany."
+        error_msg: "Can not back up content volume with PersistentVolumeClaim accessMode {{ pvc_access_mode }}, must be ReadWriteMany."
 
     - name: Handle error
       import_tasks: error_handling.yml


### PR DESCRIPTION
  - backups are not supported when the pulp-content volume is
    ReadWriteMany, the backup volume can be RWO

The current wording is a bit confusing and implies that the backup volume needs to be RWM, this clarifies that it can be RWO.  