### PR TITLE
Fix node affinity handling.

### DIFF
--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -22,3 +22,7 @@ postgres_host_auth_method: 'scram-sha-256'
 
 custom_resource_key: '_pulp_pulpproject_org_pulp'
 database_status_present: false
+
+# Here we use  _pulpproject_org_pulp to get un-modified cr
+# see: https://github.com/operator-framework/operator-sdk/issues/1770
+raw_spec: "{{ vars['_pulpproject_org_pulp']['spec'] }}"

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Set node affinity
+  set_fact:
+    _node_affinity: "{{ raw_spec['affinity']['node_affinity'] | default({}) }}"
+  when: affinity is defined and affinity.node_affinity is defined
 
 - name: Obtain custom resource information
   set_fact:

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -45,9 +45,9 @@ spec:
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}
-{% if affinity is defined and affinity.node_affinity is defined %}
+{% if _node_affinity is defined %}
       affinity:
-        nodeAffinity: {{ affinity.node_affinity }}
+        nodeAffinity: {{ _node_affinity }}
 {% endif %}
       serviceAccountName: pulp-operator-sa
       containers:

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -146,6 +146,11 @@
   set_fact:
     _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image, true) }}"
 
+- name: Set node affinity
+  set_fact:
+    _node_affinity: "{{ raw_spec['affinity']['node_affinity'] | default({}) }}"
+  when: affinity is defined and affinity.node_affinity is defined
+
 - name: pulp-api deployment
   k8s:
     state: "{{ deployment_state }}"

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -35,9 +35,9 @@ spec:
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}
-{% if affinity is defined and affinity.node_affinity is defined %}
+{% if _node_affinity is defined %}
       affinity:
-        nodeAffinity: {{ affinity.node_affinity }}
+        nodeAffinity: {{ _node_affinity }}
 {% endif %}
 {% if is_k8s %}
       securityContext:

--- a/roles/pulp-content/defaults/main.yml
+++ b/roles/pulp-content/defaults/main.yml
@@ -12,3 +12,7 @@ content:
 
 ingress_type: none
 is_file_storage: true
+
+# Here we use  _pulpproject_org_pulp to get un-modified cr
+# see: https://github.com/operator-framework/operator-sdk/issues/1770
+raw_spec: "{{ vars['_pulpproject_org_pulp']['spec'] }}"

--- a/roles/pulp-content/tasks/main.yml
+++ b/roles/pulp-content/tasks/main.yml
@@ -21,6 +21,11 @@
   set_fact:
     _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image, true) }}"
 
+- name: Set node affinity
+  set_fact:
+    _node_affinity: "{{ raw_spec['affinity']['node_affinity'] | default({}) }}"
+  when: affinity is defined and affinity.node_affinity is defined
+
 - name: pulp-content deployment
   k8s:
     state: "{{ deployment_state }}"

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -37,9 +37,9 @@ spec:
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}
-{% if affinity is defined and affinity.node_affinity is defined %}
+{% if _node_affinity is defined %}
       affinity:
-        nodeAffinity: {{ affinity.node_affinity }}
+        nodeAffinity: {{ _node_affinity }}
 {% endif %}
 {% if is_k8s %}
       securityContext:

--- a/roles/pulp-resource-manager/defaults/main.yml
+++ b/roles/pulp-resource-manager/defaults/main.yml
@@ -12,3 +12,7 @@ resource_manager:
       memory: 1Gi
 
 is_file_storage: true
+
+# Here we use  _pulpproject_org_pulp to get un-modified cr
+# see: https://github.com/operator-framework/operator-sdk/issues/1770
+raw_spec: "{{ vars['_pulpproject_org_pulp']['spec'] }}"

--- a/roles/pulp-resource-manager/tasks/main.yml
+++ b/roles/pulp-resource-manager/tasks/main.yml
@@ -15,6 +15,11 @@
   set_fact:
     _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image, true) }}"
 
+- name: Set node affinity
+  set_fact:
+    _node_affinity: "{{ raw_spec['affinity']['node_affinity'] | default({}) }}"
+  when: affinity is defined and affinity.node_affinity is defined
+
 - name: pulp-resource-manager deployment
   k8s:
     state: "{{ deployment_state }}"

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -37,9 +37,9 @@ spec:
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}
-{% if affinity is defined and affinity.node_affinity is defined %}
+{% if _node_affinity is defined %}
       affinity:
-        nodeAffinity: {{ affinity.node_affinity }}
+        nodeAffinity: {{ _node_affinity }}
 {% endif %}
 {% if is_k8s %}
       securityContext:

