### PR TITLE
Add a field to set operator unmanaged

### DIFF
--- a/api/v1alpha1/repo_manager_types.go
+++ b/api/v1alpha1/repo_manager_types.go
@@ -29,6 +29,11 @@ type PulpSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// Define if the operator should stop managing Pulp resources.
+	// If set to true, the operator will not execute any task (it will be "disabled").
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
+	Unmanaged bool `json:"unmanaged,omitempty"`
+
 	// Name of the deployment type.
 	// +kubebuilder:default:="pulp"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}

--- a/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
+++ b/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
@@ -5909,6 +5909,10 @@ spec:
                 - Azure
                 - azure
                 type: string
+              unmanaged:
+                description: Define if the operator should be disabled. If set to
+                  true, the operator will not execute any task (it will be "disabled").
+                type: boolean
               web:
                 properties:
                   livenessProbe:

--- a/controllers/repo_manager/README.md
+++ b/controllers/repo_manager/README.md
@@ -135,6 +135,7 @@ PulpSpec defines the desired state of Pulp
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
+| unmanaged | Define if the operator should be disabled. If set to true, the operator will not execute any task (it will be \"disabled\"). | bool | false |
 | deployment_type | Name of the deployment type. | string | false |
 | file_storage_size | The size of the file storage; for example 100Gi. This field should be used only if file_storage_storage_class is provided | string | false |
 | file_storage_access_mode | The file storage access mode. This field should be used only if file_storage_storage_class is provided | string | false |

--- a/controllers/repo_manager/controller.go
+++ b/controllers/repo_manager/controller.go
@@ -116,6 +116,13 @@ func (r *RepoManagerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
+	// if Unmanaged the operator should do nothing
+	// this is useful in situations where we don't want the operator to do reconciliation
+	// for example, during a troubleshooting or for testing
+	if pulp.Spec.Unmanaged {
+		return ctrl.Result{}, nil
+	}
+
 	// "initialize" operator's .status.condition field
 	if !v1.IsStatusConditionPresentAndEqual(pulp.Status.Conditions, cases.Title(language.English, cases.Compact).String(pulp.Spec.DeploymentType)+"-Operator-Finished-Execution", metav1.ConditionTrue) {
 		v1.SetStatusCondition(&pulp.Status.Conditions, metav1.Condition{


### PR DESCRIPTION
Setting the operator as unmanaged will allow to "disable" the operator without having to delete the controller-manager pod. It can be useful in situations where we need to test something and don't want the operator to reconcile our changes.
[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
