### PR TITLE
Add some guidance on how PulpBackup should be used

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -256,7 +256,8 @@ spec:
   customresourcedefinitions:
     owned:
     - description: Back up a deployment of the pulp, including all hosted Ansible
-        content
+        content, secrets and the database. By default, a persistent volume claim will
+        be created using the default StorageClass on your cluster to store the backup on.
       displayName: Pulp Backup
       kind: PulpBackup
       name: pulpbackups.pulp.pulpproject.org

--- a/bundle/manifests/pulp.pulpproject.org_pulpbackups.yaml
+++ b/bundle/manifests/pulp.pulpproject.org_pulpbackups.yaml
@@ -20,7 +20,7 @@ spec:
           spec:
             properties:
               backup_pvc:
-                description: Name of the PVC to be used for storing the backup
+                description: Name of existing PVC to be used for storing the backup (must be pre-created if specified)
                 type: string
               backup_pvc_namespace:
                 description: Namespace PVC is in

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -519,7 +519,8 @@ spec:
         - urn:alm:descriptor:io.kubernetes:Secret
       version: v1beta1
     - description: Back up a deployment of the pulp, including all hosted Ansible
-        content
+        content, secrets and the database. By default, a persistent volume claim will
+        be created using the default StorageClass on your cluster to store the backup on.
       displayName: Pulp Backup
       kind: PulpBackup
       name: pulpbackups.pulp.pulpproject.org


### PR DESCRIPTION
There has been some confusion about if the backup_pvc field should be set on PulpBackup's or not.  

This PR adds helper text that attempts to make it clearer that the backup_pvc should not be specified if the user wants a PVC to be automatically created for them.  It should only be specified if the user wants to pre-create the PVC instead of using a StorageClass.  