### PR TITLE
Fix more redis resources reconciliation

### DIFF
--- a/CHANGES/646.bugfix
+++ b/CHANGES/646.bugfix
@@ -10,3 +10,6 @@ Fixed PDB removal logic.
 Fixed Strategy removal logic.
 Set Cache.ExternalCacheSecret as immutable (the controller will reconcile with the same value if the field is modified).
 Fixed Cache.RedisPort reconciliation logic.
+Fixed Cache.Resources reconciliation logic.
+Fixed Cache.NodeSelector reconciliation logic.
+Fixed Cache.Tolerations reconciliation logic.

--- a/controllers/repo_manager/redis.go
+++ b/controllers/repo_manager/redis.go
@@ -118,7 +118,7 @@ func (r *RepoManagerReconciler) pulpCacheController(ctx context.Context, pulp *r
 	}
 
 	// Reconcile Deployment
-	if !equality.Semantic.DeepDerivative(dep.Spec, deploymentFound.Spec) {
+	if deploymentModified(dep, deploymentFound) {
 		log.Info("The Redis Deployment has been modified! Reconciling ...")
 		ctrl.SetControllerReference(pulp, dep, r.Scheme)
 		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling Redis Deployment")


### PR DESCRIPTION
Resources reconciled by this commit:
* Tolerations
* NodeSelector
* ResourceRequirements

ref: #646
[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
