### PR TITLE
Fix some issues with pulp status

### DIFF
--- a/.ci/scripts/backup_and_restore.sh
+++ b/.ci/scripts/backup_and_restore.sh
@@ -49,7 +49,7 @@ kubectl logs -l app.kubernetes.io/name=pulp-operator -c manager --tail=10000
 echo ::endgroup::
 
 sudo pkill -f "port-forward" || true
-time kubectl wait --for condition=Galaxy-Operator-Finished-Execution galaxy/galaxy-example --timeout=800s
+time kubectl wait --for condition=Galaxy-Operator-Finished-Execution galaxy.repo-manager.ansible.com/galaxy-example --timeout=800s
 kubectl get pods -o wide
 
 KUBE="k3s"

--- a/CHANGES/735.bugfix
+++ b/CHANGES/735.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue with .status.conditions[] not getting updated for pulpcore-workers.

--- a/CHANGES/736.bugfix
+++ b/CHANGES/736.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue with .status.conditions[] getting updated in a specific order.

--- a/controllers/repo_manager/controller_test.go
+++ b/controllers/repo_manager/controller_test.go
@@ -1158,9 +1158,11 @@ var _ = Describe("Pulp controller", Ordered, func() {
 })
 
 // waitPulpOperatorFinish waits until find "Pulp-Operator-Finished-Execution" pulp.Status.Condition
-// or 60 seconds timeout
+// or 5 seconds timeout
 func waitPulpOperatorFinish(ctx context.Context, createdPulp *repomanagerv1alpha1.Pulp) {
-	for timeout := 0; timeout < 60; timeout++ {
+	time.Sleep(time.Second)
+
+	for timeout := 0; timeout < 5; timeout++ {
 		objectGet(ctx, createdPulp, PulpName)
 		//a, _ := json.MarshalIndent(createdPulp.Status.Conditions, "", "  ")
 		//fmt.Println(string(a))

--- a/controllers/repo_manager/utils.go
+++ b/controllers/repo_manager/utils.go
@@ -42,6 +42,12 @@ type immutableField struct {
 	FieldPath interface{}
 }
 
+// statusReturn is used to control goroutines execution
+type statusReturn struct {
+	ctrl.Result
+	error
+}
+
 // Generate a random string with length pwdSize
 func createPwd(pwdSize int) string {
 	const chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"


### PR DESCRIPTION
refactored pulpStatus
fixes #735
fixes #736
also "fixed" an issue in which r.Status().Update() triggers a reconcile (resulting in RequeueAfter to not work if pulpStatus is modified), stopping with the spam of "pulp <resource> not ready yet ..." in logs.

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
