### PR TITLE
Only create container auth secret if needed

### DIFF
--- a/CHANGES/403.bugfix
+++ b/CHANGES/403.bugfix
@@ -1,0 +1,1 @@
+Patch container-auth secret creation to ensure the reconciliation loop converges

--- a/roles/pulp-api/tasks/container_auth_configuration.yml
+++ b/roles/pulp-api/tasks/container_auth_configuration.yml
@@ -9,7 +9,10 @@
     apply: true
     definition: "{{ lookup('template', 'pulp-container-auth.secret.yaml.j2') }}"
 
-- name: Set default token authentication secret name
-  set_fact:
-    container_token_secret: '{{ ansible_operator_meta.name }}-container-auth'
-    cacheable: yes
+- name: Get container token configuration
+  k8s_info:
+    kind: Secret
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ container_token_secret }}'
+  register: _container_token_configuration
+  no_log: true

--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -71,8 +71,10 @@
   no_log: true
   when: pulp_settings is defined
 
-- include_tasks:
-    file: container_auth_configuration.yml
+- name: Set default token authentication secret name if not set by user
+  set_fact:
+    container_token_secret: '{{ ansible_operator_meta.name }}-container-auth'
+    cacheable: yes
   when: container_token_secret is not defined
 
 - include_tasks:
@@ -170,7 +172,11 @@
     name: '{{ container_token_secret }}'
   register: _container_token_configuration
   no_log: true
-  when: container_token_secret is defined
+
+- include_tasks:
+    file: container_auth_configuration.yml
+  when:
+    - (_container_token_configuration is not defined) or not (_container_token_configuration['resources'] | length)
 
 - name: Get container token keys
   set_fact:


### PR DESCRIPTION
  - Previously, a new secret was being created on each reconciliation
    loop

fixes pulp#403

[noissue]

(cherry picked from commit 0312b669154927dc7c6fe7ae8fb62c6014b90034)

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
