### PR TITLE
Remove the `make deploy` from prow script

### DIFF
--- a/.ci/prow/openshift-test.sh
+++ b/.ci/prow/openshift-test.sh
@@ -27,13 +27,6 @@ show_logs() {
 
 sed -i 's/kubectl/oc/g' Makefile
 
-# TMP workaround to "fix" some ci-operator conflict issues
-oc get crd -oname|grep pulp |xargs oc delete
-oc delete roles --all
-oc get clusterrole -oname|grep pulp|xargs oc delete
-
-
-make deploy
 oc apply -f .ci/assets/kubernetes/pulp-admin-password.secret.yaml
 
 ROUTE_HOST="pulpci.$(oc get ingresses.config/cluster -o jsonpath={.spec.domain})"


### PR DESCRIPTION
We are installing the operator using OLM (bundle installation) therefore we don't need the `make deploy` anymore.

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
