### PR TITLE
Be consistent in how we set the default for the deployment_type param

### DIFF
--- a/bundle/manifests/repo-manager.pulpproject.org_pulpbackups.yaml
+++ b/bundle/manifests/repo-manager.pulpproject.org_pulpbackups.yaml
@@ -891,6 +891,7 @@ spec:
                 description: Name of the deployment to be backed up
                 type: string
               deployment_type:
+                default: pulp
                 description: Name of the deployment type. Can be one of {galaxy,pulp}.
                 enum:
                 - pulp

--- a/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
+++ b/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
@@ -9154,6 +9154,7 @@ spec:
               deployedVersion:
                 type: string
               deployment_type:
+                default: pulp
                 description: Name of the deployment type.
                 type: string
               external_cache_secret:

--- a/config/crd/bases/repo-manager.pulpproject.org_pulpbackups.yaml
+++ b/config/crd/bases/repo-manager.pulpproject.org_pulpbackups.yaml
@@ -892,6 +892,7 @@ spec:
                 description: Name of the deployment to be backed up
                 type: string
               deployment_type:
+                default: pulp
                 description: Name of the deployment type. Can be one of {galaxy,pulp}.
                 enum:
                 - pulp

--- a/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
+++ b/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
@@ -9155,6 +9155,7 @@ spec:
               deployedVersion:
                 type: string
               deployment_type:
+                default: pulp
                 description: Name of the deployment type.
                 type: string
               external_cache_secret:


### PR DESCRIPTION
Could we set the default value for deployment_type like this everywhere so that it is easier to regex and replace downstream as needed?