### PR TITLE
Add api_version for OpenShift Route resource in Ansible tasks.

### DIFF
--- a/CHANGES/462.bugfix
+++ b/CHANGES/462.bugfix
@@ -1,0 +1,2 @@
+
+Add api_version for OpenShift Route resource in Ansible tasks.

--- a/CHANGES/462.bugfix
+++ b/CHANGES/462.bugfix
@@ -1,2 +1,1 @@
-
 Add api_version for OpenShift Route resource in Ansible tasks.

--- a/roles/pulp-api/tasks/get_node_ip.yml
+++ b/roles/pulp-api/tasks/get_node_ip.yml
@@ -52,6 +52,7 @@
     - name: Retrieve route URL
       k8s_info:
         kind: Route
+        api_version: "route.openshift.io/v1"
         namespace: '{{ ansible_operator_meta.namespace }}'
         name: '{{ ansible_operator_meta.name }}'
       register: route_url

--- a/roles/pulp-status/tasks/main.yml
+++ b/roles/pulp-status/tasks/main.yml
@@ -177,6 +177,7 @@
     - name: Retrieve route URL
       k8s_info:
         kind: Route
+        api_version: "route.openshift.io/v1"
         namespace: '{{ ansible_operator_meta.namespace }}'
         name: '{{ ansible_operator_meta.name }}'
       register: route_url


### PR DESCRIPTION
Closes #462 
