### PR TITLE
Fix "spamming" retry in case of error

### DIFF
--- a/CHANGES/650.bugfix
+++ b/CHANGES/650.bugfix
@@ -1,0 +1,1 @@
+Fixed the backoff loop not incrementing exponentially on error.


### PR DESCRIPTION
From what I could understand, during an error condition we were calling the Status.Update() method in every retry of loop reconcile (even without anything needing to be changed).
This was kind of breaking the idempotency, so each time we called the Status.Update() method I think the controller thought that it was a new iteration, which caused the exponential backoff retry to not increment.

I'm not 100% sure if this will fix all of the "missing" exponential backoff retry.
fixes #650

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
