### PR TITLE
pulp-api: remove secret_key fact

### DIFF
--- a/roles/pulp-api/tasks/main.yml
+++ b/roles/pulp-api/tasks/main.yml
@@ -1,9 +1,5 @@
 ---
 - set_fact:
-    secret_key: "{{ lookup('password', '/dev/null length=50 chars=ascii_letters') }}"
-  no_log: "{{ no_log }}"
-
-- set_fact:
     object_storage_secret: "{{ object_storage_s3_secret }}"
   when:
     - object_storage_s3_secret is defined


### PR DESCRIPTION
The `secret_key` fact isn't use at all by the operator.

[noissue]

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>