### PR TITLE
[ansible] api: fix galaxy_feature_flags configuration

### DIFF
--- a/roles/pulp-api/tasks/get_node_ip.yml
+++ b/roles/pulp-api/tasks/get_node_ip.yml
@@ -115,7 +115,7 @@
 
 - name: Set token_server and other container default settings
   set_fact:
-    token_server_dict: "{ 'token_server': '{{ token_server }}', 'token_auth_disabled': 'False', 'token_signature_algorithm': 'ES256','public_key_path': '/etc/pulp/keys/container_auth_public_key.pem', 'private_key_path': '/etc/pulp/keys/container_auth_private_key.pem', 'galaxy_feature_flags': { 'execution_environments': 'True' }  }"
+    token_server_dict: "{ 'token_server': '{{ token_server }}', 'token_auth_disabled': 'False', 'token_signature_algorithm': 'ES256','public_key_path': '/etc/pulp/keys/container_auth_public_key.pem', 'private_key_path': '/etc/pulp/keys/container_auth_private_key.pem' }"
   when: container_token_secret is defined
 
 - name: DEBUG Show content_origin_dict


### PR DESCRIPTION
By overriding the galaxy_feature_flags configuration for enabling the EE then we loose all other default values from galaxy_feature_flags. Prior pulpcore 3.23 this wasn't a problem but starting 3.23, if the galaxy_feature_flags dict doesn't have some required key then dynaconf will fail (like during the database migration).

```console
+ /usr/bin/pulpcore-manager migrate --noinput Traceback (most recent call last):
Traceback (most recent call last):
  File "/usr/bin/pulpcore-manager", line 33, in <module>
    sys.exit(load_entry_point('pulpcore==3.23.2', 'console_scripts', 'pulpcore-manager')())
  File "/usr/lib/python3.9/site-packages/pulpcore/app/manage.py", line 11, in manage
    execute_from_command_line(sys.argv)
  File "/usr/lib/python3.9/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/usr/lib/python3.9/site-packages/django/core/management/__init__.py", line 395, in execute
    django.setup()
  File "/usr/lib/python3.9/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/lib/python3.9/site-packages/django/apps/registry.py", line 122, in populate
    app_config.ready()
  File "/usr/lib/python3.9/site-packages/galaxy_ng/app/__init__.py", line 13, in ready
    super().ready()
  File "/usr/lib/python3.9/site-packages/pulpcore/app/apps.py", line 124, in ready
    self.import_urls()
  File "/usr/lib/python3.9/site-packages/pulpcore/app/apps.py", line 191, in import_urls
    self.urls_module = import_module(urls_module_name)
  File "/usr/lib64/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/lib/python3.9/site-packages/galaxy_ng/app/urls.py", line 7, in <module>
    from galaxy_ng.app.api import urls as api_urls
  File "/usr/lib/python3.9/site-packages/galaxy_ng/app/api/urls.py", line 5, in <module>
    from .ui import urls as ui_urls
  File "/usr/lib/python3.9/site-packages/galaxy_ng/app/api/ui/urls.py", line 173, in <module>
    if settings.GALAXY_FEATURE_FLAGS['ai_deny_index']:
  File "/usr/lib/python3.9/site-packages/dynaconf/utils/boxing.py", line 18, in evaluate
    value = f(dynabox, item, *args, **kwargs)
  File "/usr/lib/python3.9/site-packages/dynaconf/utils/boxing.py", line 49, in __getitem__
    return super().__getitem__(n_item, *args, **kwargs)
  File "/usr/lib/python3.9/site-packages/dynaconf/vendor/box/box.py", line 162, in __getitem__
    raise BoxKeyError(str(E)) from _A
dynaconf.vendor.box.exceptions.BoxKeyError: "'ai_deny_index'"
```

The `execution_environments` configuration within GALAXY_FEATURE_FLAGS has always been set to True by default so there's no need to define it explicitly.

https://github.com/ansible/galaxy_ng/blob/stable-4.6/galaxy_ng/app/settings.py#L74-L77 https://github.com/ansible/galaxy_ng/blob/stable-4.7/galaxy_ng/app/settings.py#L75-L79

[noissue]