### PR TITLE
Add operator events

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,13 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - apps
   - networking.k8s.io
   resources:

--- a/controllers/pulp/api.go
+++ b/controllers/pulp/api.go
@@ -53,9 +53,11 @@ func (r *PulpReconciler) pulpApiController(ctx context.Context, pulp *repomanage
 			if err != nil {
 				log.Error(err, "Failed to create new Pulp File Storage PVC", "PVC.Namespace", expected_pvc.Namespace, "PVC.Name", expected_pvc.Name)
 				r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "ErrorCreatingPVC", "Failed to create "+pulp.Name+"-file-storage PVC: "+err.Error())
+				r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create new file storage PVC")
 				return ctrl.Result{}, err
 			}
 			// PVC created successfully - return and requeue
+			r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "File storage PVC created")
 			return ctrl.Result{Requeue: true}, nil
 		} else if err != nil {
 			log.Error(err, "Failed to get Pulp API File Storage PVC")
@@ -66,12 +68,15 @@ func (r *PulpReconciler) pulpApiController(ctx context.Context, pulp *repomanage
 		if !equality.Semantic.DeepDerivative(expected_pvc.Spec, pvcFound.Spec) {
 			log.Info("The PVC has been modified! Reconciling ...")
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "UpdatingFileStoragePVC", "Reconciling "+pulp.Name+"-file-storage PVC resource")
+			r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling file storage PVC")
 			err = r.Update(ctx, expected_pvc)
 			if err != nil {
 				log.Error(err, "Error trying to update the PVC object ... ")
 				r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "ErrorUpdatingFileStoragePVC", "Failed to reconcile "+pulp.Name+"-file-storage PVC resource")
+				r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to reconcile file storage PVC")
 				return ctrl.Result{}, err
 			}
+			r.recorder.Event(pulp, corev1.EventTypeNormal, "Updated", "File storage PVC reconciled")
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 		}
 	}
