### PR TITLE
Update the wait_on_database_migrations.sh script to actually wait in the face of errors

### DIFF
--- a/containers/images/pulp/container-assets/wait_on_database_migrations.sh
+++ b/containers/images/pulp/container-assets/wait_on_database_migrations.sh
@@ -5,7 +5,7 @@ database_migrated=false
 echo "Checking for database migrations"
 while [ $database_migrated = false ]; do
   /usr/local/bin/pulpcore-manager showmigrations | grep '\[ \]'
-  if [ $? -gt 0 ]; then
+  if [ $? -eq 1 ]; then
     echo "Database migrated!"
     database_migrated=true
   else


### PR DESCRIPTION
The `wait_on_database_migrations.sh` script would not actually wait for the database migrations if `pulpcore-manager` was returning an error for some reason. There was also a fair bit of dead code dealing with "timeouts" which never actually happen in the current version of the script, it'll wait for eternity. This PR updates it to only exit if the grep returns the "not found" exit code, and makes the output a little more correct/verbose.