### PR TITLE
Remove resource manager on upgrade

### DIFF
--- a/roles/pulp-status/tasks/main.yml
+++ b/roles/pulp-status/tasks/main.yml
@@ -80,6 +80,15 @@
     name: pulp-resource-manager
   when: installed_plugins.pulpcore is defined or installed_plugins.core is version('3.16.0', '<')
 
+- name: Remove resource manager deployment
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Deployment
+    name: "{{ ansible_operator_meta.name }}-resource-manager"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    state: absent
+  when: installed_plugins.core is version('3.16.0', '>=')
+
 - name: Update admin password status
   operator_sdk.util.k8s_status:
     api_version: '{{ api_version }}'


### PR DESCRIPTION
When upgrading from pulpcore < 3.16 then the resource manager deployment
is still present and in crashloop state since there's no entrypoint for
this service in the pulp container.
This ensures the pulp resource manager Deployment is absent when the core
version is >= 3.16

[noissue]

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>