### PR TITLE
Add reconciliation for old postgres svc

### DIFF
--- a/.ci/scripts/pulp_tests.sh
+++ b/.ci/scripts/pulp_tests.sh
@@ -35,10 +35,13 @@ else
 fi
 echo $BASE_ADDR
 
-if [ -z "$(pip3 freeze | grep pulp-cli)" ]; then
-  echo "Installing pulp-cli"
-  pip3 install --user pulp-cli[pygments]
-fi
+
+# Install pulp-cli the same way we do in pulp_ansible repo (to avoid tests with version mismatch, for example)
+# https://github.com/pulp/pulp_ansible/blob/5778d86ae51738578f7c5f00214b5ccb8aa1ee45/.github/workflows/scripts/before_install.sh#L96-L102
+git clone --depth=1 https://github.com/pulp/pulp-cli.git
+pushd pulp-cli
+pip install .
+popd
 
 if [ ! -f ~/.config/pulp/settings.toml ]; then
   echo "Configuring pulp-cli"


### PR DESCRIPTION
Golang version is keeping the database service deployed by ansible to avoid having to touch the secrets (which could have been manually modified by users). In this case, we need to also watch for any modification in this service with the golang controller because if users modify or delete it they will be lost on how to proceed and pulp-api pods would lose access to the database.

[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
