### PR TITLE
change date format to avoid ':'

### DIFF
--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -54,7 +54,7 @@
 
 - name: Determine the timestamp for the backup once for all nodes
   set_fact:
-    now: '{{ lookup("pipe", "date +%F-%T") }}'
+    now: '{{ lookup("pipe", "date +%F-%H%M%S") }}'
 
 - name: Set backup directory name
   set_fact:


### PR DESCRIPTION
Change date format to avoid : character. Some filesystems do not allow for this.

Fixes: https://issues.redhat.com/browse/AAP-9250
