### PR TITLE
Modify api and content svc to get clusterip

### DIFF
--- a/CHANGES/737.bugfix
+++ b/CHANGES/737.bugfix
@@ -1,0 +1,1 @@
+Fixed issue with headless services propagating new address to pulp-web pods.

--- a/controllers/repo_manager/api.go
+++ b/controllers/repo_manager/api.go
@@ -1163,8 +1163,6 @@ func serviceAPISpec(name, namespace, deployment_type string) corev1.ServiceSpec 
 	serviceType := corev1.ServiceType("ClusterIP")
 
 	return corev1.ServiceSpec{
-		ClusterIP:             "None",
-		ClusterIPs:            []string{"None"},
 		InternalTrafficPolicy: &serviceInternalTrafficPolicyCluster,
 		IPFamilies:            []corev1.IPFamily{"IPv4"},
 		IPFamilyPolicy:        &ipFamilyPolicyType,

--- a/controllers/repo_manager/content.go
+++ b/controllers/repo_manager/content.go
@@ -612,8 +612,6 @@ func serviceContentSpec(name, namespace, deployment_type string) corev1.ServiceS
 	serviceType := corev1.ServiceType("ClusterIP")
 
 	return corev1.ServiceSpec{
-		ClusterIP:             "None",
-		ClusterIPs:            []string{"None"},
 		InternalTrafficPolicy: &serviceInternalTrafficPolicyCluster,
 		IPFamilies:            []corev1.IPFamily{"IPv4"},
 		IPFamilyPolicy:        &ipFamilyPolicyType,


### PR DESCRIPTION
When the service was configured as "headless", the nginx upstream configuration was pointing directly to the pods backing it. Because of that, when an endpoint died, the nginx was still pointing to the same address which was returning errors.
fixes #737

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
