### PR TITLE
Add commented LDAP settings to Pulp CR example

### DIFF
--- a/config/samples/pulpproject_v1beta1_pulp_cr.default.yaml
+++ b/config/samples/pulpproject_v1beta1_pulp_cr.default.yaml
@@ -6,9 +6,21 @@ metadata:
   # The registry to grab the pulp image from.
 # image: quay.io/pulp/pulp
 # image_version: stable
+
 # Pulp settings.
 # pulp_settings:
-#    debug: "True"
+#   debug: "True"
+#   AUTHENTICATION_BACKEND_PRESET: ldap
+#   AUTH_LDAP_SERVER_URI: "ldap://ldap:10389"
+#   AUTH_LDAP_BIND_DN: "cn=admin,dc=planetexpress,dc=com"
+#   AUTH_LDAP_BIND_PASSWORD: "GoodNewsEveryone"
+#   AUTH_LDAP_USER_SEARCH_BASE_DN: "ou=people,dc=planetexpress,dc=com"
+#   AUTH_LDAP_USER_SEARCH_SCOPE: "SUBTREE"
+#   AUTH_LDAP_USER_SEARCH_FILTER: "(uid=%(user)s)"
+#   AUTH_LDAP_GROUP_SEARCH_BASE_DN: "ou=people,dc=planetexpress,dc=com"
+#   AUTH_LDAP_GROUP_SEARCH_SCOPE: "SUBTREE"
+#   AUTH_LDAP_GROUP_SEARCH_FILTER :  "(objectClass=Group)"
+#   AUTH_LDAP_GROUP_TYPE_CLASS: "django_auth_ldap.config:GroupOfNamesType"
   # The pulp adminstrator password secret.
 # admin_password_secret:
   # PostgreSQL container settings secret.


### PR DESCRIPTION
It is possible to configure LDAP now via the galaxy_ng settings.  We should include an example of how to pass those settings via the `pulp_settings` field on the spec.  

We should probably also document this on the pulp-operator docs somewhere: https://docs.pulpproject.org/pulp_operator/quickstart/

We can link to https://galaxyng.netlify.app/integration/ldap/ for more details.  