### PR TITLE
Add image_pull_secret_credentials field

### DIFF
--- a/CHANGES/343.feature
+++ b/CHANGES/343.feature
@@ -1,0 +1,1 @@
+Added a new field called image_pull_secret_credentials that will be used to populate the image_pull_secret secret.

--- a/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
+++ b/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
@@ -260,7 +260,10 @@ spec:
                   - Always
                   - Never
               image_pull_secret:
-                description: The image pull secret
+                description: Name of the secret that will be created with the content of image_pull_secret_credentials
+                type: string
+              image_pull_secret_credentials:
+                description: The credentials (following the same format as .docker/config.json) that will be stored on image pull secret
                 type: string
               affinity:
                 description: Defines various deployment affinities

--- a/config/samples/pulpproject_v1beta1_pulp_cr.default.yaml
+++ b/config/samples/pulpproject_v1beta1_pulp_cr.default.yaml
@@ -6,6 +6,12 @@ metadata:
   # The registry to grab the pulp image from.
 # image: quay.io/pulp/pulp
 # image_version: stable
+
+  # The credentials to pull the images when using private registries.
+  # By default, it is not required to set this variable because the operator will pull the images from public registries.
+  # It is useful when trying to do disconnected installations or using custom images from private registries.
+# image_pull_secret_credentials: '{ "auths": { "quay.io": { "auth": "PHVzZXI+OjxwYXNzPgo="}, "docker.io" : {"auth": "PHVzZXI+OjxwYXNzPgo="}}}'
+
 # Pulp settings.
 # pulp_settings:
 #    debug: "True"

--- a/playbooks/pulp.yml
+++ b/playbooks/pulp.yml
@@ -30,12 +30,13 @@
     _image_web: quay.io/pulp/pulp-web
     _image_web_version: stable
     image_pull_policy: IfNotPresent
-    image_pull_secret: ""
+    image_pull_secret: "pulp-image-pull-secret"
     storage_type: File
     file_storage_access_mode: "ReadWriteMany"
     file_storage_size: "100Gi"
     raw_spec: "{{ vars['_pulp_pulpproject_org_pulp']['spec'] }}"
   roles:
+    - { role: common, when: image_pull_secret_credentials is defined }
     - postgres
     - pulp-web
     - pulp-routes

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -1,0 +1,30 @@
+galaxy_info:
+  author: Pulp Team
+  description: A role to setup Pulp 3 secret to pull images from private registries
+  issue_tracker_url: https://github.com/pulp/pulp-operator/issues/new
+  license: GPL-2.0-or-later
+  company: Red Hat
+  min_ansible_version: 2.9
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+    - name: Fedora
+      versions:
+        - 30
+        - 31
+        - 32
+        - 33
+    - name: EL
+      versions:
+        - 7
+        - 8
+  galaxy_tags:
+    - pulp
+    - pulpcore
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+collections:
+  - operator_sdk.util
+  - kubernetes.core

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Create the imagepullsecret secret
+  k8s:
+    apply: true
+    definition: "{{ lookup('template', 'imagePullSecret.yaml.j2') }}"

--- a/roles/common/templates/imagePullSecret.yaml.j2
+++ b/roles/common/templates/imagePullSecret.yaml.j2
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ image_pull_secret }}'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+data:
+  .dockerconfigjson: '{{ image_pull_secret_credentials|b64encode }}'

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -42,7 +42,7 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
+{% if image_pull_secret_credentials is defined %}
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
+{% if image_pull_secret_credentials is defined %}
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -34,7 +34,7 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
+{% if image_pull_secret_credentials is defined %}
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -33,7 +33,7 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
+{% if image_pull_secret_credentials is defined %}
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
+{% if image_pull_secret_credentials is defined %}
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -34,7 +34,7 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
+{% if image_pull_secret_credentials is defined %}
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -34,7 +34,7 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
+{% if image_pull_secret_credentials is defined %}
       imagePullSecrets:
         - name: {{ image_pull_secret }}
 {% endif %}


### PR DESCRIPTION
Instead of creating multiple secrets, considering that all of them will be used by the same component (pulp-operator),
this commit will create a unique secret where users will be able to populate with multiple credentials from
different registries (for example, the user can just set image_pull_secret_credentials with the contents of
.docker/config.json).

fixes: #343

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
