### PR TITLE
Remove pulp-web on upgrade with OCP route

### DIFF
--- a/roles/pulp-routes/tasks/main.yml
+++ b/roles/pulp-routes/tasks/main.yml
@@ -23,6 +23,17 @@
     - ingress_type is defined
     - ('route' == ingress_type|lower) or ('ingress' == ingress_type|lower)
 
+- name: Remove pulp-web deployment with route
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Deployment
+    name: "{{ ansible_operator_meta.name }}-web"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    state: absent
+  when:
+    - ingress_type is defined
+    - ingress_type | lower == 'route'
+
 - k8s_status:
     api_version: "{{ api_version }}"
     kind: "{{ kind }}"


### PR DESCRIPTION
When upgrading from an older operator release (when OCP route was still using the pulp-web pod) then the pulp-web deployment is still present after the upgrade.
This ensures that the pulp web deployment is absent when the ingress type is configured to use OCP route.

[noissue]

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>