### PR TITLE
Add updateObject function

### DIFF
--- a/controllers/repo_manager/redis.go
+++ b/controllers/repo_manager/redis.go
@@ -118,7 +118,7 @@ func (r *RepoManagerReconciler) pulpCacheController(ctx context.Context, pulp *r
 	}
 
 	// Reconcile Deployment
-	if deploymentModified(dep, deploymentFound) {
+	if checkDeploymentSpec(dep.Spec, deploymentFound.Spec) {
 		log.Info("The Redis Deployment has been modified! Reconciling ...")
 		ctrl.SetControllerReference(pulp, dep, r.Scheme)
 		r.recorder.Event(pulp, corev1.EventTypeNormal, "Updating", "Reconciling Redis Deployment")

--- a/controllers/repo_manager/route.go
+++ b/controllers/repo_manager/route.go
@@ -156,16 +156,14 @@ func (r *RepoManagerReconciler) pulpRouteController(ctx context.Context, pulp *r
 			}
 
 			// Ensure route specs are as expected
-			if err := r.reconcileObject(ctx, pulp, expectedRoute, currentRoute, conditionType, log); err != nil {
-				log.Error(err, "Failed to update route spec")
-				c <- statusReturn{ctrl.Result{}, err}
+			if requeue, err := reconcileObject(FunctionResources{ctx, pulp, log, r}, expectedRoute, currentRoute, conditionType); err != nil || requeue {
+				c <- statusReturn{ctrl.Result{Requeue: requeue}, err}
 				return
 			}
 
 			// Ensure route labels and annotations are as expected
-			if err := r.reconcileMetadata(ctx, pulp, expectedRoute, currentRoute, conditionType, log); err != nil {
-				log.Error(err, "Failed to update route labels")
-				c <- statusReturn{ctrl.Result{}, err}
+			if requeue, err := reconcileMetadata(FunctionResources{ctx, pulp, log, r}, expectedRoute, currentRoute, conditionType); err != nil || requeue {
+				c <- statusReturn{ctrl.Result{Requeue: requeue}, err}
 				return
 			}
 


### PR DESCRIPTION
updateObject is used by reconcileObject and reconcileMetadata. It will use the "modified" function provided to check if a field/spec has been modified and will run an "update" request to the object if needed.
[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
