### PR TITLE
Fix wrong var attribution

### DIFF
--- a/controllers/restore/deploy.go
+++ b/controllers/restore/deploy.go
@@ -53,7 +53,7 @@ func (r *PulpRestoreReconciler) restorePulpCR(ctx context.Context, pulpRestore *
 		podReplicas = PodReplicas{
 			Api:     pulp.Spec.Api.Replicas,
 			Content: pulp.Spec.Content.Replicas,
-			Worker:  pulp.Spec.Web.Replicas,
+			Worker:  pulp.Spec.Worker.Replicas,
 			Web:     pulp.Spec.Web.Replicas,
 		}
 


### PR DESCRIPTION
A var used to store the number of worker replicas was receiving the number of web replicas.
[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