--- a/roles/pulp-web/defaults/main.yml
+++ b/roles/pulp-web/defaults/main.yml
@@ -37,3 +37,7 @@ pulp_webserver_static_dir: "/opt/app-root/src"
 pulp_nginx_conf_dir: "/opt/app-root/etc/nginx.d"
 # https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
 nginx_client_max_body_size: 10m
+
+# Here we use  _pulpproject_org_pulp to get un-modified cr
+# see: https://github.com/operator-framework/operator-sdk/issues/1770
+raw_spec: "{{ vars['_pulpproject_org_pulp']['spec'] }}"

--- a/roles/pulp-web/tasks/main.yml
+++ b/roles/pulp-web/tasks/main.yml
@@ -28,6 +28,11 @@
   set_fact:
     _image_web: "{{ _custom_image_web | default(lookup('env', 'RELATED_IMAGE_PULP_WEB')) | default(_default_image_web, true) }}"
 
+- name: Set node affinity
+  set_fact:
+    _node_affinity: "{{ raw_spec['affinity']['node_affinity'] | default({}) }}"
+  when: affinity is defined and affinity.node_affinity is defined
+
 - name: pulp-web deployment
   k8s:
     state: "{{ deployment_state }}"

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -35,9 +35,9 @@ spec:
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}
-{% if affinity is defined and affinity.node_affinity is defined %}
+{% if _node_affinity is defined %}
       affinity:
-        nodeAffinity: {{ affinity.node_affinity }}
+        nodeAffinity: {{ _node_affinity }}
 {% endif %}
       serviceAccountName: pulp-operator-sa
       containers:

--- a/roles/pulp-worker/defaults/main.yml
+++ b/roles/pulp-worker/defaults/main.yml
@@ -12,3 +12,7 @@ worker:
       memory: 1Gi
 
 is_file_storage: true
+
+# Here we use  _pulpproject_org_pulp to get un-modified cr
+# see: https://github.com/operator-framework/operator-sdk/issues/1770
+raw_spec: "{{ vars['_pulpproject_org_pulp']['spec'] }}"

--- a/roles/pulp-worker/tasks/main.yml
+++ b/roles/pulp-worker/tasks/main.yml
@@ -15,6 +15,11 @@
   set_fact:
     _image: "{{ _custom_image | default(lookup('env', 'RELATED_IMAGE_PULP')) | default(_default_image, true) }}"
 
+- name: Set node affinity
+  set_fact:
+    _node_affinity: "{{ raw_spec['affinity']['node_affinity'] | default({}) }}"
+  when: affinity is defined and affinity.node_affinity is defined
+
 - name: pulp-worker deployment
   k8s:
     state: "{{ deployment_state }}"

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -37,9 +37,9 @@ spec:
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}
-{% if affinity is defined and affinity.node_affinity is defined %}
+{% if _node_affinity is defined %}
       affinity:
-        nodeAffinity: {{ affinity.node_affinity }}
+        nodeAffinity: {{ _node_affinity }}
 {% endif %}
 {% if is_k8s %}
       securityContext:

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -5,3 +5,7 @@ redis_resource_requirements:
   requests:
     cpu: 200m
     memory: 512Mi
+
+# Here we use  _pulpproject_org_pulp to get un-modified cr
+# see: https://github.com/operator-framework/operator-sdk/issues/1770
+raw_spec: "{{ vars['_pulpproject_org_pulp']['spec'] }}"

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -23,6 +23,11 @@
   set_fact:
     _redis_image: "{{ _custom_redis_image | default(lookup('env', 'RELATED_IMAGE_PULP_REDIS')) | default(_redis_image, true) }}"
 
+- name: Set node affinity
+  set_fact:
+    _node_affinity: "{{ raw_spec['affinity']['node_affinity'] | default({}) }}"
+  when: affinity is defined and affinity.node_affinity is defined
+
 - name: redis deployment
   k8s:
     state: "{{ deployment_state }}"

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -37,9 +37,9 @@ spec:
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}
-{% if affinity is defined and affinity.node_affinity is defined %}
+{% if _node_affinity is defined %}
       affinity:
-        nodeAffinity: {{ affinity.node_affinity }}
+        nodeAffinity: {{ _node_affinity }}
 {% endif %}
       serviceAccountName: pulp-operator-sa
       containers:


### PR DESCRIPTION
* Obtain affinity from raw spec data
* If affinity and node_affinity are present apply to deployments

Affected by issue: https://github.com/operator-framework/operator-sdk/issues/1770

Related to: https://github.com/pulp/pulp-operator/issues/289
[noissue]
