### PR TITLE
Enable multi-architecture builds from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,5 +309,5 @@ jobs:
         run: echo "$QUAY_BOT_PASSWORD" | docker login -u "$QUAY_BOT_USERNAME" --password-stdin quay.io
       - name: Build and Push images
         run: |
-          make docker-build docker-push bundle-build bundle-push catalog-build catalog-push
+          make docker-buildx docker-push bundle-build bundle-push catalog-build catalog-push
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,5 +309,5 @@ jobs:
         run: echo "$QUAY_BOT_PASSWORD" | docker login -u "$QUAY_BOT_USERNAME" --password-stdin quay.io
       - name: Build and Push images
         run: |
-          make docker-buildx docker-push bundle-build bundle-push catalog-build catalog-push
+          make docker-buildx bundle-build bundle-push catalog-build catalog-push
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 


### PR DESCRIPTION
This modifies the CI to use multi-architecture builds. A fix for using buildx instead of build is provided (a context argument is needed here). I'm specifically submitting that as we would like to use that operator and we have a multi-arch amd64/arm64 cluster, where workloads are usually failing when they don't provide multi-arch containers.

[Here](https://github.com/StopMotionCuber/pulp-operator/actions/runs/3428729319/jobs/5713398320) you can see a sample workflow run, using a modified branch for rapid testing and removed dependent steps. Obviously the push didn't succeed, as I do not have quay.io credentials.

I didn't create an issue for this PR. In case something like that is needed for the changelog, let me know