### PR TITLE
Improvements for custom S3 endpoints

### DIFF
--- a/CHANGES/882.doc
+++ b/CHANGES/882.doc
@@ -1,0 +1,1 @@
+Add Documentation for custom S3 endpoints

--- a/docs/configuring/storage.md
+++ b/docs/configuring/storage.md
@@ -145,6 +145,9 @@ stringData:
   s3-region: $S3_REGION
 EOF
 ```
+If you want to use a custom S3-compatible endpoint, you can use it by specifying the endpoint 
+within the secret data as `s3-endpoint`.
+In this case `s3-region` does not need to be specified and is ignored.
 
 Now configure `Pulp CR` with the secret created:
 ```


### PR DESCRIPTION
On the one hand this fixes that no `s3-region` needs to be specified in the secret, if the `s3-endpoint` is already given (this is ignored by `django-storages` anyways, as the custom endpoint overrides the region).

On the other hand the possibility to specify the `s3-endpoint` is documented

Closes #882 