### PR TITLE
Utilize the renamed `pulp-minimal` and

### DIFF
--- a/CHANGES/717.feature
+++ b/CHANGES/717.feature
@@ -1,0 +1,1 @@
+Utilize the renamed `pulp-minimal` and `galaxy-minimal` images. Also have CI test the new big s6-contining images `pulp` and `pulp-galaxy-ng`.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CR_KIND ?= Pulp
 LOWER_CR_KIND = $(shell echo $(CR_KIND) | tr A-Z a-z)
 CR_PLURAL ?= pulps
 CR_DOMAIN ?= pulpproject.org
-APP_IMAGE ?= quay.io/pulp/pulp
+APP_IMAGE ?= quay.io/pulp/pulp-minimal
 WEB_IMAGE ?= quay.io/pulp/pulp-web
 
 # VERSION defines the project version for the bundle.

--- a/api/v1alpha1/repo_manager_types.go
+++ b/api/v1alpha1/repo_manager_types.go
@@ -174,7 +174,7 @@ type PulpSpec struct {
 
 	// The image name (repo name) for the pulp image.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:="quay.io/pulp/pulp"
+	// +kubebuilder:default:="quay.io/pulp/pulp-minimal"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	Image string `json:"image,omitempty"`
 

--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -80,8 +80,8 @@ metadata:
             "file_storage_access_mode": "ReadWriteOnce",
             "file_storage_size": "2Gi",
             "file_storage_storage_class": "standard",
-            "image_version": "latest",
-            "image_web_version": "latest",
+            "image_version": "nightly",
+            "image_web_version": "nightly",
             "ingress_type": "nodeport",
             "pulp_settings": {
               "allowed_export_paths": [
@@ -132,10 +132,10 @@ metadata:
             "file_storage_access_mode": "ReadWriteMany",
             "file_storage_size": "10Gi",
             "file_storage_storage_class": "standard",
-            "image": "quay.io/pulp/galaxy",
-            "image_version": "latest",
+            "image": "quay.io/pulp/galaxy-minimal",
+            "image_version": "nightly",
             "image_web": "quay.io/pulp/galaxy-web",
-            "image_web_version": "latest",
+            "image_web_version": "nightly",
             "ingress_type": "nodeport",
             "pulp_settings": {
               "allowed_export_paths": [
@@ -1126,7 +1126,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_PULP
-                  value: quay.io/pulp/pulp:stable
+                  value: quay.io/pulp/pulp-minimal:stable
                 - name: RELATED_IMAGE_PULP_WEB
                   value: quay.io/pulp/pulp-web:stable
                 - name: RELATED_IMAGE_PULP_REDIS
@@ -1429,7 +1429,7 @@ spec:
     name: Pulp Community
     url: https://github.com/pulp/pulp-operator
   relatedImages:
-  - image: quay.io/pulp/pulp:stable
+  - image: quay.io/pulp/pulp-minimal:stable
     name: pulp
   - image: quay.io/pulp/pulp-web:stable
     name: pulp-web

--- a/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
+++ b/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
@@ -5785,7 +5785,7 @@ spec:
                 description: The timeout for HAProxy.
                 type: string
               image:
-                default: quay.io/pulp/pulp
+                default: quay.io/pulp/pulp-minimal
                 description: The image name (repo name) for the pulp image.
                 type: string
               image_pull_policy:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,7 +49,7 @@ spec:
         name: manager
         env:
           - name: RELATED_IMAGE_PULP
-            value: quay.io/pulp/pulp:stable
+            value: quay.io/pulp/pulp-minimal:stable
           - name: RELATED_IMAGE_PULP_WEB
             value: quay.io/pulp/pulp-web:stable
           - name: RELATED_IMAGE_PULP_REDIS

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -31,10 +31,10 @@ metadata:
             "deployment_type": "pulp",
             "file_storage_access_mode": "ReadWriteMany",
             "file_storage_size": "10Gi",
-            "image": "quay.io/pulp/galaxy",
-            "image_version": "latest",
+            "image": "quay.io/pulp/galaxy-minimal",
+            "image_version": "nightly",
             "image_web": "quay.io/pulp/galaxy-web",
-            "image_web_version": "latest",
+            "image_web_version": "nightly",
             "ingress_type": "nodeport",
             "is_k8s": true,
             "pulp_settings": {
@@ -90,7 +90,7 @@ metadata:
             "file_storage_access_mode": "ReadWriteOnce",
             "file_storage_size": "2Gi",
             "file_storage_storage_class": "standard",
-            "image_version": "latest",
+            "image_version": "nightly",
             "ingress_type": "nodeport",
             "is_k8s": true,
             "pulp_settings": {
@@ -1286,7 +1286,7 @@ spec:
     name: Pulp Community
     url: https://github.com/pulp/pulp-operator
   relatedImages:
-  - image: quay.io/pulp/pulp:stable
+  - image: quay.io/pulp/pulp-minimal:stable
     name: pulp
   - image: quay.io/pulp/pulp-web:stable
     name: pulp-web

--- a/config/samples/galaxy.azure.ci.yaml
+++ b/config/samples/galaxy.azure.ci.yaml
@@ -4,10 +4,10 @@ metadata:
   name: galaxy-example
 spec:
   deployment_type: galaxy
-  image: quay.io/pulp/galaxy
-  image_version: latest
+  image: quay.io/pulp/galaxy-minimal
+  image_version: nightly
   image_web: quay.io/pulp/galaxy-web
-  image_web_version: latest
+  image_web_version: nightly
   admin_password_secret: "example-pulp-admin-password"
   signing_secret: "signing-galaxy"
   signing_scripts_configmap: "signing-scripts"

--- a/config/samples/galaxy.s3.ci.yaml
+++ b/config/samples/galaxy.s3.ci.yaml
@@ -4,10 +4,10 @@ metadata:
   name: galaxy-example
 spec:
   deployment_type: galaxy
-  image: quay.io/pulp/galaxy
-  image_version: latest
+  image: quay.io/pulp/galaxy-minimal
+  image_version: nightly
   image_web: quay.io/pulp/galaxy-web
-  image_web_version: latest
+  image_web_version: nightly
   admin_password_secret: "example-pulp-admin-password"
   signing_secret: "signing-galaxy"
   signing_scripts_configmap: "signing-scripts"

--- a/config/samples/galaxy.yaml
+++ b/config/samples/galaxy.yaml
@@ -4,10 +4,10 @@ metadata:
   name: galaxy-example
 spec:
   deployment_type: galaxy
-  image: quay.io/pulp/galaxy
-  image_version: latest
+  image: quay.io/pulp/galaxy-minimal
+  image_version: nightly
   image_web: quay.io/pulp/galaxy-web
-  image_web_version: latest
+  image_web_version: nightly
   # no_log: false
   admin_password_secret: "example-pulp-admin-password"
   signing_secret: "signing-galaxy"

--- a/config/samples/pulpproject_v1beta1_pulp_cr.galaxy.ocp.ci.yaml
+++ b/config/samples/pulpproject_v1beta1_pulp_cr.galaxy.ocp.ci.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ocp-example
 spec:
   deployment_type: pulp
-  image: quay.io/pulp/galaxy
+  image: quay.io/pulp/galaxy-minimal
   image_web: quay.io/pulp/galaxy-web
   admin_password_secret: "example-pulp-admin-password"
   signing_secret: "signing-galaxy"

--- a/config/samples/simple-external-cache.yaml
+++ b/config/samples/simple-external-cache.yaml
@@ -4,8 +4,8 @@ metadata:
   name: pulp
 spec:
   deployment_type: pulp
-  image_version: latest
-  image_web_version: latest
+  image_version: nightly
+  image_web_version: nightly
   api:
     replicas: 1
   content:

--- a/config/samples/simple-external-db.yaml
+++ b/config/samples/simple-external-db.yaml
@@ -4,8 +4,8 @@ metadata:
   name: pulp
 spec:
   deployment_type: pulp
-  image_version: latest
-  image_web_version: latest
+  image_version: nightly
+  image_web_version: nightly
   api:
     replicas: 1
   content:

--- a/config/samples/simple-sso.yaml
+++ b/config/samples/simple-sso.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   deployment_type: pulp
   cache_enabled: true
-  image_version: latest
-  image_web_version: latest
+  image_version: nightly
+  image_web_version: nightly
 #  affinity:
 #    nodeAffinity:
 #      requiredDuringSchedulingIgnoredDuringExecution:

--- a/config/samples/simple.ingress.yaml
+++ b/config/samples/simple.ingress.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-pulp
 spec:
   deployment_type: pulp
-  image_version: latest
-  image_web_version: latest
+  image_version: nightly
+  image_web_version: nightly
 #  affinity:
 #    nodeAffinity:
 #      requiredDuringSchedulingIgnoredDuringExecution:

--- a/config/samples/simple.yaml
+++ b/config/samples/simple.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-pulp
 spec:
   deployment_type: pulp
-  image_version: latest
-  image_web_version: latest
+  image_version: nightly
+  image_web_version: nightly
 #  affinity:
 #    nodeAffinity:
 #      requiredDuringSchedulingIgnoredDuringExecution:

--- a/controllers/repo_manager/api.go
+++ b/controllers/repo_manager/api.go
@@ -810,7 +810,7 @@ func (r *RepoManagerReconciler) deploymentForPulpApi(m *repomanagerv1alpha1.Pulp
 	if len(m.Spec.Image) > 0 && len(m.Spec.ImageVersion) > 0 {
 		Image = m.Spec.Image + ":" + m.Spec.ImageVersion
 	} else if Image == "" {
-		Image = "quay.io/pulp/pulp:stable"
+		Image = "quay.io/pulp/pulp-minimal:stable"
 	}
 
 	// deployment definition

--- a/controllers/repo_manager/content.go
+++ b/controllers/repo_manager/content.go
@@ -487,7 +487,7 @@ func (r *RepoManagerReconciler) deploymentForPulpContent(m *repomanagerv1alpha1.
 	if len(m.Spec.Image) > 0 && len(m.Spec.ImageVersion) > 0 {
 		Image = m.Spec.Image + ":" + m.Spec.ImageVersion
 	} else if Image == "" {
-		Image = "quay.io/pulp/pulp:stable"
+		Image = "quay.io/pulp/pulp-minimal:stable"
 	}
 
 	readinessProbe := m.Spec.Content.ReadinessProbe

--- a/controllers/repo_manager/controller_test.go
+++ b/controllers/repo_manager/controller_test.go
@@ -554,7 +554,7 @@ var _ = Describe("Pulp controller", Ordered, func() {
 					Volumes:            volumesApi,
 					Containers: []corev1.Container{{
 						Name:  "api",
-						Image: "quay.io/pulp/pulp:latest",
+						Image: "quay.io/pulp/pulp-minimal:latest",
 						Args:  []string{"pulp-api"},
 						Env:   envVarsApi,
 						Ports: []corev1.ContainerPort{{

--- a/controllers/repo_manager/worker.go
+++ b/controllers/repo_manager/worker.go
@@ -453,7 +453,7 @@ func (r *RepoManagerReconciler) deploymentForPulpWorker(m *repomanagerv1alpha1.P
 	if len(m.Spec.Image) > 0 && len(m.Spec.ImageVersion) > 0 {
 		Image = m.Spec.Image + ":" + m.Spec.ImageVersion
 	} else if Image == "" {
-		Image = "quay.io/pulp/pulp:stable"
+		Image = "quay.io/pulp/pulp-minimal:stable"
 	}
 
 	readinessProbe := m.Spec.Worker.ReadinessProbe


### PR DESCRIPTION
`galaxy-minimal` images.

Also have CI test the new big s6-contining images
`pulp` and `pulp-galaxy-ng`.

Also, the unstable images are now called "nightly" rather
than "latest".

(There are no unstable images for `pulp-galaxy-ng`).

closes: #717