### PR TITLE
Raise resource limits for operator container to avoid OOMKill

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -835,8 +835,8 @@ spec:
                   periodSeconds: 10
                 resources:
                   limits:
-                    cpu: 800m
-                    memory: 256Mi
+                    cpu: 1200m
+                    memory: 2Gi
                   requests:
                     cpu: 1m
                     memory: 6Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,8 +60,8 @@ spec:
           image: controller:latest
           resources:
             limits:
-              cpu: 800m
-              memory: 256Mi
+              cpu: 1200m
+              memory: 2Gi
             requests:
               cpu: 1m
               memory: 6Mi


### PR DESCRIPTION
It appears that the memory limit of 256Mi can be easily reached in some cases. When this happens, the pulp-manager container restarts with OOMKill as the reason.  The end result to the user is that containers never come up.  This raises the limit significantly (2Gi).  Note, that this is only a limit, the operator will not actually use this much memory in most cases.  