### PR TITLE
Set default images, but use them as a last resort

### DIFF
--- a/playbooks/pulp.yml
+++ b/playbooks/pulp.yml
@@ -24,10 +24,10 @@
       GALAXY_FEATURE_FLAGS:
         execution_environments: ""
     deployment_state: present
-    image: quay.io/pulp/pulp
-    image_version: stable
-    image_web: quay.io/pulp/pulp-web
-    image_web_version: stable
+    _image: quay.io/pulp/pulp
+    _image_version: stable
+    _image_web: quay.io/pulp/pulp-web
+    _image_web_version: stable
     image_pull_policy: IfNotPresent
     image_pull_secret: ""
     storage_type: File

--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -172,13 +172,13 @@
 
 - name: Set user provided postgres image
   set_fact:
-    _custom_postgres_image: "{{ postgres_image }}"
+    _custom_postgres_image: "{{ _postgres_image }}"
   when:
     - postgres_image is defined and postgres_image != ''
 
 - name: Set Postgres image URL
   set_fact:
-    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) }}"
+    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) | default(_postgres_image) }}"
 
 - name: Create management pod from templated deployment config
   k8s:

--- a/roles/backup/vars/main.yml
+++ b/roles/backup/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 
 deployment_type: "pulp"
-postgres_image: postgres:12
+_postgres_image: postgres:12

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -2,7 +2,7 @@
 deployment_type: pulp
 
 postgres_version: 12
-postgres_image: postgres:12
+_postgres_image: postgres:12
 postgres_default_storage:
   requests:
     storage: 8Gi

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -88,13 +88,13 @@
 
 - name: Set user provided postgres image
   set_fact:
-    _custom_postgres_image: "{{ postgres_image }}"
+    _custom_postgres_image: "{{ _postgres_image }}"
   when:
     - postgres_image is defined and postgres_image != ''
 
 - name: Set Postgres image URL
   set_fact:
-    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) }}"
+    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) | default(_postgres_image) }}"
 
 - name: Create Database if no database is specified
   k8s:

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -125,6 +125,10 @@
   - not is_openshift
   - not is_k8s
 
+- name: Set default pulp-api image
+  set_fact:
+    _default_image: "{{ _image }}:{{ _image_version }}"
+
 - name: Set user provided pulp-api image
   set_fact:
     _custom_image: "{{ image }}:{{ image_version }}"
@@ -134,7 +138,7 @@
 
 - name: Set pulp-api image URL
   set_fact:
-    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) }}"
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image) }}"
 
 - name: pulp-api deployment
   k8s:

--- a/roles/pulp-content/tasks/main.yml
+++ b/roles/pulp-content/tasks/main.yml
@@ -6,6 +6,10 @@
   with_items:
     - pulp-content
 
+- name: Set default pulp-content image
+  set_fact:
+    _default_image: "{{ _image }}:{{ _image_version }}"
+
 - name: Set user provided pulp-content image
   set_fact:
     _custom_image: "{{ image }}:{{ image_version }}"
@@ -15,7 +19,7 @@
 
 - name: Set pulp-content image URL
   set_fact:
-    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) }}"
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image) }}"
 
 - name: pulp-content deployment
   k8s:

--- a/roles/pulp-resource-manager/tasks/main.yml
+++ b/roles/pulp-resource-manager/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+
+- name: Set default pulp-resource-manager image
+  set_fact:
+    _default_image: "{{ _image }}:{{ _image_version }}"
+
 - name: Set user provided pulp-resource-manager image
   set_fact:
     _custom_image: "{{ image }}:{{ image_version }}"
@@ -8,7 +13,7 @@
 
 - name: Set pulp-resource-manager image URL
   set_fact:
-    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) }}"
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image) }}"
 
 - name: pulp-resource-manager deployment
   k8s:

--- a/roles/pulp-web/tasks/main.yml
+++ b/roles/pulp-web/tasks/main.yml
@@ -13,6 +13,10 @@
   with_items:
     - pulp-web
 
+- name: Set default pulp-web image
+  set_fact:
+    _default_image_web: "{{ _image_web }}:{{ _image_web_version }}"
+
 - name: Set user provided pulp-web image
   set_fact:
     _custom_image_web: "{{ image_web }}:{{ image_web_version }}"
@@ -22,7 +26,7 @@
 
 - name: Set pulp-web image URL
   set_fact:
-    _image_web: "{{ _custom_image_web | default(lookup('env', 'RELATED_IMAGE_PULP_WEB')) }}"
+    _image_web: "{{ _custom_image_web | default(lookup('env', 'RELATED_IMAGE_PULP_WEB')) | default(_default_image_web) }}"
 
 - name: pulp-web deployment
   k8s:

--- a/roles/pulp-worker/tasks/main.yml
+++ b/roles/pulp-worker/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+
+- name: Set default pulp-worker image
+  set_fact:
+    _default_image: "{{ _image }}:{{ _image_version }}"
+
 - name: Set user provided pulp-worker image
   set_fact:
     _custom_image: "{{ image }}:{{ image_version }}"
@@ -8,7 +13,7 @@
 
 - name: Set pulp-worker image URL
   set_fact:
-    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) }}"
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image) }}"
 
 - name: pulp-worker deployment
   k8s:

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-redis_image: redis:latest
+_redis_image: redis:latest
 
 redis_resource_requirements:
   requests:

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: Set Redis image URL
   set_fact:
-    _redis_image: "{{ _custom_redis_image | default(lookup('env', 'RELATED_IMAGE_PULP_REDIS')) }}"
+    _redis_image: "{{ _custom_redis_image | default(lookup('env', 'RELATED_IMAGE_PULP_REDIS')) | default(_redis_image) }}"
 
 - name: redis deployment
   k8s:

--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -136,7 +136,7 @@
 
 - name: Set Postgres image URL
   set_fact:
-    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) }}"
+    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) | default(_postgres_image) }}"
 
 - name: Create management pod from templated deployment config
   k8s:

--- a/roles/restore/vars/main.yml
+++ b/roles/restore/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 
 deployment_type: "pulp"
-postgres_image: postgres:12
+_postgres_image: postgres:12
 
 custom_resource_key: '_pulp_pulpproject_org_pulprestore'
 


### PR DESCRIPTION
Related awx-operator PR: https://github.com/ansible/awx-operator/pull/624

* Only use them if user did not set an image, or RELATED_IMAGES_ var
  is not set

Part of the rationale for adding this in instead of just removing the defaults is that it it prevents someone from accidentally breaking disconnected deployment support by adding in default image values later on.

Signed-off-by: Christian M. Adams <chadams@redhat.com>
