### PR TITLE
Adding a "retry" in case it fails to update status

### DIFF
--- a/CHANGES/751.bugfix
+++ b/CHANGES/751.bugfix
@@ -1,0 +1,1 @@
+Added a "retry" in case controller fails to update operator's status.conditions[].

--- a/controllers/repo_manager/status.go
+++ b/controllers/repo_manager/status.go
@@ -123,7 +123,10 @@ func (r *RepoManagerReconciler) pulpStatus(ctx context.Context, pulp *repomanage
 			LastTransitionTime: metav1.Now(),
 			Message:            "All tasks ran successfully",
 		})
-		r.Status().Update(ctx, pulp)
+		if err := r.Status().Update(ctx, pulp); err != nil {
+			log.Error(err, "Failed to update pulp status")
+			return ctrl.Result{}, err
+		}
 		log.Info(pulp.Spec.DeploymentType + " operator finished execution ...")
 	}
 


### PR DESCRIPTION
If more than one operator worker try to update a k8s resource it is common to receive an error like:
```
"error": "Operation cannot be fulfilled on galaxies.repo-manager.ansible.com
\"galaxy-example\": the object has been modified; please apply your changes
to the latest version and try again"
```
This commit is returning an error (which will trigger a reconcile loop) in case it failed to update the `.status.conditions[]` field.

fixes #751

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
