### PR TITLE
Use relatedImages to make disconnected deployments possible

### DIFF
--- a/CHANGES/232.feature
+++ b/CHANGES/232.feature
@@ -1,0 +1,1 @@
+Set RELATED_IMAGE_ vars to enable disconnected deployments

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,7 +49,16 @@ spec:
               value: explicit
             - name: ANSIBLE_DEBUG_LOGS
               value: 'false'
+            - name: RELATED_IMAGE_APP
+              value: quay.io/pulp/pulp:stable
+            - name: RELATED_IMAGE_APP_WEB
+              value: quay.io/pulp/pulp-web:stable
+            - name: RELATED_IMAGE_REDIS
+              value: redis:latest
+            - name: RELATED_IMAGE_POSTGRES
+              value: postgres:12
           image: controller:latest
+          imagePullPolicy: Always
           resources:
             limits:
               cpu: 800m

--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -170,6 +170,16 @@
     - pvc_access_mode is defined
     - pvc_access_mode | lower != "readwritemany"
 
+- name: Set user provided postgres image
+  set_fact:
+    _custom_postgres_image: "{{ postgres_image }}"
+  when:
+    - postgres_image is defined
+
+- name: Set Postgres image URL
+  set_fact:
+    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_POSTGRES')) }}"
+
 - name: Create management pod from templated deployment config
   k8s:
     state: present

--- a/roles/backup/templates/management-pod.yaml.j2
+++ b/roles/backup/templates/management-pod.yaml.j2
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
   - name: {{ ansible_operator_meta.name }}-backup-manager
-    image: "{{ postgres_image }}"
+    image: "{{ _postgres_image }}"
     imagePullPolicy: Always
     command: ["sleep", "infinity"]
     volumeMounts:

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -86,6 +86,16 @@
     postgres_resource_requirements: "{{ postgres_resource_requirements|combine(postgres_default_storage, recursive=True) }}"
   when: postgres_resource_requirements.requests is undefined or postgres_resource_requirements.requests.storage is undefined
 
+- name: Set user provided postgres image
+  set_fact:
+    _custom_postgres_image: "{{ postgres_image }}"
+  when:
+    - postgres_image is defined
+
+- name: Set Postgres image URL
+  set_fact:
+    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_POSTGRES')) }}"
+
 - name: Create Database if no database is specified
   k8s:
     apply: true

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -51,7 +51,7 @@ spec:
 {% endif %}
       serviceAccountName: pulp-operator-sa
       containers:
-        - image: '{{ postgres_image }}'
+        - image: '{{ _postgres_image }}'
           name: postgres
           env:
             # For postgres_image based on rhel8/postgresql-12

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -125,6 +125,17 @@
   - not is_openshift
   - not is_k8s
 
+- name: Set user provided pulp-api image
+  set_fact:
+    _custom_image: "{{ image }}:{{ image_version }}"
+  when:
+    - image is defined
+    - image_version is defined
+
+- name: Set pulp-api image URL
+  set_fact:
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_APP')) }}"
+
 - name: pulp-api deployment
   k8s:
     state: "{{ deployment_state }}"

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -86,7 +86,7 @@ spec:
       serviceAccountName: pulp-operator-sa
       containers:
         - name: api
-          image: "{{ image }}"
+          image: "{{ _image }}"
           imagePullPolicy: "{{ image_pull_policy }}"
           # We set args, not command, so as to not override the entrypoint script
           args: ["pulp-api"]

--- a/roles/pulp-content/tasks/main.yml
+++ b/roles/pulp-content/tasks/main.yml
@@ -6,6 +6,17 @@
   with_items:
     - pulp-content
 
+- name: Set user provided pulp-content image
+  set_fact:
+    _custom_image: "{{ image }}:{{ image_version }}"
+  when:
+    - image is defined
+    - image_version is defined
+
+- name: Set pulp-content image URL
+  set_fact:
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_APP')) }}"
+
 - name: pulp-content deployment
   k8s:
     state: "{{ deployment_state }}"

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -67,7 +67,7 @@ spec:
       serviceAccountName: pulp-operator-sa
       containers:
         - name: content
-          image: "{{ image }}"
+          image: "{{ _image }}"
           imagePullPolicy: "{{ image_pull_policy }}"
           # We set args, not command, so as to not override the entrypoint script
           args: ["pulp-content"]

