### PR TITLE
Revert "config/rbac: Add ingresses.config.openshift.io"

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -1006,6 +1006,17 @@ spec:
     mediatype: image/svg+xml
   install:
     spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - config.openshift.io
+          resourceNames:
+          - cluster
+          resources:
+          - ingresses
+          verbs:
+          - get
+        serviceAccountName: pulp-operator-sa
       deployments:
       - label:
           app.kubernetes.io/component: operator
@@ -1146,16 +1157,6 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        - apiGroups:
-          - config.openshift.io
-          resourceNames:
-          - cluster
-          resources:
-          - ingresses
-          verbs:
-          - get
-          - list
-          - watch
         - apiGroups:
           - route.openshift.io
           resources:

--- a/config/rbac/cluster_role.yaml
+++ b/config/rbac/cluster_role.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pulp-manager-cluster-role
+rules:
+  - apiGroups:
+      - config.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - ingresses
+    verbs:
+      - get

--- a/config/rbac/cluster_role_binding.yaml
+++ b/config/rbac/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pulp-manager-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pulp-manager-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: sa

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -6,7 +6,9 @@ resources:
 # subjects if changing service account names.
 - service_account.yaml
 - role.yaml
+- cluster_role.yaml
 - role_binding.yaml
+- cluster_role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,16 +8,6 @@ rules:
   ## Base operator rules
   ##
   - apiGroups:
-      - config.openshift.io
-    resourceNames:
-      - cluster
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - route.openshift.io
     resources:
       - routes

--- a/molecule/default/resources.yml
+++ b/molecule/default/resources.yml
@@ -7,5 +7,7 @@
   with_items:
     - service_account.yaml
     - role.yaml
+    - cluster_role.yaml
     - role_binding.yaml
+    - cluster_role_binding.yaml
     - operator.yaml


### PR DESCRIPTION
This change was initially made to enable downstream builds.  We have since added logic downstream to handle this, and this change can be reverted.  
