### PR TITLE
Split postgres resource and storage values into different vars

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -188,7 +188,8 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Back up a deployment of pulp, including all hosted Ansible content
+    - description: Back up a deployment of the pulp, including all hosted Ansible
+        content
       displayName: Pulp Backup
       kind: PulpBackup
       name: pulpbackups.pulp.pulpproject.org
@@ -375,11 +376,16 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Database resource requirements
+      - displayName: PostgreSQL container storage requirements (when using a managed
+          instance)
+        path: postgres_storage_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: PostgreSQL container resource requirements (when using a managed
+          instance)
         path: postgres_resource_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Database data path
         path: postgres_data_path
         x-descriptors:

--- a/bundle/manifests/pulp.pulpproject.org_pulps.yaml
+++ b/bundle/manifests/pulp.pulpproject.org_pulps.yaml
@@ -248,25 +248,41 @@ spec:
                   limits:
                     properties:
                       cpu:
+                        default: 1000m
                         type: string
                       memory:
-                        type: string
-                      storage:
+                        default: 8Gi
                         type: string
                     type: object
                   requests:
                     properties:
                       cpu:
+                        default: 500m
                         type: string
                       memory:
-                        type: string
-                      storage:
+                        default: 2Gi
                         type: string
                     type: object
                 type: object
               postgres_storage_class:
                 description: Storage class to use for the PostgreSQL PVC
                 type: string
+              postgres_storage_requirements:
+                description: Storage requirements for the PostgreSQL container
+                properties:
+                  limits:
+                    properties:
+                      storage:
+                        default: 50Gi
+                        type: string
+                    type: object
+                  requests:
+                    properties:
+                      storage:
+                        default: 8Gi
+                        type: string
+                    type: object
+                type: object
               pulp_settings:
                 description: The pulp settings.
                 properties:

--- a/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
+++ b/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
@@ -92,25 +92,41 @@ spec:
               postgres_image:
                 description: Registry path to the PostgreSQL container to use
                 type: string
+              postgres_storage_requirements:
+                description: Storage requirements for the PostgreSQL container
+                properties:
+                  requests:
+                    properties:
+                      storage:
+                        default: 8Gi
+                        type: string
+                    type: object
+                  limits:
+                    properties:
+                      storage:
+                        default: 50Gi
+                        type: string
+                    type: object
+                type: object
               postgres_resource_requirements:
                 description: Resource requirements for the PostgreSQL container
                 properties:
                   requests:
                     properties:
                       cpu:
+                        default: 500m
                         type: string
                       memory:
-                        type: string
-                      storage:
+                        default: 2Gi
                         type: string
                     type: object
                   limits:
                     properties:
                       cpu:
+                        default: 1000m
                         type: string
                       memory:
-                        type: string
-                      storage:
+                        default: 8Gi
                         type: string
                     type: object
                 type: object

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -88,11 +88,16 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Database resource requirements
+      - displayName: PostgreSQL container storage requirements (when using a managed
+          instance)
+        path: postgres_storage_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: PostgreSQL container resource requirements (when using a managed
+          instance)
         path: postgres_resource_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - displayName: Database data path
         path: postgres_data_path
         x-descriptors:
@@ -403,7 +408,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
       version: v1beta1
-    - description: Back up a deployment of the pulp, including all hosted Ansible content
+    - description: Back up a deployment of the pulp, including all hosted Ansible
+        content
       displayName: Pulp Backup
       kind: PulpBackup
       name: pulpbackups.pulp.pulpproject.org

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -3,7 +3,8 @@ deployment_type: pulp
 
 postgres_version: 12
 _postgres_image: postgres:12
-postgres_default_storage:
+
+postgres_storage_requirements:
   requests:
     storage: 8Gi
 postgres_resource_requirements: {}

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -81,11 +81,6 @@
     pg_config: '{{ _generated_pg_config_resources["resources"] | default([]) | length | ternary(_generated_pg_config_resources, _pg_config) }}'
   no_log: true
 
-- name: Ensure storage request is set
-  set_fact:
-    postgres_resource_requirements: "{{ postgres_resource_requirements|combine(postgres_default_storage, recursive=True) }}"
-  when: postgres_resource_requirements.requests is undefined or postgres_resource_requirements.requests.storage is undefined
-
 - name: Set user provided postgres image
   set_fact:
     _custom_postgres_image: "{{ postgres_image }}"

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -126,6 +126,7 @@ spec:
             - name: postgres
               mountPath: '{{ postgres_data_path | dirname }}'
               subPath: '{{ postgres_data_path | dirname | basename }}'
+          resources: {{ postgres_resource_requirements }}
   volumeClaimTemplates:
     - metadata:
         name: postgres
@@ -135,7 +136,7 @@ spec:
 {% if postgres_storage_class is defined %}
         storageClassName: '{{ postgres_storage_class }}'
 {% endif %}
-        resources: {{ postgres_resource_requirements }}
+        resources: {{ postgres_storage_requirements }}
 
 # Postgres Service.
 ---


### PR DESCRIPTION
The pvc storage size is specified separately from the pod cpu & memory.  I also changed how this shows up in the OLM form so that unneeded fields from the resourceRequirements descriptor are not shown.  

![image](https://user-images.githubusercontent.com/11698892/143385311-4430e787-f874-43f3-86af-50d746ab54c8.png)

Signed-off-by: Christian M. Adams <chadams@redhat.com>

