### PR TITLE
Allow users to provide multiple pull secrets

### DIFF
--- a/CHANGES/343.feature
+++ b/CHANGES/343.feature
@@ -1,0 +1,1 @@
+Modified image_pull_secret to allow users to provide multiple secrets.

--- a/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
+++ b/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
@@ -259,9 +259,11 @@ spec:
                   - IfNotPresent
                   - Always
                   - Never
-              image_pull_secret:
-                description: The image pull secret
-                type: string
+              image_pull_secrets:
+                description: The image pull secrets
+                type: array
+                items:
+                  type: string
               affinity:
                 description: Defines various deployment affinities
                 properties:

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -219,9 +219,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Image pull secret for container images
-        displayName: Image pull secret
-        path: image_pull_secret
+      - description: Image pull secrets for container images
+        displayName: Image pull secrets
+        path: image_pull_secrets
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:imagePullSecret

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -71,6 +71,22 @@ rules:
       - deployments/scale
     verbs:
       - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resourceNames:
+      - pulp-operator-sa
+    resources:
+      - serviceaccounts
+    verbs:
+      - patch
+      - get
   ##
   ## Rules for pulp.pulpproject.org/v1beta1, Kind: Pulp
   ##

--- a/docs/roles/common.md
+++ b/docs/roles/common.md
@@ -1,0 +1,1 @@
+../../roles/common/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
   - Custom Resources:
       - Pulp:
         - API: roles/pulp-api.md
+        - Common: roles/common.md
         - Content: roles/pulp-content.md
         - Routes: roles/pulp-routes.md
         - Worker: roles/pulp-worker.md

--- a/molecule/default/tasks/pulp_test.yml
+++ b/molecule/default/tasks/pulp_test.yml
@@ -7,6 +7,43 @@
   vars:
     cr_file: 'pulpproject_v1beta1_pulp_cr.molecule.ci.yaml'
 
+- name: Create role to allow patch/get on osdk-sa serviceaccount
+  k8s:
+    state: present
+    namespace: '{{ namespace }}'
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: 'osdk-sa-role'
+      rules:
+      - apiGroups:
+        - ""
+        resourceNames:
+        - osdk-sa
+        resources:
+        - serviceaccounts
+        verbs:
+        - patch
+        - get
+
+- name: Bind osdk-sa-role to osdk-sa serviceaccount
+  k8s:
+    state: present
+    namespace: '{{ namespace }}'
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: 'osdk-sa-rolebinding'
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osdk-sa-role
+      subjects:
+      - kind: ServiceAccount
+        name: osdk-sa
+
 - name: Wait 15m for reconciliation to run
   k8s_info:
     api_version: '{{ custom_resource.apiVersion }}'

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -36,7 +36,7 @@
           k8s_log:
             name: '{{ item.metadata.name }}'
             namespace: '{{ namespace }}'
-            container: manager
+            container: pulp-manager
           loop: "{{ q('k8s', api_version='v1', kind='Pod', namespace=namespace, label_selector=ctrl_label) }}"
           register: debug_logs
 

--- a/playbooks/pulp.yml
+++ b/playbooks/pulp.yml
@@ -30,12 +30,13 @@
     _image_web: quay.io/pulp/pulp-web
     _image_web_version: stable
     image_pull_policy: IfNotPresent
-    image_pull_secret: ""
+    image_pull_secrets: []
     storage_type: File
     file_storage_access_mode: "ReadWriteMany"
     file_storage_size: "100Gi"
     raw_spec: "{{ vars['_pulp_pulpproject_org_pulp']['spec'] }}"
   roles:
+    - common
     - postgres
     - pulp-web
     - pulp-routes

--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -1,0 +1,45 @@
+Common
+========
+
+A role to setup shared tasks in Pulp 3.
+
+In order to pull the images from a private registry (in a disconnected installation, for example) it is
+possible to configure the `image_pull_secrets` with the names of the secrets that have the credentials to
+pull the images from the private registry.
+The secrets that will be used by `image_pull_secrets` need to be created manually:
+~~~
+kubectl create secret docker-registry <name-of-the-secret> --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email>
+~~~
+
+If you have a `~/.docker/config.json` already, you can create the secret through:
+~~~
+kubectl create secret docker-registry <name-of-the-secret> --from-file=.dockerconfigjson=path/to/.docker/config.json
+~~~
+
+Role Variables
+--------------
+
+* `image_pull_secrets`: An array of secrets that will be used to pull image from private registries
+
+Requirements
+------------
+
+Requires the `openshift` Python library to interact with Kubernetes: `pip install openshift`.
+
+Dependencies
+------------
+
+collections:
+
+  - kubernetes.core
+  - operator_sdk.util
+
+License
+-------
+
+GPLv2+
+
+Author Information
+------------------
+
+[Pulp Team](https://pulpproject.org/)

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -1,0 +1,31 @@
+---
+galaxy_info:
+  author: Pulp Team
+  description: A role to setup Pulp 3 shared obects
+  issue_tracker_url: https://github.com/pulp/pulp-operator/issues/new
+  license: GPL-2.0-or-later
+  company: Red Hat
+  min_ansible_version: 2.9
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+    - name: Fedora
+      versions:
+        - 30
+        - 31
+        - 32
+        - 33
+    - name: EL
+      versions:
+        - 7
+        - 8
+  galaxy_tags:
+    - pulp
+    - pulpcore
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+collections:
+  - operator_sdk.util
+  - kubernetes.core

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Update service account with image pull secret
+  k8s:
+    apply: true
+    definition: "{{ lookup('template', 'pulp-operator-sa.yaml.j2') }}"

--- a/roles/common/templates/pulp-operator-sa.yaml.j2
+++ b/roles/common/templates/pulp-operator-sa.yaml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1
+{% if image_pull_secrets is defined %}
+imagePullSecrets:
+{% for secret in image_pull_secrets %}
+- name: {{ secret }}
+{% endfor %}
+{% endif %}
+kind: ServiceAccount
+metadata:
+  name: pulp-operator-sa
+  namespace: '{{ ansible_operator_meta.namespace }}'

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -42,10 +42,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -32,10 +32,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -34,10 +34,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -33,10 +33,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -32,10 +32,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -34,10 +34,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -34,10 +34,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret %}
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}


### PR DESCRIPTION
Update image_pull_secret from string to image_pull_secrets array so
that users can now provide multiple secrets to pull images from
private registries.

fixes: #343