### PR TITLE
Add Related Images to CSVs & check for empty image specs

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -806,6 +806,14 @@ spec:
                   value: explicit
                 - name: ANSIBLE_DEBUG_LOGS
                   value: "false"
+                - name: RELATED_IMAGE_APP
+                  value: quay.io/pulp/pulp:stable
+                - name: RELATED_IMAGE_APP_WEB
+                  value: quay.io/pulp/pulp-web:stable
+                - name: RELATED_IMAGE_REDIS
+                  value: redis:latest
+                - name: RELATED_IMAGE_POSTGRES
+                  value: postgres:12
                 image: quay.io/pulp/pulp-operator:v0.5.0.dev
                 livenessProbe:
                   httpGet:

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -748,6 +748,14 @@ spec:
                   value: explicit
                 - name: ANSIBLE_DEBUG_LOGS
                   value: "false"
+                - name: RELATED_IMAGE_APP
+                  value: quay.io/pulp/pulp:stable
+                - name: RELATED_IMAGE_APP_WEB
+                  value: quay.io/pulp/pulp-web:stable
+                - name: RELATED_IMAGE_REDIS
+                  value: redis:latest
+                - name: RELATED_IMAGE_POSTGRES
+                  value: postgres:12
                 image: quay.io/pulp/pulp-operator:devel
                 name: pulp-manager
                 resources: {}

--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -174,7 +174,7 @@
   set_fact:
     _custom_postgres_image: "{{ postgres_image }}"
   when:
-    - postgres_image is defined
+    - postgres_image is defined and postgres_image != ''
 
 - name: Set Postgres image URL
   set_fact:

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -90,7 +90,7 @@
   set_fact:
     _custom_postgres_image: "{{ postgres_image }}"
   when:
-    - postgres_image is defined
+    - postgres_image is defined and postgres_image != ''
 
 - name: Set Postgres image URL
   set_fact:

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -129,8 +129,8 @@
   set_fact:
     _custom_image: "{{ image }}:{{ image_version }}"
   when:
-    - image is defined
-    - image_version is defined
+    - image is defined and image != ''
+    - image_version is defined and image_version != ''
 
 - name: Set pulp-api image URL
   set_fact:

--- a/roles/pulp-content/tasks/main.yml
+++ b/roles/pulp-content/tasks/main.yml
@@ -10,8 +10,8 @@
   set_fact:
     _custom_image: "{{ image }}:{{ image_version }}"
   when:
-    - image is defined
-    - image_version is defined
+    - image is defined and image != ''
+    - image_version is defined and image_version != ''
 
 - name: Set pulp-content image URL
   set_fact:

--- a/roles/pulp-resource-manager/tasks/main.yml
+++ b/roles/pulp-resource-manager/tasks/main.yml
@@ -3,8 +3,8 @@
   set_fact:
     _custom_image: "{{ image }}:{{ image_version }}"
   when:
-    - image is defined
-    - image_version is defined
+    - image is defined and image != ''
+    - image_version is defined and image_version != ''
 
 - name: Set pulp-resource-manager image URL
   set_fact:

--- a/roles/pulp-web/tasks/main.yml
+++ b/roles/pulp-web/tasks/main.yml
@@ -17,7 +17,7 @@
   set_fact:
     _custom_image_web: "{{ image_web }}:{{ image_web_version }}"
   when:
-    - image_web is defined
+    - image_web is defined and image_web != ''
     - image_web_version is defined
 
 - name: Set pulp-api image URL

--- a/roles/pulp-worker/tasks/main.yml
+++ b/roles/pulp-worker/tasks/main.yml
@@ -3,8 +3,8 @@
   set_fact:
     _custom_image: "{{ image }}:{{ image_version }}"
   when:
-    - image is defined
-    - image_version is defined
+    - image is defined and image != ''
+    - image_version is defined and image_version != ''
 
 - name: Set pulp-worker image URL
   set_fact:

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -17,7 +17,7 @@
   set_fact:
     _custom_redis_image: "{{ redis_image }}"
   when:
-    - redis_image is defined
+    - redis_image is defined and redis_image != ''
 
 - name: Set Redis image URL
   set_fact:

--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -132,7 +132,7 @@
   set_fact:
     _custom_postgres_image: "{{ postgres_image }}"
   when:
-    - postgres_image is defined
+    - postgres_image is defined and postgres_image != ''
 
 - name: Set Postgres image URL
   set_fact:


### PR DESCRIPTION
As the CSV is maintained in the repo for the pulp-operator, these variables need to be added to the CSV.  I also added them to the base CSV so that future CSV's will be created with these `RELATED_IMAGES_` variables.  

Follow-up for https://github.com/pulp/pulp-operator/pull/233

I also added some defensive checks to make sure that users don't set image names/versions as empty strings (which would just error).  



[noissue]

Signed-off-by: Christian M. Adams <chadams@redhat.com>
