### PR TITLE
Add readiness probe to pulp-web container

### DIFF
--- a/CHANGES/579.feature
+++ b/CHANGES/579.feature
@@ -1,0 +1,1 @@
+Added default readiness probe for pulp-web pods.

--- a/controllers/pulp/api.go
+++ b/controllers/pulp/api.go
@@ -1021,7 +1021,8 @@ func serviceAPISpec(name, namespace, deployment_type string) corev1.ServiceSpec 
 			"app":                          "pulp-api",
 			"pulp_cr":                      name,
 		},
-		SessionAffinity: serviceAffinity,
-		Type:            serviceType,
+		SessionAffinity:          serviceAffinity,
+		Type:                     serviceType,
+		PublishNotReadyAddresses: true,
 	}
 }

--- a/controllers/pulp/content.go
+++ b/controllers/pulp/content.go
@@ -529,7 +529,8 @@ func serviceContentSpec(name, namespace, deployment_type string) corev1.ServiceS
 			"app":                          "pulp-content",
 			"pulp_cr":                      name,
 		},
-		SessionAffinity: serviceAffinity,
-		Type:            serviceType,
+		SessionAffinity:          serviceAffinity,
+		Type:                     serviceType,
+		PublishNotReadyAddresses: true,
 	}
 }

--- a/controllers/pulp/web.go
+++ b/controllers/pulp/web.go
@@ -155,6 +155,25 @@ func (r *PulpReconciler) deploymentForPulpWeb(m *repomanagerv1alpha1.Pulp) *apps
 	}
 
 	readinessProbe := m.Spec.Web.ReadinessProbe
+	if readinessProbe == nil {
+		readinessProbe = &corev1.Probe{
+			FailureThreshold: 5,
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: getPulpSetting(m, "api_root") + "api/v3/status/",
+					Port: intstr.IntOrString{
+						IntVal: 8080,
+					},
+					Scheme: corev1.URIScheme("HTTP"),
+				},
+			},
+			InitialDelaySeconds: 150,
+			PeriodSeconds:       20,
+			SuccessThreshold:    1,
+			TimeoutSeconds:      10,
+		}
+	}
+
 	livenessProbe := m.Spec.Web.LivenessProbe
 
 	nodeSelector := map[string]string{}


### PR DESCRIPTION
closes #579

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
