### PR TITLE
Modify bkp/restore controllers for compatibility

### DIFF
--- a/.ci/scripts/kubelinter.sh
+++ b/.ci/scripts/kubelinter.sh
@@ -15,5 +15,5 @@ if [ ! -e $TARGET ]; then
   tar -xf $TARGET
 fi
 mkdir -p lint
-kubectl get ${TEST:-pulp},${TEST:-pulp}backup,${TEST:-pulp}restore,pvc,configmap,serviceaccount,secret,networkpolicy,ingress,service,deployment,statefulset,hpa,job,cronjob -o yaml > ./lint/k8s-all.yaml
+kubectl get ${TEST:-pulp,pulpbackup,pulprestore},pvc,configmap,serviceaccount,secret,networkpolicy,ingress,service,deployment,statefulset,hpa,job,cronjob -o yaml > ./lint/k8s-all.yaml
 ./kube-linter lint ./lint --config .ci/assets/kubernetes/.kube-linter.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
           echo ::endgroup::
           echo "HTTPIE_CONFIG_DIR=$GITHUB_WORKSPACE/.ci/assets/httpie/" >> $GITHUB_ENV
           echo "CI_TEST=true" >> $GITHUB_ENV
-          echo "TEST=galaxy" >> $GITHUB_ENV
+          echo "TEST=galaxy,galaxybackup,galaxyrestore" >> $GITHUB_ENV
           echo "CI_TEST_STORAGE=${{ matrix.STORAGE }}" >> $GITHUB_ENV
           echo "API_ROOT=/api/galaxy/pulp/" >> $GITHUB_ENV
         shell: bash
@@ -501,6 +501,154 @@ jobs:
           kubectl get pulps.repo-manager.pulpproject.org
           sudo systemctl stop pulp-operator.service
           make local
+        shell: bash
+      - name: Check and wait pulp-operator deploy
+        run: kubectl wait --for condition=Pulp-Operator-Finished-Execution pulp/example-pulp --timeout=600s
+        shell: bash
+      - name: KubeLinter
+        if: github.event_name == 'pull_request'
+        run: .ci/scripts/kubelinter.sh
+      - name: Test all components
+        run: |
+          git clone --depth=1 https://github.com/pulp/pulp_ansible.git
+          git clone --depth=1 https://github.com/pulp/pulp_container.git
+          .ci/scripts/pulp_tests.sh -m
+        shell: bash
+        env:
+          PY_COLORS: '1'
+      - name: Logs
+        if: always()
+        run: .github/workflows/scripts/show_logs.sh
+  migrate:
+    runs-on: ubuntu-latest
+    if: github.ref_name != 'ansible'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - INGRESS_TYPE: nodeport
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: pulp/pulp-operator
+          ref: ansible
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.8'
+      - name: Install httpie
+        run: |
+          echo ::group::HTTPIE
+          sudo apt-get update -yq
+          sudo -E apt-get -yq --no-install-suggests --no-install-recommends install httpie
+          echo ::endgroup::
+          echo "HTTPIE_CONFIG_DIR=$GITHUB_WORKSPACE/.ci/assets/httpie/" >> $GITHUB_ENV
+          echo "CI_TEST=true" >> $GITHUB_ENV
+          echo "TEST=pulp" >> $GITHUB_ENV
+          echo "INGRESS_TYPE=${{ matrix.INGRESS_TYPE }}" >> $GITHUB_ENV
+        shell: bash
+      - name: Updating registries configuration
+        run: |
+          if [ -f "/etc/docker/daemon.json" ]
+          then
+            echo "INFO:
+            Updating docker configuration
+            "
+
+            echo "$(cat /etc/docker/daemon.json | jq -s '.[0] + {
+            "insecure-registries" : ["ingress.local"]
+            }')" | sudo tee /etc/docker/daemon.json
+            sudo service docker restart || true
+          fi
+
+          if [ -f "/etc/containers/registries.conf" ]
+          then
+            echo "INFO:
+            Updating registries configuration
+            "
+            echo "[registries.insecure]
+            registries = ['ingress.local']
+            " | sudo tee -a /etc/containers/registries.conf
+          fi
+        shell: bash
+      - name: Start minikube
+        run: |
+          minikube start --memory=max --cpus=max --vm-driver=docker --extra-config=apiserver.service-node-port-range=80-32000
+          minikube addons enable metrics-server
+          minikube addons enable ingress
+        # now you can run kubectl to see the pods in the cluster
+      - name: Try the cluster !
+        run: kubectl get pods -A
+      - name: Setup a minikube docker env
+        run: minikube -p minikube docker-env | grep "export" | sed 's/export //' | sed 's/"//g' >> $GITHUB_ENV
+      - name: Uninstalling GHA kustomize
+        run: |
+          # hack for uninstalling kustomize from GHA
+          mv /usr/local/bin/kustomize /usr/local/bin/ghakustomize
+          make kustomize
+          mv ./bin/kustomize /usr/local/bin/kustomize
+          kustomize version
+        shell: bash
+      - name: Prepare Object Storage
+        run: |
+          .ci/scripts/prepare-object-storage.sh
+        shell: bash
+      - name: Deploy pulp-operator to K8s
+        run: |
+          sudo -E make docker-build IMG=quay.io/pulp/pulp-operator:ansible-devel
+          make deploy IMG=quay.io/pulp/pulp-operator:ansible-devel
+          kubectl get namespace
+          kubectl config set-context --current --namespace=pulp-operator-system
+          kubectl apply -f .ci/assets/kubernetes/pulp-admin-password.secret.yaml
+          kubectl apply -f-<<EOF
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: container-auth
+          stringData:
+            container_auth_private_key.pem: |-
+              -----BEGIN EC PRIVATE KEY-----
+              MHcCAQEEIMgYinafJVjYHHnAk8w3EOiZxJLK5sXaXtSMT6APWYq+oAoGCCqGSM49
+              AwEHoUQDQgAEzWXdtJTvHinfnN2xzn71etmfkBTmDMZHMMQmSIofMNMcl8ATneZU
+              pGplUzS5UspaSUomdfkJ0d92Mk0DDXLV7A==
+              -----END EC PRIVATE KEY-----
+            container_auth_public_key.pem: |-
+              -----BEGIN PUBLIC KEY-----
+              MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzWXdtJTvHinfnN2xzn71etmfkBTm
+              DMZHMMQmSIofMNMcl8ATneZUpGplUzS5UspaSUomdfkJ0d92Mk0DDXLV7A==
+              -----END PUBLIC KEY-----
+          EOF
+          if [[ "$INGRESS_TYPE" == "ingress" ]]; then
+            kubectl apply -f config/samples/simple.ingress.yaml
+          else
+            kubectl apply -f config/samples/pulpproject_v1beta1_pulp_cr.ci.yaml
+          fi
+        shell: bash
+      - name: Check and wait pulp-operator deploy [before migration]
+        run: kubectl wait --for condition=Pulp-Operator-Finished-Execution pulp/example-pulp --timeout=600s
+        shell: bash
+      - name: Logs [before migration]
+        if: always()
+        run: .github/workflows/scripts/show_logs.sh
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Go environment
+        uses: actions/setup-go@v3.2.0
+        with:
+          go-version: '1.18.3'
+          cache: true
+      - name: Migrate to golang version
+        run: |
+          grep repo-manager * -rl | xargs sed -i 's/repo-manager/pulp/g'
+          mv apis/{repo-manager,pulp}.pulpproject.org
+
+          kubectl get clusterroles -oname|grep pulp|xargs oc delete
+          kubectl delete roles --all
+          kubectl delete deployment pulp-operator-controller-manager
+          sudo -E docker build -t quay.io/pulp/pulp-operator:go-devel .
+          make deploy IMG=quay.io/pulp/pulp-operator:go-devel
+          kubectl get pulps.pulp.pulpproject.org
         shell: bash
       - name: Check and wait pulp-operator deploy
         run: kubectl wait --for condition=Pulp-Operator-Finished-Execution pulp/example-pulp --timeout=600s

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,4 +7,5 @@
     ".ci/assets/kubernetes/galaxy_sign.secret.yaml",
     ".ci/scripts/prepare-object-storage.sh",
     "containers/compose/certs/database_fields.symmetric.key",
