### PR TITLE
Changed default pull secret to agreed upon name

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -87,5 +87,5 @@ spec:
             memory: 256Mi
       serviceAccountName: sa
       imagePullSecrets:
-        - name: ansible-deployment-pull-secret
+        - name: redhat-operators-pull-secret
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Follow-up change for https://github.com/pulp/pulp-operator/pull/383

@fao89 we decided to change the string name, sorry for the extra churn.  