@@ -90,9 +95,11 @@ func (r *PulpReconciler) pulpApiController(ctx context.Context, pulp *repomanage
 		if err != nil {
 			log.Error(err, "Failed to create new pulp-server secret", "Secret.Namespace", sec.Namespace, "Secret.Name", sec.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "ErrorCreatingServerSecret", "Failed to create "+pulp.Name+"-server secret: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create a new server secret")
 			return ctrl.Result{}, err
 		}
 		// Deployment created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "File storage PVC created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get pulp-server secret")
@@ -113,9 +120,11 @@ func (r *PulpReconciler) pulpApiController(ctx context.Context, pulp *repomanage
 		if err != nil {
 			log.Error(err, "Failed to create new pulp-db-fields-encryption secret", "Secret.Namespace", dbFields.Namespace, "Secret.Name", dbFields.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "ErrorCreatingDBFieldsEncryptionSecret", "Failed to create "+pulp.Name+"-db-fields-encryption secret: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create a new db-fields-encryption secret")
 			return ctrl.Result{}, err
 		}
 		// Deployment created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "db-fields-encryption secret created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get pulp-db-fields-encryption secret")
@@ -140,9 +149,11 @@ func (r *PulpReconciler) pulpApiController(ctx context.Context, pulp *repomanage
 		if err != nil {
 			log.Error(err, "Failed to create new pulp-admin-password secret", "Secret.Namespace", adminPwd.Namespace, "Secret.Name", adminPwd.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "ErrorCreatingAdminPasswordSecret", "Failed to create "+pulp.Name+"-admin-password secret: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create a new admin-password secret")
 			return ctrl.Result{}, err
 		}
 		// Secret created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "admin-password secret created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get pulp-admin-password secret")
@@ -164,9 +175,11 @@ func (r *PulpReconciler) pulpApiController(ctx context.Context, pulp *repomanage
 		if err != nil {
 			log.Error(err, "Failed to create new pulp-container-auth secret", "Secret.Namespace", authSecret.Namespace, "Secret.Name", authSecret.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "ErrorCreatingContainerAuthSecret", "Failed to create "+pulp.Name+"-container-auth secret: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create a new container-auth secret")
 			return ctrl.Result{}, err
 		}
 		// Secret created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "container-auth secret created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get pulp-container-auth secret")
@@ -186,9 +199,11 @@ func (r *PulpReconciler) pulpApiController(ctx context.Context, pulp *repomanage
 		if err != nil {
 			log.Error(err, "Failed to create new Pulp API Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "ErrorCreatingApiDeployment", "Failed to create "+pulp.Name+"-api deployment: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create a new API deployment")
 			return ctrl.Result{}, err
 		}
 		// Deployment created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "API deployment created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get Pulp API Deployment")
@@ -200,12 +215,15 @@ func (r *PulpReconciler) pulpApiController(ctx context.Context, pulp *repomanage
 	if !equality.Semantic.DeepDerivative(dep.Spec, found.Spec) {
 		log.Info("The API deployment has been modified! Reconciling ...")
 		r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "UpdatingApiDeployment", "Reconciling "+pulp.Name+"-api deployment")
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling API deployment")
 		err = r.Update(ctx, dep)
 		if err != nil {
 			log.Error(err, "Error trying to update the API deployment object ... ")
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "ErrorUpdatingApiDeployment", "Failed to reconcile "+pulp.Name+"-api deployment: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to update API deployment")
 			return ctrl.Result{}, err
 		}
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updated", "Reconciled API deployment")
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -221,9 +239,11 @@ func (r *PulpReconciler) pulpApiController(ctx context.Context, pulp *repomanage
 		if err != nil {
 			log.Error(err, "Failed to create new API Service", "Service.Namespace", newApiSvc.Namespace, "Service.Name", newApiSvc.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "ErrorCreatingApiService", "Failed to create "+pulp.Name+"-api-svc service: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create new API service")
 			return ctrl.Result{}, err
 		}
 		// Service created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "API service created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get API Service")
@@ -234,25 +254,18 @@ func (r *PulpReconciler) pulpApiController(ctx context.Context, pulp *repomanage
 	if !equality.Semantic.DeepDerivative(newApiSvc.Spec, apiSvc.Spec) {
 		log.Info("The API service has been modified! Reconciling ...")
 		r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "UpdatingApiService", "Reconciling "+pulp.Name+"-api-svc service")
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling API service")
 		err = r.Update(ctx, newApiSvc)
 		if err != nil {
 			log.Error(err, "Error trying to update the API Service object ... ")
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-API-Ready", "ErrorUpdatingApiService", "Failed to reconcile "+pulp.Name+"-api-svc service: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to update API service")
 			return ctrl.Result{}, err
 		}
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updated", "Reconciled API service")
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// pulpController, err := r.checkRunningPods(ctx, pulp, labelsForPulpApi(pulp), log)
-	// if err != nil {
-	// 	return pulpController, err
-	// } else if pulpController.Requeue {
-	// 	return pulpController, nil
-	// } else if pulpController.RequeueAfter > 0 {
-	// 	return pulpController, nil
-	// }
-
-	//r.updateStatus(ctx, pulp, metav1.ConditionTrue, pulp.Spec.DeploymentType+"-API-Ready", "ApiTasksFinished", "All API tasks ran successfully")
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/pulp/content.go
+++ b/controllers/pulp/content.go
@@ -50,9 +50,11 @@ func (r *PulpReconciler) pulpContentController(ctx context.Context, pulp *repoma
 		if err != nil {
 			log.Error(err, "Failed to create new Pulp Content Deployment", "Deployment.Namespace", newCntDeployment.Namespace, "Deployment.Name", newCntDeployment.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Content-Ready", "ErrorCreatingContentDeployment", "Failed to create "+pulp.Name+"-content deployment resource: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create new content deployment")
 			return ctrl.Result{}, err
 		}
 		// Deployment created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "Content deployment created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get Pulp Content Deployment")
@@ -63,12 +65,15 @@ func (r *PulpReconciler) pulpContentController(ctx context.Context, pulp *repoma
 	if !equality.Semantic.DeepDerivative(newCntDeployment.Spec, cntDeployment.Spec) {
 		log.Info("The Content Deployment has been modified! Reconciling ...")
 		r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Content-Ready", "UpdatingContentDeployment", "Reconciling "+pulp.Name+"-content deployment resource")
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling content deployment")
 		err = r.Update(ctx, newCntDeployment)
 		if err != nil {
 			log.Error(err, "Error trying to update the Content Deployment object ... ")
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Content-Ready", "ErrorUpdatingContentDeployment", "Failed to reconcile "+pulp.Name+"-content deployment resource: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to reconcile content deployment")
 			return ctrl.Result{}, err
 		}
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updated", "Content deployment reconciled")
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 	}
 
@@ -84,9 +89,11 @@ func (r *PulpReconciler) pulpContentController(ctx context.Context, pulp *repoma
 		if err != nil {
 			log.Error(err, "Failed to create new Content Service", "Service.Namespace", newCntSvc.Namespace, "Service.Name", newCntSvc.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Content-Ready", "ErrorCreatingContentService", "Failed to create "+pulp.Name+"-content-svc service: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create new content service")
 			return ctrl.Result{}, err
 		}
 		// Service created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "Content service created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get Content Service")
@@ -97,16 +104,20 @@ func (r *PulpReconciler) pulpContentController(ctx context.Context, pulp *repoma
 	if !equality.Semantic.DeepDerivative(newCntSvc.Spec, cntSvc.Spec) {
 		log.Info("The Content Service has been modified! Reconciling ...")
 		r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Content-Ready", "UpdatingContentService", "Reconciling "+pulp.Name+"-content-svc service")
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling content service")
 		err = r.Update(ctx, newCntSvc)
 		if err != nil {
 			log.Error(err, "Error trying to update the Content Service object ... ")
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Content-Ready", "ErrorUpdatingContentService", "Failed to reconcile "+pulp.Name+"-content-svc service: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to reconcile content service")
 			return ctrl.Result{}, err
 		}
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updated", "Content service reconciled")
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 	}
 
 	r.updateStatus(ctx, pulp, metav1.ConditionTrue, pulp.Spec.DeploymentType+"-Content-Ready", "ContentTasksFinished", "All Content tasks ran successfully")
+	r.recorder.Event(pulp, corev1.EventTypeNormal, "ContentReady", "All Content tasks ran successfully")
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/pulp/controller.go
+++ b/controllers/pulp/controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,6 +45,7 @@ type PulpReconciler struct {
 	RESTClient rest.Interface
 	RESTConfig *rest.Config
 	Scheme     *runtime.Scheme
+	recorder   record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=repo-manager.pulpproject.org,resources=pulps,verbs=get;list;watch;create;update;patch;delete
@@ -54,6 +56,7 @@ type PulpReconciler struct {
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
 //+kubebuilder:rbac:groups=core,resources=configmaps;secrets;services;persistentvolumeclaims,verbs=create;update;patch;delete;watch;get;list;
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -176,6 +179,10 @@ func (r *PulpReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *PulpReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	// creates a new eventRecorder to be able to interact with events
+	r.recorder = mgr.GetEventRecorderFor("Pulp")
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&repomanagerv1alpha1.Pulp{}).
 		Owns(&appsv1.StatefulSet{}).

--- a/controllers/pulp/database.go
+++ b/controllers/pulp/database.go
@@ -55,9 +55,11 @@ func (r *PulpReconciler) databaseController(ctx context.Context, pulp *repomanag
 		if err != nil {
 			log.Error(err, "Failed to create new pulp-postgres-configuration secret secret", "Secret.Namespace", expected_secret.Namespace, "Secret.Name", expected_secret.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Database-Ready", "ErrorCreatingDatabasePostgresSecret", "Failed to create "+pulp.Name+"-postgres-configuration secret resource: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create new postgres-configuration secret")
 			return ctrl.Result{}, err
 		}
 		// Secret created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "Postgres-configuration secret created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get pulp-postgres-configuration secret")
@@ -78,10 +80,11 @@ func (r *PulpReconciler) databaseController(ctx context.Context, pulp *repomanag
 		if err != nil {
 			log.Error(err, "Failed to create new Database StatefulSet", "StatefulSet.Namespace", expected_sts.Namespace, "StatefulSet.Name", expected_sts.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Database-Ready", "ErrorCreatingDatabaseSts", "Failed to create "+pulp.Name+"-database statefulset resource: "+err.Error())
-
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create database StatefulSet")
 			return ctrl.Result{}, err
 		}
 		// Deployment created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "Database StatefulSet created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get Database StatefulSet")
@@ -92,6 +95,7 @@ func (r *PulpReconciler) databaseController(ctx context.Context, pulp *repomanag
 	if !equality.Semantic.DeepDerivative(expected_sts.Spec, pgSts.Spec) {
 		log.Info("The Database StatefulSet has been modified! Reconciling ...")
 		r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Database-Ready", "UpdatingDatabaseSts", "Reconciling "+pulp.Name+"-database statefulset resource")
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling database StatefulSet")
 		// Set Pulp instance as the owner and controller
 		// not sure if this is the best way to do this, but every time that
 		// a reconciliation occurred the object lost the owner reference
@@ -100,8 +104,10 @@ func (r *PulpReconciler) databaseController(ctx context.Context, pulp *repomanag
 		if err != nil {
 			log.Error(err, "Error trying to update the Database StatefulSet object ... ")
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Database-Ready", "ErrorUpdatingDatabaseSts", "Failed to reconcile "+pulp.Name+"-database statefulset resource")
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to reconcile database StatefulSet")
 			return ctrl.Result{}, err
 		}
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updated", "Database StatefulSet reconciled")
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, nil
 	}
 
@@ -119,9 +125,11 @@ func (r *PulpReconciler) databaseController(ctx context.Context, pulp *repomanag
 		if err != nil {
 			log.Error(err, "Failed to create new Database Service", "Service.Namespace", expected_svc.Namespace, "Service.Name", expected_svc.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Database-Ready", "ErrorCreatingDatabaseService", "Failed to create "+pulp.Name+"-database-svc service resource: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create database service")
 			return ctrl.Result{}, err
 		}
 		// Service created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "Database service created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get Database Service")
@@ -132,17 +140,21 @@ func (r *PulpReconciler) databaseController(ctx context.Context, pulp *repomanag
 	if !equality.Semantic.DeepDerivative(expected_svc.Spec, dbSvc.Spec) {
 		log.Info("The Database service has been modified! Reconciling ...")
 		r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Database-Ready", "UpdatingDatabaseService", "Reconciling "+pulp.Name+"-database-svc service resource")
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling database service")
 		ctrl.SetControllerReference(pulp, expected_svc, r.Scheme)
 		err = r.Update(ctx, expected_svc)
 		if err != nil {
 			log.Error(err, "Error trying to update the Database Service object ... ")
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Database-Ready", "ErrorUpdatingDatabaseService", "Failed to reconcile "+pulp.Name+"-database-svc service resource: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to reconcile database service")
 			return ctrl.Result{}, err
 		}
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updated", "Database service reconciled")
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 	}
 
 	r.updateStatus(ctx, pulp, metav1.ConditionTrue, pulp.Spec.DeploymentType+"-Database-Ready", "DatabaseTasksFinished", "All Database tasks ran successfully")
+	r.recorder.Event(pulp, corev1.EventTypeNormal, "DatabaseReady", "All Database tasks ran successfully")
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/pulp/redis.go
+++ b/controllers/pulp/redis.go
@@ -29,9 +29,11 @@ func (r *PulpReconciler) pulpCacheController(ctx context.Context, pulp *repomana
 		err = r.Create(ctx, pvc)
 		if err != nil {
 			log.Error(err, "Failed to create new Pulp Redis Data PVC", "PVC.Namespace", pvc.Namespace, "PVC.Name", pvc.Name)
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create new Redis Data PVC")
 			return ctrl.Result{}, err
 		}
 		// PVC created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "Redis Data PVC created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get Pulp Redis Data PVC")
@@ -41,12 +43,15 @@ func (r *PulpReconciler) pulpCacheController(ctx context.Context, pulp *repomana
 	// Reconcile PVC
 	if !equality.Semantic.DeepDerivative(pvc.Spec, pvcFound.Spec) {
 		log.Info("The Redis PVC has been modified! Reconciling ...")
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling Redis PVC")
 		ctrl.SetControllerReference(pulp, pvc, r.Scheme)
 		err = r.Update(ctx, pvc)
 		if err != nil {
 			log.Error(err, "Error trying to update the Redis PVC object ... ")
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to reconcile Redis PVC")
 			return ctrl.Result{}, err
 		}
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updated", "Redis PVC reconciled")
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 	}
 
@@ -60,9 +65,11 @@ func (r *PulpReconciler) pulpCacheController(ctx context.Context, pulp *repomana
 		err = r.Create(ctx, svc)
 		if err != nil {
 			log.Error(err, "Failed to create new Redis Service", "Service.Namespace", svc.Namespace, "Service.Name", svc.Name)
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create new Redis Service")
 			return ctrl.Result{}, err
 		}
 		// Service created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "Redis Service created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get Redis Service")
@@ -73,11 +80,14 @@ func (r *PulpReconciler) pulpCacheController(ctx context.Context, pulp *repomana
 	if !equality.Semantic.DeepDerivative(svc.Spec, svcFound.Spec) {
 		log.Info("The Redis Service has been modified! Reconciling ...")
 		ctrl.SetControllerReference(pulp, svc, r.Scheme)
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling Redis Service")
 		err = r.Update(ctx, svc)
 		if err != nil {
 			log.Error(err, "Error trying to update the Redis Service object ... ")
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to reconcile Redis Service")
 			return ctrl.Result{}, err
 		}
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updated", "Redis Service reconciled")
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 	}
 
@@ -91,9 +101,11 @@ func (r *PulpReconciler) pulpCacheController(ctx context.Context, pulp *repomana
 		err = r.Create(ctx, dep)
 		if err != nil {
 			log.Error(err, "Failed to create new Pulp Redis Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create new Redis Deployment")
 			return ctrl.Result{}, err
 		}
 		// Deployment created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "Redis Deployment created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get Pulp Redis Deployment")
@@ -104,14 +116,18 @@ func (r *PulpReconciler) pulpCacheController(ctx context.Context, pulp *repomana
 	if !equality.Semantic.DeepDerivative(dep.Spec, deploymentFound.Spec) {
 		log.Info("The Redis Deployment has been modified! Reconciling ...")
 		ctrl.SetControllerReference(pulp, dep, r.Scheme)
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling Redis Deployment")
 		err = r.Update(ctx, dep)
 		if err != nil {
 			log.Error(err, "Error trying to update the Redis Deployment object ... ")
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to reconcile Redis Deployment")
 			return ctrl.Result{}, err
 		}
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updated", "Redis Deployment reconciled")
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 	}
 
+	r.recorder.Event(pulp, corev1.EventTypeNormal, "RedisReady", "All Redis tasks ran successfully")
 	return ctrl.Result{}, nil
 
 }

--- a/controllers/pulp/route.go
+++ b/controllers/pulp/route.go
@@ -129,6 +129,7 @@ func (r *PulpReconciler) pulpRouteController(ctx context.Context, pulp *repomana
 			if err != nil {
 				log.Error(err, "Failed to create new route", "Route.Namespace", routePwd.Namespace, "Route.Name", routePwd.Name)
 				r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Route-Ready", "ErrorCreatingRoute", "Failed to create "+pulp.Name+"-route: "+err.Error())
+				r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create new route")
 				return ctrl.Result{}, err
 			}
 		} else if err != nil {
@@ -137,6 +138,7 @@ func (r *PulpReconciler) pulpRouteController(ctx context.Context, pulp *repomana
 		}
 	}
 	r.updateStatus(ctx, pulp, metav1.ConditionTrue, pulp.Spec.DeploymentType+"-Route-Ready", "RouteTasksFinished", "All Route tasks ran successfully")
+	r.recorder.Event(pulp, corev1.EventTypeNormal, "RouteReady", "All Route tasks ran successfully")
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/pulp/status.go
+++ b/controllers/pulp/status.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,6 +45,7 @@ func (r *PulpReconciler) pulpStatus(ctx context.Context, pulp *repomanagerv1alph
 			return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
 		} else {
 			r.updateStatus(ctx, pulp, metav1.ConditionTrue, pulp.Spec.DeploymentType+"-API-Ready", "ApiTasksFinished", "All API tasks ran successfully")
+			r.recorder.Event(pulp, corev1.EventTypeNormal, "APIReady", "All API tasks ran successfully")
 		}
 	} else {
 		log.Error(err, "Failed to get Pulp API Deployment")
@@ -59,6 +61,7 @@ func (r *PulpReconciler) pulpStatus(ctx context.Context, pulp *repomanagerv1alph
 				return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
 			} else {
 				r.updateStatus(ctx, pulp, metav1.ConditionTrue, pulp.Spec.DeploymentType+"-Web-Ready", "WebTasksFinished", "All Web tasks ran successfully")
+				r.recorder.Event(pulp, corev1.EventTypeNormal, "WebReady", "All Web tasks ran successfully")
 			}
 		} else {
 			log.Error(err, "Failed to get Pulp Web Deployment")

--- a/controllers/pulp/web.go
+++ b/controllers/pulp/web.go
@@ -48,9 +48,11 @@ func (r *PulpReconciler) pulpWebController(ctx context.Context, pulp *repomanage
 		if err != nil {
 			log.Error(err, "Failed to create new Pulp Web ConfigMap", "ConfigMap.Namespace", newWebConfigMap.Namespace, "ConfigMap.Name", newWebConfigMap.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Web-Ready", "ErrorCreatingWebConfigmap", "Failed to create "+pulp.Name+"-web configmap resource: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create new Web ConfigMap")
 			return ctrl.Result{}, err
 		}
 		// ConfigMap created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "Web ConfigMap created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get Pulp Web ConfigMap")
@@ -68,9 +70,11 @@ func (r *PulpReconciler) pulpWebController(ctx context.Context, pulp *repomanage
 		if err != nil {
 			log.Error(err, "Failed to create new Pulp Web Deployment", "Deployment.Namespace", newWebDeployment.Namespace, "Deployment.Name", newWebDeployment.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Web-Ready", "ErrorCreatingWebDeployment", "Failed to create "+pulp.Name+"-web deployment resource: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create new Web Deployment")
 			return ctrl.Result{}, err
 		}
 		// Deployment created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "Web Deployment created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get Pulp Web Deployment")
@@ -81,12 +85,15 @@ func (r *PulpReconciler) pulpWebController(ctx context.Context, pulp *repomanage
 	if !equality.Semantic.DeepDerivative(newWebDeployment.Spec, webDeployment.Spec) {
 		log.Info("The Web Deployment has been modified! Reconciling ...")
 		r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Web-Ready", "UpdatingWebDeployment", "Reconciling "+pulp.Name+"-web deployment resource")
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling Web Deployment")
 		err = r.Update(ctx, newWebDeployment)
 		if err != nil {
 			log.Error(err, "Error trying to update the Web Deployment object ... ")
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Web-Ready", "ErrorUpdatingWebDeployment", "Failed to reconcile "+pulp.Name+"-web deployment resource: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to reconcile Web Deployment")
 			return ctrl.Result{}, err
 		}
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updated", "Web Deployment reconciled")
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 	}
 
@@ -102,9 +109,11 @@ func (r *PulpReconciler) pulpWebController(ctx context.Context, pulp *repomanage
 		if err != nil {
 			log.Error(err, "Failed to create new Web Service", "Service.Namespace", newWebSvc.Namespace, "Service.Name", newWebSvc.Name)
 			r.updateStatus(ctx, pulp, metav1.ConditionFalse, pulp.Spec.DeploymentType+"-Web-Ready", "ErrorCreatingWebDService", "Failed to create "+pulp.Name+"-web-svc service resource: "+err.Error())
+			r.recorder.Event(pulp, corev1.EventTypeWarning, "Failed", "Failed to create new Web Service")
 			return ctrl.Result{}, err
 		}
 		// Service created successfully - return and requeue
+		r.recorder.Event(pulp, corev1.EventTypeNormal, "Created", "Web Service created")
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get Web Service")
@@ -125,7 +134,6 @@ func (r *PulpReconciler) pulpWebController(ctx context.Context, pulp *repomanage
 	}
 	*/
 
-	//r.updateStatus(ctx, pulp, metav1.ConditionTrue, pulp.Spec.DeploymentType+"-Web-Ready", "WebTasksFinished", "All Web tasks ran successfully")
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
Now it is also possible to watch/follow the operator events with:
```
$ kubectl get events --sort-by lastTimestamp --field-selector involvedObject.kind=Pulp -w
```

closes #517

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
