### PR TITLE
Take into account aarch64 architecture return from uname

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ resources: kustomize ## Get pulp resources
 	$(KUSTOMIZE) build config/default > pulp_resources.yaml
 
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
-ARCH := $(shell uname -m | sed 's/x86_64/amd64/')
+ARCH := $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
 
 .PHONY: kustomize
 KUSTOMIZE = $(shell pwd)/bin/kustomize


### PR DESCRIPTION
[noissue]
Ref: https://github.com/ansible/awx-operator/pull/766

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
