### PR TITLE
Use the default value when variables evaluate to an empty string

### DIFF
--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -178,7 +178,7 @@
 
 - name: Set Postgres image URL
   set_fact:
-    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) | default(_postgres_image) }}"
+    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) | default(_postgres_image, true) }}"
 
 - name: Create management pod from templated deployment config
   k8s:

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -94,7 +94,7 @@
 
 - name: Set Postgres image URL
   set_fact:
-    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) | default(_postgres_image) }}"
+    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) | default(_postgres_image, true) }}"
 
 - name: Create Database if no database is specified
   k8s:

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -138,7 +138,7 @@
 
 - name: Set pulp-api image URL
   set_fact:
-    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image) }}"
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image, true) }}"
 
 - name: pulp-api deployment
   k8s:

--- a/roles/pulp-content/tasks/main.yml
+++ b/roles/pulp-content/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Set pulp-content image URL
   set_fact:
-    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image) }}"
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image, true) }}"
 
 - name: pulp-content deployment
   k8s:

--- a/roles/pulp-resource-manager/tasks/main.yml
+++ b/roles/pulp-resource-manager/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Set pulp-resource-manager image URL
   set_fact:
-    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image) }}"
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image, true) }}"
 
 - name: pulp-resource-manager deployment
   k8s:

--- a/roles/pulp-web/tasks/main.yml
+++ b/roles/pulp-web/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - name: Set pulp-web image URL
   set_fact:
-    _image_web: "{{ _custom_image_web | default(lookup('env', 'RELATED_IMAGE_PULP_WEB')) | default(_default_image_web) }}"
+    _image_web: "{{ _custom_image_web | default(lookup('env', 'RELATED_IMAGE_PULP_WEB')) | default(_default_image_web, true) }}"
 
 - name: pulp-web deployment
   k8s:

--- a/roles/pulp-worker/tasks/main.yml
+++ b/roles/pulp-worker/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Set pulp-worker image URL
   set_fact:
-    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image) }}"
+    _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image, true) }}"
 
 - name: pulp-worker deployment
   k8s:

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: Set Redis image URL
   set_fact:
-    _redis_image: "{{ _custom_redis_image | default(lookup('env', 'RELATED_IMAGE_PULP_REDIS')) | default(_redis_image) }}"
+    _redis_image: "{{ _custom_redis_image | default(lookup('env', 'RELATED_IMAGE_PULP_REDIS')) | default(_redis_image, true) }}"
 
 - name: redis deployment
   k8s:

--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -136,7 +136,7 @@
 
 - name: Set Postgres image URL
   set_fact:
-    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) | default(_postgres_image) }}"
+    _postgres_image: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) | default(_postgres_image, true) }}"
 
 - name: Create management pod from templated deployment config
   k8s:


### PR DESCRIPTION
If custom image is not provided, and environment variable is not
provided, it ends up defaulting to '' in current state.

This commit fixes that.

[noissue]

https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#providing-default-values


Reproducer:

```
---
- hosts: localhost
  gather_facts: false
  vars:
    _postgres_image: foo
  tasks:
    - debug:
        msg: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) | default(_postgres_image) }}"

    - debug:
        msg: "{{ _custom_postgres_image | default(lookup('env', 'RELATED_IMAGE_PULP_POSTGRES')) | default(_postgres_image, true) }}"
```

Output

```
PLAY [localhost] ************************************************************************************************************************

TASK [debug] ****************************************************************************************************************************
ok: [localhost] => 
  msg: ''

TASK [debug] ****************************************************************************************************************************
ok: [localhost] => 
  msg: foo

PLAY RECAP ******************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```