### PR TITLE
Fix issue with signing secret backup

### DIFF
--- a/CHANGES/581.bugfix
+++ b/CHANGES/581.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue with backup controller failing when there was no signing secret.

--- a/controllers/backup/secret.go
+++ b/controllers/backup/secret.go
@@ -71,11 +71,13 @@ func (r *PulpBackupReconciler) backupSecret(ctx context.Context, pulpBackup *rep
 	log.Info("Fields encryption secret backup finished")
 
 	// SIGNING SECRET
-	err = r.createBackupFile(ctx, secretType{"signing_secret", pulpBackup, backupDir, "signing_secret.yaml", pulp.Spec.SigningSecret, pod})
-	if err != nil {
-		return err
+	if len(pulp.Spec.SigningSecret) > 0 {
+		err = r.createBackupFile(ctx, secretType{"signing_secret", pulpBackup, backupDir, "signing_secret.yaml", pulp.Spec.SigningSecret, pod})
+		if err != nil {
+			return err
+		}
+		log.Info("Signing secret backup finished")
 	}
-	log.Info("Signing secret backup finished")
 
 	// CONTAINER TOKEN SECRET
 	err = r.createBackupFile(ctx, secretType{"container_token_secret", pulpBackup, backupDir, "db_fields_encryption_secret.yaml", pulpBackup.Spec.DeploymentName + "-container-auth", pod})


### PR DESCRIPTION
Before trying to backup a non-existent signing secret (which is optional) the controller will first check if it is defined in pulp CR.

fixes #581

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
