### PR TITLE
Remove pymdown-extensions from doc_requirements.txt

### DIFF
--- a/CHANGES/386.misc
+++ b/CHANGES/386.misc
@@ -1,0 +1,1 @@
+Remove pymdown-extensions from doc_requirements.txt

--- a/docs/doc_requirements.txt
+++ b/docs/doc_requirements.txt
@@ -1,5 +1,4 @@
 mkdocs
-pymdown-extensions
 mike
 mkdocs-git-revision-date-plugin
 mkdocs-material


### PR DESCRIPTION
Remove `pymdown-extention` from requirements.txt to leave the selection of the version of `pymdown-extention` to the dependency resolution for `mkdocs-material`.

closes #386

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
