### PR TITLE
route: Ensure route_host backward compatibility

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -37,7 +37,7 @@
 
   - name: Ensure route host
     set_fact:
-      route_host: "{{ ansible_operator_meta.name + '.' + _default_ingress_domain.resources[0].spec.domain | default('') }}"
+      route_host: "{{ ansible_operator_meta.name + '-' + ansible_operator_meta.namespace + '.' + _default_ingress_domain.resources[0].spec.domain | default('') }}"
     when:
       - route_host == ''
       - ingress_type | lower == 'route'


### PR DESCRIPTION
Before the Route refact for removing the need of the web container when using OCP Route then the default route host was using the following parttern:

`<CR name>-<CR namespace>.<default domain>`

Now the pattern is using:

`<CR name>.<default domain>`

which breaks the backward compatibility when upgrading from a previous release.

[noissue]

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
