### PR TITLE
Remove buildplatform for docker buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -194,11 +194,9 @@ docker-push: ## Push docker image with the manager.
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: test ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 


### PR DESCRIPTION
This is a follow up to #764

As I have now been testing the operator, I found out that it still doesn't run on non-amd64 nodes. Digging into the issue, I found out that $BUILDPLATFORM is specified as platform, leading to amd64 images being built. Additionally GOARCH=amd64 is set, which would suggest and amd64 binary being built.

An according action is present [here](https://github.com/StopMotionCuber/pulp-operator/actions/runs/3523113259/jobs/5906876847), on a further branch with testing and quay login cut off additionally.

Another option would be to utilize $TARGETARCH as $GOARCH, making go cross-compile to the desired architecture