### PR TITLE
Remove cache resources with CR update

### DIFF
--- a/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
+++ b/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
@@ -5910,8 +5910,9 @@ spec:
                 - azure
                 type: string
               unmanaged:
-                description: Define if the operator should be disabled. If set to
-                  true, the operator will not execute any task (it will be "disabled").
+                description: Define if the operator should stop managing Pulp resources.
+                  If set to true, the operator will not execute any task (it will
+                  be "disabled").
                 type: boolean
               web:
                 properties:

--- a/controllers/repo_manager/README.md
+++ b/controllers/repo_manager/README.md
@@ -135,7 +135,7 @@ PulpSpec defines the desired state of Pulp
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| unmanaged | Define if the operator should be disabled. If set to true, the operator will not execute any task (it will be \"disabled\"). | bool | false |
+| unmanaged | Define if the operator should stop managing Pulp resources. If set to true, the operator will not execute any task (it will be \"disabled\"). | bool | false |
 | deployment_type | Name of the deployment type. | string | false |
 | file_storage_size | The size of the file storage; for example 100Gi. This field should be used only if file_storage_storage_class is provided | string | false |
 | file_storage_access_mode | The file storage access mode. This field should be used only if file_storage_storage_class is provided | string | false |

--- a/controllers/repo_manager/controller.go
+++ b/controllers/repo_manager/controller.go
@@ -218,6 +218,17 @@ func (r *RepoManagerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		} else if pulpController.RequeueAfter > 0 {
 			return pulpController, nil
 		}
+
+		// remove redis resources if cache is not enabled
+	} else {
+		pulpController, err = r.deprovisionCache(ctx, pulp, log)
+		if err != nil {
+			return pulpController, err
+		} else if pulpController.Requeue {
+			return pulpController, nil
+		} else if pulpController.RequeueAfter > 0 {
+			return pulpController, nil
+		}
 	}
 
 	log.V(1).Info("Running API tasks")


### PR DESCRIPTION
This commit adds the logic of removing Redis resource based on Pulp CR modification. For example, if .cache.enabled was true and now we set it to false, all cache resources will be removed. 
[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
