### PR TITLE
Add check for nil ingress_host

### DIFF
--- a/CHANGES/675.bugfix
+++ b/CHANGES/675.bugfix
@@ -1,0 +1,1 @@
+Added a check for `ingress_host` being null when `ingress_type` defined as "ingress".


### PR DESCRIPTION
From pulpcore doc https://docs.pulpproject.org/pulpcore/configuration/settings.html#content-origin this is a required setting, so the operator will output an error if ingress_host is not provided.
closes #675

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
