### PR TITLE
Syntax fix for specifying redis deployment strategy default as recreate

### DIFF
--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -17,8 +17,7 @@ metadata:
 spec:
   replicas: {{ api.replicas }}
 {% if api.strategy is defined %}
-  strategy:
-    type: {{ api.strategy }}
+  strategy: {{ api.strategy }}
 {% endif %}
   selector:
     matchLabels:

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -18,8 +18,7 @@ metadata:
 spec:
   replicas: {{ content.replicas }}
 {% if content.strategy is defined %}
-  strategy:
-    type: {{ content.strategy }}
+  strategy: {{ content.strategy }}
 {% endif %}
   selector:
     matchLabels:

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -17,8 +17,7 @@ metadata:
 spec:
   replicas: {{ web.replicas }}
 {% if web.strategy is defined %}
-  strategy:
-    type: {{ web.strategy }}
+  strategy: {{ web.strategy }}
 {% endif %}
   selector:
     matchLabels:

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -18,8 +18,7 @@ metadata:
 spec:
   replicas: {{ worker.replicas }}
 {% if worker.strategy is defined %}
-  strategy:
-    type: {{ worker.strategy }}
+  strategy: {{ worker.strategy }}
 {% endif %}
   selector:
     matchLabels:

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -2,7 +2,8 @@
 _redis_image: redis:latest
 
 redis:
-  strategy: Recreate
+  strategy:
+    type: Recreate
   resource_requirements:
     requests:
       cpu: 200m

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -19,8 +19,7 @@ metadata:
 spec:
   replicas: 1
 {% if redis.strategy is defined %}
-  strategy:
-    type: {{ redis.strategy }}
+  strategy: {{ redis.strategy }}
 {% endif %}
   selector:
     matchLabels:


### PR DESCRIPTION
The correct syntax for the default is actually:

```
  redis:
    strategy:
      type: Recreate
```

If you fill it out in the form using the "deployment descriptor" it forces you to use this syntax.  As such, we need to also modify how this gets passed in the <component>.deployment.yml.j2 templates.  

I tested this out with the following in my spec.  Once the Pulp object was created, I checked to make sure the k8s validator didn't remove the strategy lines this time, it did not.  

```
  spec:
...
    redis:
      log_level: INFO
      replicas: 1
      strategy:
        type: Recreate

    worker:
      replicas: 1
      resource_requirements:
        requests:
          cpu: 150m
          memory: 256Mi
      strategy:
        type: Recreate
```

This now works as expected.  Here is the yaml on the resulting deployment object:

```
$ oc get deployment galaxy-demo-redis -o yaml | grep strategy -A1
        f:strategy:
          f:type: {}
--
  strategy:
    type: Recreate

```