--- a/roles/pulp-resource-manager/tasks/main.yml
+++ b/roles/pulp-resource-manager/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Set user provided pulp-resource-manager image
+  set_fact:
+    _custom_image: "{{ image }}:{{ image_version }}"
+  when:
+    - image is defined
+    - image_version is defined
+
+- name: Set pulp-resource-manager image URL
+  set_fact:
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_APP')) }}"
+
 - name: pulp-resource-manager deployment
   k8s:
     state: "{{ deployment_state }}"

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -70,7 +70,7 @@ spec:
       serviceAccountName: pulp-operator-sa
       containers:
         - name: resource-manager
-          image: "{{ image }}"
+          image: "{{ _image }}"
           imagePullPolicy: "{{ image_pull_policy }}"
           # We set args, not command, so as to not override the entrypoint script
           args: ["pulp-resource-manager"]

--- a/roles/pulp-web/tasks/main.yml
+++ b/roles/pulp-web/tasks/main.yml
@@ -13,6 +13,18 @@
   with_items:
     - pulp-web
 
+- name: Set user provided pulp-web image
+  set_fact:
+    _custom_image_web: "{{ image_web }}:{{ image_web_version }}"
+  when:
+    - image_web is defined
+    - image_web_version is defined
+
+- name: Set pulp-api image URL
+  set_fact:
+    _image_web: "{{ _custom_image_web | default(lookup('env', 'RELATED_IMAGE_APP_WEB')) }}"
+
+
 - name: pulp-web deployment
   k8s:
     state: "{{ deployment_state }}"

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -42,7 +42,7 @@ spec:
       serviceAccountName: pulp-operator-sa
       containers:
         - name: web
-          image: "{{ image_web }}"
+          image: "{{ _image_web }}"
           imagePullPolicy: "{{ image_pull_policy }}"
 {% if ingress_type | lower == 'nodeport' %}
           env:

--- a/roles/pulp-worker/tasks/main.yml
+++ b/roles/pulp-worker/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Set user provided pulp-worker image
+  set_fact:
+    _custom_image: "{{ image }}:{{ image_version }}"
+  when:
+    - image is defined
+    - image_version is defined
+
+- name: Set pulp-worker image URL
+  set_fact:
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_APP')) }}"
+
 - name: pulp-worker deployment
   k8s:
     state: "{{ deployment_state }}"

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: pulp-operator-sa
       containers:
         - name: worker
-          image: "{{ image }}"
+          image: "{{ _image }}"
           imagePullPolicy: "{{ image_pull_policy }}"
           # We set args, not command, so as to not override the entrypoint script
           args: ["pulp-worker"]

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -13,6 +13,16 @@
   with_items:
     - redis
 
+- name: Set user provided redis image
+  set_fact:
+    _custom_redis_image: "{{ redis_image }}"
+  when:
+    - redis_image is defined
+
+- name: Set Redis image URL
+  set_fact:
+    _redis_image: "{{ _custom_redis_image | default(lookup('env', 'RELATED_IMAGE_REDIS')) }}"
+
 - name: redis deployment
   k8s:
     state: "{{ deployment_state }}"

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -44,7 +44,7 @@ spec:
       serviceAccountName: pulp-operator-sa
       containers:
         - name: redis
-          image: "{{ redis_image }}"
+          image: "{{ _redis_image }}"
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - readOnly: false

--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -128,6 +128,16 @@
     force: true
     wait: true
 
+- name: Set user provided postgres image
+  set_fact:
+    _custom_postgres_image: "{{ postgres_image }}"
+  when:
+    - postgres_image is defined
+
+- name: Set Postgres image URL
+  set_fact:
+    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_POSTGRES')) }}"
+
 - name: Create management pod from templated deployment config
   k8s:
     state: present

--- a/roles/restore/templates/management-pod.yaml.j2
+++ b/roles/restore/templates/management-pod.yaml.j2
@@ -17,8 +17,7 @@ spec:
   serviceAccountName: pulp-operator-sa
   containers:
   - name: {{ ansible_operator_meta.name }}-backup-manager
-    image: "{{ postgres_image }}"
-    imagePullPolicy: Always
+    image: "{{ _postgres_image }}"
     command: ["sleep", "infinity"]
     volumeMounts:
     - name: {{ ansible_operator_meta.name }}-backup


### PR DESCRIPTION
   * Add ability to pass images in from the CSV for disconnected installs

[closes #232]

Related: https://github.com/pulp/pulp-operator/issues/232

Signed-off-by: Christian M. Adams <chadams@redhat.com>