### PR TITLE
Fix a reference to an incorrect variable in pulp-status role

### DIFF
--- a/CHANGES/388.bugfix
+++ b/CHANGES/388.bugfix
@@ -1,0 +1,1 @@
+Fix a reference to an incorrect variable in pulp-status role

--- a/roles/pulp-status/tasks/main.yml
+++ b/roles/pulp-status/tasks/main.yml
@@ -79,7 +79,7 @@
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
     status:
-      databaseConfigurationSecret: "{{ _pg_config['resources'][0]['metadata']['name'] }}"
+      databaseConfigurationSecret: "{{ pg_config['resources'][0]['metadata']['name'] }}"
 
 - name: Update storage type status
   operator_sdk.util.k8s_status:


### PR DESCRIPTION
closes #388

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message

Tested as follows:

```bash
# Build and push custom operator image including this PR
$ IMG=registry.example.com/pulp/pulp-operator:0.9.1 make docker-build docker-push

# Deploy operator using custom image
$ IMG=registry.example.com/pulp/pulp-operator:0.9.1 make deploy

# Deploy pulp using file described in the issue #388
$ kubectl -n pulp apply -f galaxy.yml

# Watch the logs
$ kubectl -n pulp logs -f deployments/pulp-operator-controller-manager -c pulp-manager
```

The first attempt is exited with `failed=0` as expected. The issue #385 still remain, but #388 is solved.

```bash
$ kubectl -n pulp logs deployments/pulp-operator-controller-manager -c pulp-manager | grep "PLAY RECAP" -A 1
PLAY RECAP *********************************************************************
localhost                  : ok=80   changed=28   unreachable=0    failed=0    skipped=60   rescued=0    ignored=0   
--
PLAY RECAP *********************************************************************
localhost                  : ok=73   changed=0    unreachable=0    failed=0    skipped=67   rescued=0    ignored=0   
--
PLAY RECAP *********************************************************************
localhost                  : ok=73   changed=0    unreachable=0    failed=0    skipped=67   rescued=0    ignored=0   
--
PLAY RECAP *********************************************************************
localhost                  : ok=73   changed=0    unreachable=0    failed=0    skipped=67   rescued=0    ignored=0
```


