### PR TITLE
Add ansibleMigrationTasks method

### DIFF
--- a/api/v1alpha1/repo_manager_types.go
+++ b/api/v1alpha1/repo_manager_types.go
@@ -1003,6 +1003,19 @@ type PulpStatus struct {
 	AdminPasswordSecret string `json:"admin_password_secret,omitempty"`
 	// Name of the secret with the parameters to connect to an external Redis cluster
 	ExternalCacheSecret string `json:"external_cache_secret,omitempty"`
+
+	// [DEPRECATED] Temporarily adding to keep compatibility with ansible version.
+	StoragePersistentVolumeClaim       string `json:"storagePersistentVolumeClaim,omitempty"`
+	WebURL                             string `json:"webURL,omitempty"`
+	DatabaseConfigurationSecret        string `json:"databaseConfigurationSecret,omitempty"`
+	StorageType                        string `json:"storageType,omitempty"`
+	StorageSecret                      string `json:"storageSecret,omitempty"`
+	DeployedVersion                    string `json:"deployedVersion,omitempty"`
+	DeployedImage                      string `json:"deployedImage,omitempty"`
+	MigrantDatabaseConfigurationSecret string `json:"migrantDatabaseConfigurationSecret,omitempty"`
+	DbFieldsEncryptionSecret           string `json:"dbFieldsEncryptionSecret,omitempty"`
+	UpgradedPostgresVersion            string `json:"upgradedPostgresVersion,omitempty"`
+	MigrationDone                      bool   `json:"migration_done,omitempty"`
 }
 
 // Pulp is the Schema for the pulps API

--- a/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
+++ b/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
@@ -8826,8 +8826,16 @@ spec:
               container_token_secret:
                 description: Secret where the container token certificates are stored.
                 type: string
+              databaseConfigurationSecret:
+                type: string
               db_fields_encryption_secret:
                 description: Secret where the Fernet symmetric encryption key is stored.
+                type: string
+              dbFieldsEncryptionSecret:
+                type: string
+              deployedImage:
+                type: string
+              deployedVersion:
                 type: string
               deployment_type:
                 description: Name of the deployment type.
@@ -8843,11 +8851,27 @@ spec:
               ingress_type:
                 description: The ingress type to use to reach the deployed instance
                 type: string
+              migrantDatabaseConfigurationSecret:
+                type: string
+              migration_done:
+                type: boolean
               object_storage_azure_secret:
                 description: The secret for Azure compliant object storage configuration.
                 type: string
               object_storage_s3_secret:
                 description: The secret for S3 compliant object storage configuration.
+                type: string
+              storagePersistentVolumeClaim:
+                description: '[DEPRECATED] Temporarily adding to keep compatibility
+                  with ansible version.'
+                type: string
+              storageSecret:
+                type: string
+              storageType:
+                type: string
+              upgradedPostgresVersion:
+                type: string
+              webURL:
                 type: string
             required:
             - conditions

--- a/controllers/repo_manager/README.md
+++ b/controllers/repo_manager/README.md
@@ -244,6 +244,17 @@ PulpStatus defines the observed state of Pulp
 | container_token_secret | Secret where the container token certificates are stored. | string | false |
 | admin_password_secret | Secret where the administrator password can be found | string | false |
 | external_cache_secret | Name of the secret with the parameters to connect to an external Redis cluster | string | false |
+| storagePersistentVolumeClaim | [DEPRECATED] Temporarily adding to keep compatibility with ansible version. | string | false |
+| webURL |  | string | false |
+| databaseConfigurationSecret |  | string | false |
+| storageType |  | string | false |
+| storageSecret |  | string | false |
+| deployedVersion |  | string | false |
+| deployedImage |  | string | false |
+| migrantDatabaseConfigurationSecret |  | string | false |
+| dbFieldsEncryptionSecret |  | string | false |
+| upgradedPostgresVersion |  | string | false |
+| migration_done |  | bool | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/controllers/repo_manager/api.go
+++ b/controllers/repo_manager/api.go
@@ -249,7 +249,7 @@ func deploymentForPulpApi(resources FunctionResources) client.Object {
 	}
 	gunicornTimeout := strconv.Itoa(resources.Pulp.Spec.Api.GunicornTimeout)
 	if resources.Pulp.Spec.GunicornTimeout > 0 { // [DEPRECATED] Temporarily adding to keep compatibility with ansible version.
-		gunicornWorkers = strconv.Itoa(resources.Pulp.Spec.GunicornTimeout)
+		gunicornTimeout = strconv.Itoa(resources.Pulp.Spec.GunicornTimeout)
 	}
 	envVars := []corev1.EnvVar{
 		{Name: "PULP_GUNICORN_TIMEOUT", Value: gunicornTimeout},

--- a/controllers/repo_manager/content.go
+++ b/controllers/repo_manager/content.go
@@ -269,7 +269,7 @@ func deploymentForPulpContent(resources FunctionResources) client.Object {
 	}
 	gunicornTimeout := strconv.Itoa(resources.Pulp.Spec.Content.GunicornTimeout)
 	if resources.Pulp.Spec.GunicornTimeout > 0 { // [DEPRECATED] Temporarily adding to keep compatibility with ansible version.
-		gunicornWorkers = strconv.Itoa(resources.Pulp.Spec.GunicornTimeout)
+		gunicornTimeout = strconv.Itoa(resources.Pulp.Spec.GunicornTimeout)
 	}
 	envVars := []corev1.EnvVar{
 		{Name: "PULP_GUNICORN_TIMEOUT", Value: gunicornTimeout},

--- a/controllers/repo_manager/controller.go
+++ b/controllers/repo_manager/controller.go
@@ -171,6 +171,11 @@ func (r *RepoManagerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	}
 
+	// [DEPRECATED] Temporarily adding to keep compatibility with ansible version.
+	if requeue, err := ansibleMigrationTasks(FunctionResources{ctx, pulp, log, r}); needsRequeue(err, requeue) {
+		return ctrl.Result{Requeue: true}, err
+	}
+
 	// Checking if there is more than one storage type defined.
 	// Only a single type should be provided, if more the operator will not be able to
 	// determine which one should be used.

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -74,6 +74,21 @@ func IsOpenShift() (bool, error) {
 func MultiStorageConfigured(pulp *repomanagerv1alpha1.Pulp, resource string) (bool, []string) {
 	var names []string
 
+	// [DEPRECATED] Temporarily adding to keep compatibility with ansible version.
+	// for ansible migration we are ignoring the multistorage check
+	if pulp.Status.MigrationDone {
+		if resource == DatabaseResource {
+			return false, []string{PVCType}
+		}
+		if len(pulp.Spec.ObjectStorageAzureSecret) > 0 {
+			return false, []string{AzureObjType}
+		}
+		if len(pulp.Spec.ObjectStorageS3Secret) > 0 {
+			return false, []string{S3ObjType}
+		}
+		return false, []string{PVCType}
+	}
+
 	switch resource {
 	case PulpResource:
 		if len(pulp.Spec.ObjectStorageAzureSecret) > 0 {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20220825183227-75c111537c4d
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd
+	golang.org/x/exp v0.0.0-20230108222341-4b8118a2686a
 	golang.org/x/text v0.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230108222341-4b8118a2686a h1:tlXy25amD5A7gOfbXdqCGN5k8ESEed/Ee1E5RcrYnqU=
+golang.org/x/exp v0.0.0-20230108222341-4b8118a2686a/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
The ansibleMigrationTasks method will automate some steps needed when upgrading from ansible-based to go-based version of the operator.

[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
