### PR TITLE
Add missing full path to container images

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -1169,9 +1169,9 @@ spec:
                 - name: RELATED_IMAGE_PULP_WEB
                   value: quay.io/pulp/pulp-web:stable
                 - name: RELATED_IMAGE_PULP_REDIS
-                  value: redis:latest
+                  value: docker.io/library/redis:latest
                 - name: RELATED_IMAGE_PULP_POSTGRES
-                  value: postgres:13
+                  value: docker.io/library/postgres:13
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -1468,8 +1468,8 @@ spec:
     name: pulp
   - image: quay.io/pulp/pulp-web:stable
     name: pulp-web
-  - image: redis:latest
+  - image: docker.io/library/redis:latest
     name: pulp-redis
-  - image: postgres:13
+  - image: docker.io/library/postgres:13
     name: pulp-postgres
   version: 1.0.0-alpha.3


### PR DESCRIPTION
Adding the full path to redis and postgres image containers in the CSV.
[noissue]

Signed-off-by: Leo Ochoa [lochoa@redhat.com](mailto:lochoa@redhat.com)