### PR TITLE
Fix SA reconcile issue on OCP environments

### DIFF
--- a/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
+++ b/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
@@ -300,6 +300,9 @@ spec:
                   - IfNotPresent
                   - Always
                   - Never
+              image_pull_secret:
+                description: The image pull secret (deprecated. Use image_pull_secrets instead)
+                type: string
               image_pull_secrets:
                 description: The image pull secrets
                 type: array

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -255,12 +255,18 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Image pull secret for container images
+        displayName: Image pull secret
+        path: image_pull_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:imagePullSecret
       - description: Image pull secrets for container images
         displayName: Image pull secrets
         path: image_pull_secrets
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:imagePullSecret
+        - urn:alm:descriptor:com.tectonic.ui:imagePullSecrets
       - description: The deployment affinity
         displayName: Deployment Affinity
         path: affinity

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -71,6 +71,22 @@ rules:
       - deployments/scale
     verbs:
       - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resourceNames:
+      - pulp-operator-sa
+    resources:
+      - serviceaccounts
+    verbs:
+      - patch
+      - get
   ##
   ## Rules for pulp.pulpproject.org/v1beta1, Kind: Pulp
   ##

--- a/config/testing/manager_image.yaml
+++ b/config/testing/manager_image.yaml
@@ -10,3 +10,6 @@ spec:
       containers:
         - name: pulp-manager
           image: testing
+          env:
+            - name: OPERATOR_SA_NAME
+              value: osdk-sa

--- a/docs/roles/common.md
+++ b/docs/roles/common.md
@@ -1,0 +1,1 @@
+roles/common/README.md

--- a/molecule/default/tasks/pulp_test.yml
+++ b/molecule/default/tasks/pulp_test.yml
@@ -7,6 +7,43 @@
   vars:
     cr_file: 'pulpproject_v1beta1_pulp_cr.molecule.ci.yaml'
 
+- name: Create role to allow patch/get on "{{ operator_service_account_name }}" serviceaccount
+  k8s:
+    state: present
+    namespace: '{{ namespace }}'
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: "{{ operator_service_account_name }}-role"
+      rules:
+      - apiGroups:
+        - ""
+        resourceNames:
+        - "{{ operator_service_account_name }}"
+        resources:
+        - serviceaccounts
+        verbs:
+        - patch
+        - get
+
+- name: Bind "{{ operator_service_account_name }}-role" to "{{ operator_service_account_name }}" serviceaccount
+  k8s:
+    state: present
+    namespace: '{{ namespace }}'
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: "{{ operator_service_account_name }}-rolebinding"
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: "{{ operator_service_account_name }}-role"
+      subjects:
+      - kind: ServiceAccount
+        name: "{{ operator_service_account_name }}"
+
 - name: Wait 15m for reconciliation to run
   k8s_info:
     api_version: '{{ custom_resource.apiVersion }}'

--- a/molecule/kind/molecule.yml
+++ b/molecule/kind/molecule.yml
@@ -28,6 +28,7 @@ provisioner:
     group_vars:
       all:
         namespace: ${TEST_OPERATOR_NAMESPACE:-osdk-test}
+        operator_service_account_name: osdk-sa
     host_vars:
       localhost:
         ansible_python_interpreter: '{{ ansible_playbook_python }}'

--- a/playbooks/pulp.yml
+++ b/playbooks/pulp.yml
@@ -31,7 +31,6 @@
     _image_web: quay.io/pulp/pulp-web
     _image_web_version: stable
     image_pull_policy: IfNotPresent
-    image_pull_secrets: []
     storage_type: File
     file_storage_access_mode: "ReadWriteMany"
     file_storage_size: "100Gi"
@@ -58,6 +57,7 @@
       when:
         - (_rh_ops_secret is not defined) or not (_rh_ops_secret['resources'] | length)
   roles:
+    - common
     - postgres
     - pulp-web
     - pulp-routes

