### PR TITLE
Force https redirects while using SSO

### DIFF
--- a/roles/pulp-api/tasks/sso-configuration.yml
+++ b/roles/pulp-api/tasks/sso-configuration.yml
@@ -188,6 +188,7 @@
           social_auth_keycloak_secret: "{{ social_auth_keycloak_secret }}"
           social_auth_keycloak_public_key: "{{ social_auth_keycloak_public_key }}"
           social_auth_login_redirect_url: "{{ social_auth_login_redirect_url | default(omit) }}"
+          social_auth_redirect_is_https: True
           keycloak_host: "{{ keycloak_host }}"
           keycloak_port: "{{ keycloak_port }}"
           keycloak_protocol: "{{ keycloak_protocol }}"


### PR DESCRIPTION
[noissue]

Signed-off-by: Julen Landa Alustiza <jlanda@redhat.com>

We are hardcoding [https](https://github.com/pulp/pulp-operator/blob/main/roles/pulp-api/tasks/get_node_ip.yml#L5) url here, but SSO tries to build the redirect_uri using http.

From https://python-social-auth.readthedocs.io/en/latest/configuration/settings.html:
> SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
>
>    On projects behind a reverse proxy that uses HTTPS, the redirect URIs can have the wrong schema (http:// instead of https://) if the request lacks the appropriate headers, which might cause errors during the auth process. To force HTTPS in the final URIs set this setting to True

So hardcode this too during sso configuration