### PR TITLE
containers: fix nginx env var for pulp web

### DIFF
--- a/containers/images/pulp/Containerfile.web.j2
+++ b/containers/images/pulp/Containerfile.web.j2
@@ -20,7 +20,7 @@ LABEL quay.expires-after={{ quay_expire }}d
 {% if item.value.base_image_name == "galaxy" %}
 COPY --from=builder /www/data .
 {% endif %}
-COPY --from=builder /etc/nginx/pulp/*.conf "${NGINX_CONFIGURATION_PATH}"/
+COPY --from=builder /etc/nginx/pulp/*.conf "${NGINX_DEFAULT_CONFIGURATION_PATH}"/
 
 # Run script uses standard ways to run the application
 CMD nginx -g "daemon off;"


### PR DESCRIPTION
Currently the container fails to start:

```console
$ podman run --rm quay.io/pulp/pulp-web:3.16.1
nginx: [emerg] "location" directive is not allowed here in /opt/app-root/etc/nginx.d/pulp_ansible.conf:1
```

Those custom nginx config files should be present in the
/opt/app-root/etc/nginx.default.d directory instead.

NGINX_CONFIGURATION_PATH -> config under the http section.
NGINX_DEFAULT_CONF_PATH -> config under the server section.

The `location` directive should be used in the server section.

[noissue]

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>