+    ".github/workflows/ci.yml",
   ]

--- a/apis/repo-manager.pulpproject.org/v1beta2/pulp_backup_types.go
+++ b/apis/repo-manager.pulpproject.org/v1beta2/pulp_backup_types.go
@@ -25,7 +25,7 @@ import (
 type PulpBackupSpec struct {
 
 	// Name of the deployment type. Can be one of {galaxy,pulp}.
-	// +kubebuilder:validation:Enum:=pulp;galaxy
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	DeploymentType string `json:"deployment_type"`
 
@@ -65,12 +65,12 @@ type PulpBackupSpec struct {
 	PostgresLabelSelector string `json:"postgres_label_selector"`
 
 	// Secret where the administrator password can be found
-	// +kubebuilder:default:="pulp-admin-password"
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
 	AdminPasswordSecret string `json:"admin_password_secret,omitempty"`
 
 	// Secret where the database configuration can be found
-	// +kubebuilder:default:="pulp-postgres-configuration"
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Database configuration"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
 	PostgresConfigurationSecret string `json:"postgres_configuration_secret"`

--- a/bundle/manifests/repo-manager.pulpproject.org_pulpbackups.yaml
+++ b/bundle/manifests/repo-manager.pulpproject.org_pulpbackups.yaml
@@ -2064,7 +2064,6 @@ spec:
             description: PulpBackupSpec defines the desired state of PulpBackup
             properties:
               admin_password_secret:
-                default: pulp-admin-password
                 description: Secret where the administrator password can be found
                 type: string
               affinity:
@@ -2912,24 +2911,17 @@ spec:
                 type: string
               deployment_type:
                 description: Name of the deployment type. Can be one of {galaxy,pulp}.
-                enum:
-                - pulp
-                - galaxy
                 type: string
               instance_name:
                 default: pulp
                 type: string
               postgres_configuration_secret:
-                default: pulp-postgres-configuration
                 description: Secret where the database configuration can be found
                 type: string
               postgres_label_selector:
                 description: Label selector used to identify postgres pod for executing
                   migration
                 type: string
-            required:
-            - deployment_type
-            - postgres_configuration_secret
             type: object
           status:
             description: PulpBackupStatus defines the observed state of PulpBackup

--- a/config/crd/bases/repo-manager.pulpproject.org_pulpbackups.yaml
+++ b/config/crd/bases/repo-manager.pulpproject.org_pulpbackups.yaml
@@ -2065,7 +2065,6 @@ spec:
             description: PulpBackupSpec defines the desired state of PulpBackup
             properties:
               admin_password_secret:
-                default: pulp-admin-password
                 description: Secret where the administrator password can be found
                 type: string
               affinity:
@@ -2913,24 +2912,17 @@ spec:
                 type: string
               deployment_type:
                 description: Name of the deployment type. Can be one of {galaxy,pulp}.
-                enum:
-                - pulp
-                - galaxy
                 type: string
               instance_name:
                 default: pulp
                 type: string
               postgres_configuration_secret:
-                default: pulp-postgres-configuration
                 description: Secret where the database configuration can be found
                 type: string
               postgres_label_selector:
                 description: Label selector used to identify postgres pod for executing
                   migration
                 type: string
-            required:
-            - deployment_type
-            - postgres_configuration_secret
             type: object
           status:
             description: PulpBackupStatus defines the observed state of PulpBackup

--- a/controllers/backup/cr.go
+++ b/controllers/backup/cr.go
@@ -12,26 +12,28 @@ import (
 
 func (r *RepoManagerBackupReconciler) backupCR(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup, backupDir string, pod *corev1.Pod) error {
 	log := r.RawLogger
+	deploymentName := getDeploymentName(ctx, pulpBackup)
+	deploymentType := getDeploymentType(ctx, pulpBackup)
 
 	// we are considering that pulp CR instance is running in the same namespace as pulpbackup and
 	// that there is only a single instance of pulp CR available
 	// we could also let users pass the name of pulp instance
 	pulp := &repomanagerpulpprojectorgv1beta2.Pulp{}
-	err := r.Get(ctx, types.NamespacedName{Name: pulpBackup.Spec.DeploymentName, Namespace: pulpBackup.Namespace}, pulp)
+	err := r.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: pulpBackup.Namespace}, pulp)
 	if err != nil {
 		log.Error(err, "Failed to get Pulp")
 		return err
 	}
 
 	// CR BACKUP
-	log.Info("Starting " + pulpBackup.Spec.DeploymentType + " CR backup process ...")
+	log.Info("Starting " + deploymentType + " CR backup process ...")
 	pulpSpec, _ := json.Marshal(pulp.Spec)
 	execCmd := []string{
 		"bash", "-c", "echo '" + string(pulpSpec) + "' > " + backupDir + "/cr_object",
 	}
 	_, err = controllers.ContainerExec(r, pod, execCmd, pulpBackup.Name+"-backup-manager", pod.Namespace)
 	if err != nil {
-		log.Error(err, "Failed to backup "+pulpBackup.Spec.DeploymentType+" CR")
+		log.Error(err, "Failed to backup "+deploymentType+" CR")
 		return err
 	}
 	return nil

--- a/controllers/backup/utils.go
+++ b/controllers/backup/utils.go
@@ -1,0 +1,114 @@
+package repo_manager_backup
+
+import (
+	"context"
+	"errors"
+
+	repomanagerpulpprojectorgv1beta2 "github.com/pulp/pulp-operator/apis/repo-manager.pulpproject.org/v1beta2"
+	"github.com/pulp/pulp-operator/controllers"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// createBackupDir creates the directory to store the backup
+func (r *RepoManagerBackupReconciler) createBackupDir(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup, backupDir string, pod *corev1.Pod) error {
+	log := r.RawLogger
+	backupPod := pulpBackup.Name + "-backup-manager"
+
+	log.Info("Creating backup folder ...")
+	execCmd := []string{"mkdir", "-p", backupDir}
+	_, err := controllers.ContainerExec(r, pod, execCmd, backupPod, pod.Namespace)
+	if err != nil {
+		log.Error(err, "Failed to create backup folder")
+		return err
+	}
+	return nil
+}
+
+// checkRequiredFields will verify if all required fields are provided
+func checkRequiredFields(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup) error {
+	if len(pulpBackup.Spec.DeploymentName) == 0 {
+		return errors.New("error! deployment_name not provided")
+	}
+	return nil
+}
+
+// getDeploymentName returns the deployment_name
+func getDeploymentName(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup) string {
+	return pulpBackup.Spec.DeploymentName
+}
+
+// getDeploymentType returns the deployment_type
+func getDeploymentType(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup) string {
+	deploymentType := pulpBackup.Spec.DeploymentType
+	if len(pulpBackup.Spec.DeploymentType) == 0 {
+		deploymentType = "pulp"
+	}
+	return deploymentType
+}
+
+// getAdminPasswordSecret returns the admin_password_secret if provided, if not will return the default one based
+// on deployment_name
+func getAdminPasswordSecret(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup) string {
+	adminPasswordSecret := pulpBackup.Spec.AdminPasswordSecret
+	if len(adminPasswordSecret) == 0 {
+		adminPasswordSecret = getDeploymentName(ctx, pulpBackup) + "-admin-password"
+	}
+	return adminPasswordSecret
+}
+
+// getBackupPVC returns the backup_pvc if provided, if not will return the default one based
+// on deployment_name
+func getBackupPVC(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup) string {
+	backupPVC := pulpBackup.Spec.BackupPVC
+	if len(backupPVC) == 0 {
+		backupPVC = pulpBackup.Name + "-backup-claim"
+	}
+	return backupPVC
+}
+
+// getBackupPVCNamespace returns the backup_pvc_namespace if provided, if not will return the default one based
+// on deployment_name
+func getBackupPVCNamespace(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup) string {
+	backupPVCNamespace := pulpBackup.Spec.BackupPVCNamespace
+	if len(backupPVCNamespace) == 0 {
+		backupPVCNamespace = pulpBackup.Namespace
+	}
+	return backupPVCNamespace
+}
+
+// getBackupDir returns the backup path based on the provided timestamp
+func getBackupDir(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup, timestamp string) string {
+	return "/backups/openshift-backup-" + timestamp
+}
+
+// getPostgresCfgSecret returns the name of the secret with postgres configuration
+func getPostgresCfgSecret(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup) string {
+	postgresCfgSecret := pulpBackup.Spec.PostgresConfigurationSecret
+	if len(postgresCfgSecret) == 0 {
+		postgresCfgSecret = getDeploymentName(ctx, pulpBackup) + "-postgres-configuration"
+	}
+	return postgresCfgSecret
+}
+
+// getDBFieldsEncryption returns the db_fields_encryption_secret
+func getDBFieldsEncryption(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup, pulp *repomanagerpulpprojectorgv1beta2.Pulp) string {
+	return pulp.Status.DBFieldsEncryptionSecret
+}
+
+// getContainerTokenSecret returns the container_token_secret
+func getContainerTokenSecret(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup, pulp *repomanagerpulpprojectorgv1beta2.Pulp) string {
+	return pulp.Status.ContainerTokenSecret
+}
+
+// setStatusFields will populate all the related status but conditions[].
+func (r *RepoManagerBackupReconciler) setStatusFields(ctx context.Context, pulpBackup *repomanagerpulpprojectorgv1beta2.PulpBackup, timestamp string) error {
+	pulpBackup.Status.AdminPasswordSecret = getAdminPasswordSecret(ctx, pulpBackup)
+	pulpBackup.Status.BackupClaim = getBackupPVC(ctx, pulpBackup)
+	pulpBackup.Status.BackupDirectory = getBackupDir(ctx, pulpBackup, timestamp)
+	pulpBackup.Status.BackupNamespace = getBackupPVCNamespace(ctx, pulpBackup)
+	pulpBackup.Status.DeploymentName = getDeploymentName(ctx, pulpBackup)
+	if err := r.Status().Update(ctx, pulpBackup); err != nil {
+		return err
+	}
+	return nil
+}

--- a/controllers/restore/database.go
+++ b/controllers/restore/database.go
@@ -2,6 +2,7 @@ package repo_manager_restore
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	repomanagerpulpprojectorgv1beta2 "github.com/pulp/pulp-operator/apis/repo-manager.pulpproject.org/v1beta2"
@@ -40,6 +41,13 @@ func (r *RepoManagerRestoreReconciler) restoreDatabaseData(ctx context.Context, 
 		"pg_restore", "-d",
 		"postgresql://" + string(pgConfig.Data["username"]) + ":" + string(pgConfig.Data["password"]) + "@" + string(pgConfig.Data["host"]) + ":" + string(pgConfig.Data["port"]) + "/" + string(pgConfig.Data["database"]),
 		backupDir + "/" + backupFile,
+	}
+
+	// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+	if ansible, _ := r.isAnsibleBackup(ctx, pulpRestore, backupDir, pod); ansible {
+		log.V(1).Info("Restoring from ansible db backup ...")
+		psqlRestore := fmt.Sprintf("psql -U %v -h %v -d %v -p %v", string(pgConfig.Data["username"]), string(pgConfig.Data["host"]), string(pgConfig.Data["database"]), string(pgConfig.Data["port"]))
+		execCmd = []string{"sh", "-c", fmt.Sprintf("cat %v/pulp.db | PGPASSWORD=%v %v", backupDir, string(pgConfig.Data["password"]), psqlRestore)}
 	}
 
 	log.Info("Running db restore ...")

--- a/controllers/restore/deploy.go
+++ b/controllers/restore/deploy.go
@@ -3,6 +3,7 @@ package repo_manager_restore
 import (
 	"context"
 	"encoding/json"
+	"regexp"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -48,7 +50,39 @@ func (r *RepoManagerRestoreReconciler) restorePulpCR(ctx context.Context, pulpRe
 			},
 		}
 
-		json.Unmarshal([]byte(cmdOutput), &pulp.Spec)
+		// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+		ansible, _ := r.isAnsibleBackup(ctx, pulpRestore, backupDir, pod)
+		if !ansible {
+			json.Unmarshal([]byte(cmdOutput), &pulp.Spec)
+		} else {
+			json.Unmarshal([]byte(parseUnquotedJson(cmdOutput)), &pulp.Spec)
+			log.V(1).Info("Restoring Pulp CR from ansible ...", "CR", pulp.Spec)
+
+			// in ansible version the pvc used by database pods was created by the statefulset volumeClaimTemplates
+			// in the current version, if users do not provide a SC or PVC the sts will use emptyDir (no PVC will be created through volumeClaimTemplates)
+			// for ansible restoration we are manually creating the PVC to "replicate" the volumeClaimTemplates behavior
+			postgresPVCName, err := r.deployPostgresPVC(ctx, pulpRestore, &pulp)
+			if err != nil {
+				return PodReplicas{}, err
+			}
+
+			// Configure Pulp CR to use this new PVC
+			pulp.Spec.Database.PVC = postgresPVCName
+
+			// Ansible version deploys Redis by default
+			// cache_enabled is defined in playbook, so we cannot recover this from the copied CR
+			pulp.Spec.Cache.Enabled = true
+
+			// in ansible version if no object storage is defined, the operator will deploy a pvc
+			// in the current version, if users do not provide a SC or PVC or Object Storage credentials
+			// the operator will deploy pulp pods with emptyDir
+			// for ansible restoration we are manually creating the PVC to "replicate" ansible behavior
+			pulpPVCName, err := r.deployPulpPVC(ctx, pulpRestore, &pulp)
+			if err != nil {
+				return PodReplicas{}, err
+			}
+			pulp.Spec.PVC = pulpPVCName
+		}
 
 		// store the number of replicas so we can rescale with the same amount later
 		podReplicas = PodReplicas{
@@ -62,6 +96,7 @@ func (r *RepoManagerRestoreReconciler) restorePulpCR(ctx context.Context, pulpRe
 		pulp.Spec.Content.Replicas = 0
 		pulp.Spec.Worker.Replicas = 0
 		pulp.Spec.Web.Replicas = 0
+
 		if err = r.Create(ctx, &pulp); err != nil {
 			log.Error(err, "Error trying to restore "+pulpRestore.Spec.DeploymentName+" CR!")
 			r.updateStatus(ctx, pulpRestore, metav1.ConditionFalse, "RestoreComplete", "Failed to restore cr_object!", "FailedRestore"+pulpRestore.Spec.DeploymentName+"CR")
@@ -141,4 +176,121 @@ func (r *RepoManagerRestoreReconciler) scaleDeployments(ctx context.Context, pul
 	}
 
 	return nil
+}
+
+// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+// ansible backup of Pulp CR produces a "non-formatted" file (it is a "json" without quotes in key and values).
+// since it is not formatted we cannot just unmarshal it to Pulp type
+func parseUnquotedJson(pulpCR string) string {
+	re := regexp.MustCompile(`([a-zA-Z0-9-_]+):\s*(http(s)?:\/\/[a-z0-9.-]+(:[0-9]+)?|[a-zA-Z0-9-_./]+)`)
+
+	simpleFields := re.ReplaceAllString(string(pulpCR), `"$1": "$2"`)
+	re = regexp.MustCompile(`([a-zA-Z0-9-_]+):\s*(\{)`)
+
+	objectFields := re.ReplaceAllString(string(simpleFields), `"$1": $2`)
+	re = regexp.MustCompile(`(["a-zA-Z0-9-_]+):\s*\[(.*?)\]`)
+
+	return re.ReplaceAllString(string(objectFields), `"$1": ["$2"]`)
+}
+
+// getDeploymentType returns the deployment_type (if not provided default is "pulp")
+func getDeploymentType(pulp *repomanagerpulpprojectorgv1beta2.Pulp) string {
+	deploymentType := pulp.Spec.DeploymentType
+	if len(pulp.Spec.DeploymentType) == 0 {
+		deploymentType = "pulp"
+	}
+	return deploymentType
+}
+
+// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+func (r *RepoManagerRestoreReconciler) deployPostgresPVC(ctx context.Context, pulpRestore *repomanagerpulpprojectorgv1beta2.PulpRestore, pulp *repomanagerpulpprojectorgv1beta2.Pulp) (string, error) {
+
+	log := r.RawLogger
+	postgresPVCName := "postgres-" + pulp.Name
+	deploymentType := getDeploymentType(pulp)
+	postgresPVC := &corev1.PersistentVolumeClaim{}
+	if err := r.Get(ctx, types.NamespacedName{Name: postgresPVCName, Namespace: pulp.Namespace}, postgresPVC); err != nil {
+		postgresPVC = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      postgresPVCName,
+				Namespace: pulpRestore.Namespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/name":       "postgres",
+					"app.kubernetes.io/instance":   "postgres-" + pulp.Name,
+					"app.kubernetes.io/component":  "database",
+					"app.kubernetes.io/part-of":    deploymentType,
+					"app.kubernetes.io/managed-by": deploymentType + "-operator",
+					"owner":                        "pulp-dev",
+					"app":                          "postgresql",
+					"pulp_cr":                      pulp.Name,
+				},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				StorageClassName: pulp.Spec.PostgresStorageClass,
+			},
+		}
+
+		if pulp.Spec.PostgresResourceRequirements != nil {
+			postgresPVC.Spec.Resources = *pulp.Spec.PostgresResourceRequirements
+		} else {
+			postgresPVC.Spec.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("8Gi"),
+			}
+		}
+
+		if err = r.Create(ctx, postgresPVC); err != nil {
+			log.Error(err, "Error trying to create the database PVC!")
+			r.updateStatus(ctx, pulpRestore, metav1.ConditionFalse, "RestoreComplete", "Failed to create the database PVC!", "FailedCreateDBPVC")
+			return "", err
+		}
+	}
+	return postgresPVCName, nil
+}
+
+// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+func (r *RepoManagerRestoreReconciler) deployPulpPVC(ctx context.Context, pulpRestore *repomanagerpulpprojectorgv1beta2.PulpRestore, pulp *repomanagerpulpprojectorgv1beta2.Pulp) (string, error) {
+
+	log := r.RawLogger
+	deploymentType := getDeploymentType(pulp)
+
+	// in ansible, if no azure nor s3 secret are provided it means it should deploy a PVC
+	if len(pulp.Spec.ObjectStorageAzureSecret) == 0 && len(pulp.Spec.ObjectStorageS3Secret) == 0 {
+		pulpPVCName := pulpRestore.Spec.DeploymentName + "-file-storage"
+		pulpPVC := &corev1.PersistentVolumeClaim{}
+		if err := r.Get(ctx, types.NamespacedName{Name: pulpPVCName, Namespace: pulp.Namespace}, pulpPVC); err != nil {
+			pulpPVC = &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pulpPVCName,
+					Namespace: pulpRestore.Namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       deploymentType + "-storage",
+						"app.kubernetes.io/instance":   deploymentType + "-storage-" + pulpRestore.Spec.DeploymentName,
+						"app.kubernetes.io/component":  "storage",
+						"app.kubernetes.io/part-of":    deploymentType,
+						"app.kubernetes.io/managed-by": deploymentType + "-operator",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					StorageClassName: &pulp.Spec.FileStorageClass,
+				},
+			}
+
+			pulpPVC.Spec.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceName(corev1.ResourceStorage): resource.MustParse(pulp.Spec.FileStorageSize),
+			}
+
+			if err = r.Create(ctx, pulpPVC); err != nil {
+				log.Error(err, "Error trying to create Pulp PVC!")
+				r.updateStatus(ctx, pulpRestore, metav1.ConditionFalse, "RestoreComplete", "Failed to create Pulp PVC!", "FailedCreatePUlpPVC")
+				return "", err
+			}
+		}
+
+		return pulpPVCName, nil
+	}
+
+	// if object storage secret provided, we should not return a PVC
+	return "", nil
 }

