### PR TITLE
Gunicorn API workers default to 2

### DIFF
--- a/CHANGES/437.bugfix
+++ b/CHANGES/437.bugfix
@@ -1,0 +1,1 @@
+Gunicorn API workers default to 2

--- a/bundle/manifests/pulp.pulpproject.org_pulps.yaml
+++ b/bundle/manifests/pulp.pulpproject.org_pulps.yaml
@@ -148,7 +148,7 @@ spec:
                 description: Storage class to use for the file persistentVolumeClaim
                 type: string
               gunicorn_api_workers:
-                default: 1
+                default: 2
                 description: The number of gunicorn workers to use for the api.
                 type: integer
               gunicorn_content_workers:

--- a/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
+++ b/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
@@ -179,7 +179,7 @@ spec:
               gunicorn_api_workers:
                 description: The number of gunicorn workers to use for the api.
                 type: integer
-                default: 1
+                default: 2
               gunicorn_content_workers:
                 description: The number of gunicorn workers to use for the content.
                 type: integer

--- a/containers/images/pulp/container-assets/pulp-api
+++ b/containers/images/pulp/container-assets/pulp-api
@@ -32,7 +32,7 @@ fi
 bash -x
 
 PULP_GUNICORN_TIMEOUT=${PULP_GUNICORN_TIMEOUT:-90}
-PULP_API_WORKERS=${PULP_API_WORKERS:-1}
+PULP_API_WORKERS=${PULP_API_WORKERS:-2}
 
 mkdir -p /var/lib/pulp/media \
          /var/lib/pulp/assets \

--- a/roles/pulp-api/defaults/main.yml
+++ b/roles/pulp-api/defaults/main.yml
@@ -96,4 +96,4 @@ keycloak_realm_available: false
 __pulp_gpg_inspect_command: "gpg --import-options show-only --import --with-fingerprint"
 
 gunicorn_timeout: 90
-gunicorn_api_workers: 1
+gunicorn_api_workers: 2


### PR DESCRIPTION
closes #437

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
