### PR TITLE
container-assets: Fix wrong bash syntax

### DIFF
--- a/containers/images/pulp/container-assets/pulp-resource-manager
+++ b/containers/images/pulp/container-assets/pulp-resource-manager
@@ -9,6 +9,6 @@ echo $NEW_TASKING_SYSTEM
 if [[ "$NEW_TASKING_SYSTEM" == "no" ]]; then
     exec rq worker --url "redis://${REDIS_SERVICE_HOST}:${REDIS_SERVICE_PORT}" -n "resource-manager" -w "pulpcore.tasking.worker.PulpWorker" -c "pulpcore.rqconfig"
 else
-    export PATH /usr/local/bin:/usr/bin/
+    export PATH=/usr/local/bin:/usr/bin/
     /usr/local/bin/pulpcore-worker --resource-manager
 fi

--- a/containers/images/pulp/container-assets/pulp-worker
+++ b/containers/images/pulp/container-assets/pulp-worker
@@ -11,6 +11,6 @@ if [[ "$NEW_TASKING_SYSTEM" == "no" ]]; then
     # In the meantime, the hostname provides uniqueness.
     exec rq worker --url "redis://${REDIS_SERVICE_HOST}:${REDIS_SERVICE_PORT}" -w "pulpcore.tasking.worker.PulpWorker" -c "pulpcore.rqconfig"
 else
-    export PATH /usr/local/bin:/usr/bin/
+    export PATH=/usr/local/bin:/usr/bin/
     /usr/local/bin/pulpcore-worker
 fi


### PR DESCRIPTION
Current implementation is incorrect

```
$> export PATH /usr/local/bin:/usr/bin/
bash: export: `/usr/local/bin:/usr/bin/': not a valid identifier'`
```

[noissue]