### PR TITLE
Dev mode logs to be enabled with env vars

### DIFF
--- a/.ci/scripts/local.sh
+++ b/.ci/scripts/local.sh
@@ -14,6 +14,7 @@ ExecStart=pulp
 Restart=always
 User=root
 Environment="KUBECONFIG=$HOME/.kube/config"
+Environment="DEV_MODE=true"
 [Install]
 WantedBy=multi-user.target
 EOF

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strconv"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -79,8 +80,13 @@ func main() {
 	}
 	logfmtEncoder := zaplogfmt.NewEncoder(configLog)
 
+	DevMode, err := strconv.ParseBool(os.Getenv("DEV_MODE"))
+	if err != nil {
+		DevMode = false
+	}
+
 	// Construct a new logr.logger.
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout), zap.Encoder(logfmtEncoder)))
+	ctrl.SetLogger(zap.New(zap.UseDevMode(DevMode), zap.WriteTo(os.Stdout), zap.Encoder(logfmtEncoder)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
adding env vars to your debugger:
```json
{
    "version": "0.2.0",
    "configurations": [
        {
          "name": "Launch Operator",
          "type": "go",
          "request": "launch",
          "mode": "auto",
          "env": {
            "DEV_MODE": "true"
          },
          "program": "${workspaceFolder}"
        }
    ]
}
```
https://github.com/golang/vscode-go/wiki/debugging