--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -1,0 +1,45 @@
+Common
+========
+
+A role to setup shared tasks in Pulp 3.
+
+In order to pull the images from a private registry (in a disconnected installation, for example) it is
+possible to configure the `image_pull_secrets` with the names of the secrets that have the credentials to
+pull the images from the private registry.
+The secrets that will be used by `image_pull_secrets` need to be created manually:
+~~
+kubectl create secret docker-registry <name-of-the-secret> --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email>
+~~
+
+If you have a `~/.docker/config.json` already, you can create the secret through:
+~~
+kubectl create secret docker-registry <name-of-the-secret> --from-file=.dockerconfigjson=path/to/.docker/config.json
+~~
+
+Role Variables
+--------------
+
+* `image_pull_secrets`: An array of secrets that will be used to pull image from private registries
+
+Requirements
+------------
+
+Requires the `openshift` Python library to interact with Kubernetes: `pip install openshift`.
+
+Dependencies
+------------
+
+collections:
+
+  - kubernetes.core
+  - operator_sdk.util
+
+License
+-------
+
+GPLv2+
+
+Author Information
+------------------
+
+[Pulp Team](https://pulpproject.org/)

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+image_pull_secret: ''
+image_pull_secrets: []
+operator_service_account_name: '{{ lookup("env","OPERATOR_SA_NAME") | default("pulp-operator-sa",true) }}'

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -1,0 +1,31 @@
+---
+galaxy_info:
+  author: Pulp Team
+  description: A role to setup Pulp 3 shared obects
+  issue_tracker_url: https://github.com/pulp/pulp-operator/issues/new
+  license: GPL-2.0-or-later
+  company: Red Hat
+  min_ansible_version: 2.9
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+    - name: Fedora
+      versions:
+        - 30
+        - 31
+        - 32
+        - 33
+    - name: EL
+      versions:
+        - 7
+        - 8
+  galaxy_tags:
+    - pulp
+    - pulpcore
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+collections:
+  - operator_sdk.util
+  - kubernetes.core

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Fail execution if image_pull_secret or image_pull_secrets are defined but as NoneType ('image_pull_secret[s]:')
+  fail:
+    msg: "If image_pull_secret or image_pull_secrets will not be used, their declarations should be removed."
+  when: image_pull_secret|type_debug == 'NoneType' or image_pull_secrets|type_debug == 'NoneType'
+
+- name: Get the imagePullSecrets from "{{ operator_service_account_name }}"
+  k8s_info:
+    api_version: v1
+    kind: ServiceAccount
+    name: '{{ operator_service_account_name }}'
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: __pulp_operator_sa_output
+
+- name: Iterate over the imagePullSecrets to see if can find the dockercfg secret (for OCP environments)
+  set_fact:
+    __dockercfg_secret: "{{ item.name | regex_search( operator_service_account_name + '-dockercfg-' + '[a-z0-9]{5}') }}"
+  when: __pulp_operator_sa_output.resources[0].imagePullSecrets is defined and __dockercfg_secret | default() | length == 0
+  with_items: '{{ __pulp_operator_sa_output.resources[0].imagePullSecrets }}'
+
+- name: Update service account with image pull secret
+  k8s:
+    apply: true
+    definition: "{{ lookup('template', 'pulp-operator-sa.yaml.j2') }}"

--- a/roles/common/templates/pulp-operator-sa.yaml.j2
+++ b/roles/common/templates/pulp-operator-sa.yaml.j2
@@ -1,0 +1,17 @@
+apiVersion: v1
+imagePullSecrets:
+{% if image_pull_secret|length > 0 and image_pull_secrets|length == 0 %}
+# image_pull_secret is deprecated in favor of image_pull_secrets
+- name: {{ image_pull_secret }}
+{% else %}
+{% for secret in image_pull_secrets %}
+- name: {{ secret }}
+{% endfor %}
+{% endif %}
+{% if __dockercfg_secret is defined and __dockercfg_secret | length > 0%}
+- name: {{ __dockercfg_secret }}
+{% endif %}
+kind: ServiceAccount
+metadata:
+  name: '{{ operator_service_account_name }}'
+  namespace: '{{ ansible_operator_meta.namespace }}'

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -42,16 +42,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret is defined and image_pull_secrets is undefined %}
-# image_pull_secret is deprecated in favor of image_pull_secrets
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% elif image_pull_secrets is defined %}
-      imagePullSecrets:
-{% for secret in image_pull_secrets %}
-        - name: {{ secret }}
-{% endfor %}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -32,16 +32,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret is defined and image_pull_secrets is undefined %}
-# image_pull_secret is deprecated in favor of image_pull_secrets
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% elif image_pull_secrets is defined %}
-      imagePullSecrets:
-{% for secret in image_pull_secrets %}
-        - name: {{ secret }}
-{% endfor %}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -34,16 +34,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret is defined and image_pull_secrets is undefined %}
-# image_pull_secret is deprecated in favor of image_pull_secrets
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% elif image_pull_secrets is defined %}
-      imagePullSecrets:
-{% for secret in image_pull_secrets %}
-        - name: {{ secret }}
-{% endfor %}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.deployment.yaml.j2
@@ -33,16 +33,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret is defined and image_pull_secrets is undefined %}
-# image_pull_secret is deprecated in favor of image_pull_secrets
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% elif image_pull_secrets is defined %}
-      imagePullSecrets:
-{% for secret in image_pull_secrets %}
-        - name: {{ secret }}
-{% endfor %}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -32,16 +32,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret is defined and image_pull_secrets is undefined %}
-# image_pull_secret is deprecated in favor of image_pull_secrets
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% elif image_pull_secrets is defined %}
-      imagePullSecrets:
-{% for secret in image_pull_secrets %}
-        - name: {{ secret }}
-{% endfor %}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -34,16 +34,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret is defined and image_pull_secrets is undefined %}
-# image_pull_secret is deprecated in favor of image_pull_secrets
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% elif image_pull_secrets is defined %}
-      imagePullSecrets:
-{% for secret in image_pull_secrets %}
-        - name: {{ secret }}
-{% endfor %}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -34,16 +34,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% if image_pull_secret is defined and image_pull_secrets is undefined %}
-# image_pull_secret is deprecated in favor of image_pull_secrets
-      imagePullSecrets:
-        - name: {{ image_pull_secret }}
-{% elif image_pull_secrets is defined %}
-      imagePullSecrets:
-{% for secret in image_pull_secrets %}
-        - name: {{ secret }}
-{% endfor %}
-{% endif %}
 {% if _node_affinity is defined %}
       affinity:
         nodeAffinity: {{ _node_affinity }}


### PR DESCRIPTION
The OpenShift Controller Manager (OCM) ensures that the serviceaccounts
are synced with the secret to pull from the internal registry.
To handle this behavior - specific to OCP environments - this commit
allows configuring an image_pull_secrets variable to pull from private
registries without overwriting the secret added by OCM.
[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
