### PR TITLE
Fix Postgres version label

### DIFF
--- a/roles/common/templates/service_account.yaml.j2
+++ b/roles/common/templates/service_account.yaml.j2
@@ -7,6 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: "{{ ansible_operator_meta.name }}"
     app.kubernetes.io/part-of: "{{ ansible_operator_meta.name }}"
+{% if image_pull_secret|length > 0 or image_pull_secrets|length > 0 %}
 imagePullSecrets:
 {% if image_pull_secret|length > 0 and image_pull_secrets|length == 0 %}
 # image_pull_secret is deprecated in favor of image_pull_secrets
@@ -16,8 +17,9 @@ imagePullSecrets:
 - name: {{ secret }}
 {% endfor %}
 {% endif %}
-{% if __dockercfg_secret is defined and __dockercfg_secret | length > 0%}
+{% if __dockercfg_secret is defined and __dockercfg_secret | length > 0 %}
 - name: {{ __dockercfg_secret }}
+{% endif %}
 {% endif %}
 
 ---

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -151,7 +151,7 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     label_selectors:
       - "{{ postgres_label_selector }}"
-      - app.kubernetes.io/version='12'
+      - "app.kubernetes.io/version=12"
     field_selectors:
       - status.phase=Running
   register: old_postgres_pod

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -199,6 +199,7 @@
           cat {{ path_to_pg_version }}
           """
       register: _old_pg_version
+      changed_when: false
 
     - name: Upgrade data dir from Postgres 12 to 13 if applicable
       include_tasks: upgrade_postgres.yml

--- a/roles/pulp-routes/tasks/load_routes.yml
+++ b/roles/pulp-routes/tasks/load_routes.yml
@@ -28,6 +28,7 @@
       pod: "{{ _pod_list.resources[0].metadata.name }}"
       command: "/usr/bin/route_paths.py {{ ansible_operator_meta.name }}"
     register: _route_paths_output
+    changed_when: false
 
   - set_fact:
       _pulp_plugins: "{{ _pulp_default_plugins + _route_paths_output.stdout | from_json }}"


### PR DESCRIPTION
There is a bug where the reconciliation loop  does not converge because the task that checks for the old postgres 12 pod fails.  It fails because the label_selector should not have quotes on the value. 

Correct syntax is like the output of a `get describe`, not a `get pod -o yaml`:

```
    label_selectors:
      - "{{ postgres_label_selector }}"
      - app.kubernetes.io/version=12
 ```

The deployment was still coming up, but the reconciliation loop always showed changed tasks, so it never converged.  



### Additional Fixes

* Ensure that `imagePullSecrets` is not set as an empty key on the SA
* Add `changed_when: false` to tasks when necessary to ensure the reconciliation loop converges