### PR TITLE
use content_origin if defined for social_auth_login_redirect_url

### DIFF
--- a/roles/pulp-api/tasks/sso-configuration.yml
+++ b/roles/pulp-api/tasks/sso-configuration.yml
@@ -187,7 +187,7 @@
           social_auth_keycloak_key: "{{ social_auth_keycloak_key }}"
           social_auth_keycloak_secret: "{{ social_auth_keycloak_secret }}"
           social_auth_keycloak_public_key: "{{ social_auth_keycloak_public_key }}"
-          social_auth_login_redirect_url: "{{ social_auth_login_redirect_url | default(omit) }}"
+          social_auth_login_redirect_url: "{{ social_auth_login_redirect_url | default( content_origin | default(omit)) }}"
           keycloak_host: "{{ keycloak_host }}"
           keycloak_port: "{{ keycloak_port }}"
           keycloak_protocol: "{{ keycloak_protocol }}"


### PR DESCRIPTION
[noissue]

Signed-off-by: Julen Landa Alustiza <jlanda@redhat.com>

Even when the ingress is using `https` we get a `http` `redirect_uri` parameter while we are redirected to sso. This should workaround this since `content_origin` contains the real url on the ingress