--- a/controllers/restore/secret.go
+++ b/controllers/restore/secret.go
@@ -73,12 +73,13 @@ type ssoSecret struct {
 }
 
 const (
-	resourceTypeAdminPassword  = "AdminPassword"
-	resourceTypePostgres       = "Postgres"
-	resourceTypeObjectStorage  = "ObjectStorage"
-	resourceTypeSigningSecret  = "Signing"
-	resourceTypeContainerToken = "ContainerToken"
-	resourceTypeSSOSecret      = "SSO"
+	resourceTypeAdminPassword      = "AdminPassword"
+	resourceTypePostgres           = "Postgres"
+	resourceTypeObjectStorage      = "ObjectStorage"
+	resourceTypeSigningSecret      = "Signing"
+	resourceTypeContainerToken     = "ContainerToken"
+	resourceTypeSSOSecret          = "SSO"
+	resourceTypeDBFieldsEncryption = "DBFieldsEncryption"
 )
 
 // restoreSecret restores the operator secrets created by pulpbackup CR
@@ -88,6 +89,13 @@ func (r *RepoManagerRestoreReconciler) restoreSecret(ctx context.Context, pulpRe
 	// type secretTypes struct {resourceType string, secretNameKey string, backupFile string}
 	// secrets := []secretTypes{ ... }
 	// for i in range secrets { r.secret(...) }
+
+	// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+	if ansible, err := r.isAnsibleBackup(ctx, pulpRestore, backupDir, pod); ansible {
+		return r.restoreSecretsFromAnsible(ctx, pulpRestore, backupDir, pod)
+	} else {
+		r.RawLogger.V(1).Info("Restoring from golang backup version", "error: ", err)
+	}
 
 	// restore admin password secret
 	if _, err := r.secret(ctx, resourceTypeAdminPassword, "admin_password_secret", backupDir, "admin_secret.yaml", pod, pulpRestore); err != nil {
@@ -100,7 +108,7 @@ func (r *RepoManagerRestoreReconciler) restoreSecret(ctx context.Context, pulpRe
 	}
 
 	// restore db fields encryption secret
-	if _, err := r.secret(ctx, resourceTypeContainerToken, "db_fields_encryption_secret", backupDir, "db_fields_encryption_secret.yaml", pod, pulpRestore); err != nil {
+	if _, err := r.secret(ctx, resourceTypeDBFieldsEncryption, "db_fields_encryption_secret", backupDir, "db_fields_encryption_secret.yaml", pod, pulpRestore); err != nil {
 		return err
 	}
 
@@ -259,4 +267,273 @@ func setStatusField(fieldName, fieldValue string, pulpRestore *repomanagerpulppr
 	}
 
 	return nil
+}
+
+// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+// restoreSecretsFromAnsible will restore the secrets copied by an ansible-based version of the operator
+func (r *RepoManagerRestoreReconciler) restoreSecretsFromAnsible(ctx context.Context, pulpRestore *repomanagerpulpprojectorgv1beta2.PulpRestore, backupDir string, pod *corev1.Pod) error {
+
+	// [TODO] check if it worth to refactor all of the following methods with a single method to address all secrets
+	//        they are basically doing the same steps but with different data, but since they are all deprecated I'm not
+	//        sure if if worth spending time with it now.
+	// restore admin password secret
+	r.restoreAdminPasswordFromAnsible(ctx, pulpRestore, backupDir, pod)
+	r.restoreDBSecretFromAnsible(ctx, pulpRestore, backupDir, pod)
+	r.restoreObjectStorageFromAnsible(ctx, pulpRestore, backupDir, pod)
+	r.restoreSigningSecretFromAnsible(ctx, pulpRestore, backupDir, pod)
+	r.restoreContainerTokenFromAnsible(ctx, pulpRestore, backupDir, pod)
+	r.restoreDBFieldsEncryptionFromAnsible(ctx, pulpRestore, backupDir, pod)
+	r.restoreSSOSecretFromAnsible(ctx, pulpRestore, backupDir, pod)
+	return nil
+}
+
+// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+func (r *RepoManagerRestoreReconciler) restoreAdminPasswordFromAnsible(ctx context.Context, pulpRestore *repomanagerpulpprojectorgv1beta2.PulpRestore, backupDir string, pod *corev1.Pod) {
+	execCmd := []string{
+		"grep", "admin_password", backupDir + "/secrets.yaml",
+	}
+	cmdOutput, _ := controllers.ContainerExec(r, pod, execCmd, pulpRestore.Name+"-backup-manager", pod.Namespace)
+	data := make(map[string]string)
+	yaml.Unmarshal([]byte(cmdOutput), &data)
+
+	secretName := data["admin_password_name"]
+	adminPwd := data["admin_password"]
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: pulpRestore.Namespace,
+		},
+		StringData: map[string]string{"password": adminPwd},
+	}
+
+	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: pulpRestore.Namespace}, secret); err != nil && errors.IsNotFound(err) {
+		r.Create(ctx, secret)
+		r.updateStatus(ctx, pulpRestore, metav1.ConditionFalse, "RestoreComplete", resourceTypeAdminPassword+" secret restored", resourceTypeAdminPassword+"SecretRestored")
+	}
+}
+
+// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+func (r *RepoManagerRestoreReconciler) restoreDBSecretFromAnsible(ctx context.Context, pulpRestore *repomanagerpulpprojectorgv1beta2.PulpRestore, backupDir string, pod *corev1.Pod) {
+	execCmd := []string{
+		"cat", backupDir + "/secrets.yaml",
+	}
+	cmdOutput, _ := controllers.ContainerExec(r, pod, execCmd, pulpRestore.Name+"-backup-manager", pod.Namespace)
+	data := make(map[string]string)
+	yaml.Unmarshal([]byte(cmdOutput), &data)
+
+	secretName := getDeploymentName(ctx, pulpRestore) + "-postgres-configuration"
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: pulpRestore.Namespace,
+		},
+		StringData: map[string]string{
+			"password":         data["database_password"],
+			"username":         data["database_username"],
+			"database":         data["database_name"],
+			"port":             data["database_port"],
+			"host":             getDeploymentName(ctx, pulpRestore) + "-database-svc",
+			"type":             data["database_type"],
+			"sslmode":          data["database_sslmode"],
+			"postgres_version": data["postgres_version"],
+		},
+	}
+
+	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: pulpRestore.Namespace}, secret); err != nil && errors.IsNotFound(err) {
+		r.Create(ctx, secret)
+		r.updateStatus(ctx, pulpRestore, metav1.ConditionFalse, "RestoreComplete", resourceTypePostgres+" secret restored", resourceTypePostgres+"SecretRestored")
+		pulpRestore.Status.PostgresSecret = secretName
+		r.Status().Update(ctx, pulpRestore)
+	}
+}
+
+// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+func (r *RepoManagerRestoreReconciler) restoreObjectStorageFromAnsible(ctx context.Context, pulpRestore *repomanagerpulpprojectorgv1beta2.PulpRestore, backupDir string, pod *corev1.Pod) {
+	execCmd := []string{
+		"cat", backupDir + "/objectstorage_secret.yaml",
+	}
+	cmdOutput, err := controllers.ContainerExec(r, pod, execCmd, pulpRestore.Name+"-backup-manager", pod.Namespace)
+
+	// if file not found it means that it is a file storage installation
+	if err != nil {
+		return
+	}
+
+	data := make(map[string]string)
+	yaml.Unmarshal([]byte(cmdOutput), &data)
+
+	secretName := data["storage_secret"]
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: pulpRestore.Namespace,
+		},
+	}
+	if data["s3_access_key_id"] != "" {
+		secret.StringData = map[string]string{
+			"s3-access-key-id":     data["s3_access_key_id"],
+			"s3-secret-access-key": data["s3_secret_access_key"],
+			"s3-bucket-name":       data["s3_bucket_name"],
+			"s3-region":            data["s3_region"],
+		}
+		if data["s3_endpoint"] != "" {
+			secret.StringData = map[string]string{"s3-endpoint": data["s3_endpoint"]}
+		}
+	} else if data["azure-account-key"] != "" {
+		secret.StringData = map[string]string{
+			"azure-account-name":   data["azure_account_name"],
+			"azure-account-key":    data["azure_account_key"],
+			"azure-container":      data["azure_container"],
+			"azure-container-path": data["azure_container_path"],
+		}
+		if data["azure_connection_string"] != "" {
+			secret.StringData = map[string]string{"azure-connection-string": data["azure_connection_string"]}
+		}
+	}
+
+	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: pulpRestore.Namespace}, secret); err != nil && errors.IsNotFound(err) {
+		r.Create(ctx, secret)
+		r.updateStatus(ctx, pulpRestore, metav1.ConditionFalse, "RestoreComplete", resourceTypeObjectStorage+" secret restored", resourceTypeObjectStorage+"SecretRestored")
+	}
+}
+
+// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+func (r *RepoManagerRestoreReconciler) restoreSigningSecretFromAnsible(ctx context.Context, pulpRestore *repomanagerpulpprojectorgv1beta2.PulpRestore, backupDir string, pod *corev1.Pod) {
+	execCmd := []string{
+		"cat", backupDir + "/signing_secret.yaml",
+	}
+	cmdOutput, err := controllers.ContainerExec(r, pod, execCmd, pulpRestore.Name+"-backup-manager", pod.Namespace)
+
+	// signing secret is not a required secret
+	// leaving method in case file is not found
+	if err != nil {
+		return
+	}
+
+	data := make(map[string]string)
+	yaml.Unmarshal([]byte(cmdOutput), &data)
+
+	secretName := data["signing_secret"]
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: pulpRestore.Namespace,
+		},
+		StringData: map[string]string{
+			"signing_service.gpg": data["signing_service_gpg"],
+			"signing_service.asc": data["signing_service_asc"],
+		},
+	}
+
+	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: pulpRestore.Namespace}, secret); err != nil && errors.IsNotFound(err) {
+		r.Create(ctx, secret)
+		r.updateStatus(ctx, pulpRestore, metav1.ConditionFalse, "RestoreComplete", resourceTypeSigningSecret+" secret restored", resourceTypeSigningSecret+"SecretRestored")
+	}
+}
+
+// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+func (r *RepoManagerRestoreReconciler) restoreContainerTokenFromAnsible(ctx context.Context, pulpRestore *repomanagerpulpprojectorgv1beta2.PulpRestore, backupDir string, pod *corev1.Pod) {
+	execCmd := []string{
+		"cat", backupDir + "/container_token_secret.yaml",
+	}
+	cmdOutput, err := controllers.ContainerExec(r, pod, execCmd, pulpRestore.Name+"-backup-manager", pod.Namespace)
+
+	// container_token_secret is not a required secret
+	// leaving method in case file is not found
+	if err != nil {
+		return
+	}
+
+	data := make(map[string]string)
+	yaml.Unmarshal([]byte(cmdOutput), &data)
+
+	secretName := data["container_token_secret"]
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: pulpRestore.Namespace,
+		},
+		StringData: map[string]string{
+			"container_auth_private_key.pem": data["container_auth_private_key"],
+			"container_auth_public_key.pem":  data["container_auth_public_key"],
+		},
+	}
+
+	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: pulpRestore.Namespace}, secret); err != nil && errors.IsNotFound(err) {
+		r.Create(ctx, secret)
+		r.updateStatus(ctx, pulpRestore, metav1.ConditionFalse, "RestoreComplete", resourceTypeContainerToken+" secret restored", resourceTypeContainerToken+"SecretRestored")
+	}
+}
+
+// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+func (r *RepoManagerRestoreReconciler) restoreDBFieldsEncryptionFromAnsible(ctx context.Context, pulpRestore *repomanagerpulpprojectorgv1beta2.PulpRestore, backupDir string, pod *corev1.Pod) {
+	execCmd := []string{
+		"cat", backupDir + "/db_fields_encryption_secret.yaml",
+	}
+	cmdOutput, err := controllers.ContainerExec(r, pod, execCmd, pulpRestore.Name+"-backup-manager", pod.Namespace)
+
+	// container_token_secret is not a required secret
+	// leaving method in case file is not found
+	if err != nil {
+		return
+	}
+
+	data := make(map[string]string)
+	yaml.Unmarshal([]byte(cmdOutput), &data)
+
+	secretName := data["db_fields_encryption_secret"]
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: pulpRestore.Namespace,
+		},
+		StringData: map[string]string{
+			"database_fields.symmetric.key": data["db_fields_encryption_key"],
+		},
+	}
+
+	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: pulpRestore.Namespace}, secret); err != nil && errors.IsNotFound(err) {
+		r.Create(ctx, secret)
+		r.updateStatus(ctx, pulpRestore, metav1.ConditionFalse, "RestoreComplete", resourceTypeDBFieldsEncryption+" secret restored", resourceTypeDBFieldsEncryption+"SecretRestored")
+	}
+}
+
+// [DEPRECATED] Temporarily adding to keep compatibility with ansible version
+func (r *RepoManagerRestoreReconciler) restoreSSOSecretFromAnsible(ctx context.Context, pulpRestore *repomanagerpulpprojectorgv1beta2.PulpRestore, backupDir string, pod *corev1.Pod) {
+	execCmd := []string{
+		"cat", backupDir + "/sso_secret.yaml",
+	}
+	cmdOutput, err := controllers.ContainerExec(r, pod, execCmd, pulpRestore.Name+"-backup-manager", pod.Namespace)
+
+	// container_token_secret is not a required secret
+	// leaving method in case file is not found
+	if err != nil {
+		return
+	}
+
+	data := make(map[string]string)
+	yaml.Unmarshal([]byte(cmdOutput), &data)
+
+	secretName := data["sso_secret"]
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: pulpRestore.Namespace,
+		},
+		StringData: map[string]string{
+			"social_auth_keycloak_key":        data["social_auth_keycloak_key"],
+			"social_auth_keycloak_secret":     data["social_auth_keycloak_secret"],
+			"social_auth_keycloak_public_key": data["social_auth_keycloak_public_key"],
+			"keycloak_host":                   data["keycloak_host"],
+			"keycloak_protocol":               data["keycloak_protocol"],
+			"keycloak_port":                   data["keycloak_port"],
+			"keycloak_realm":                  data["keycloak_realm"],
+		},
+	}
+
+	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: pulpRestore.Namespace}, secret); err != nil && errors.IsNotFound(err) {
+		r.Create(ctx, secret)
+		r.updateStatus(ctx, pulpRestore, metav1.ConditionFalse, "RestoreComplete", resourceTypeSSOSecret+" secret restored", resourceTypeSSOSecret+"SecretRestored")
+	}
 }


### PR DESCRIPTION
This commit configures the backup and restore controllers to allow
compatibility with ansible version of the operator.
ref: https://issues.redhat.com/browse/AAP-8757
ref: https://github.com/pulp/pulp-operator/issues/693
[noissue]