### PR TITLE
[ansible] csv: Fix file_storage_access_mode enum

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -605,6 +605,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:storage_type:File
         - urn:alm:descriptor:com.tectonic.ui:select:ReadWriteMany
+        - urn:alm:descriptor:com.tectonic.ui:select:ReadWriteOnce
       - displayName: File storage size
         path: file_storage_size
         x-descriptors:

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -237,6 +237,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:storage_type:File
         - urn:alm:descriptor:com.tectonic.ui:select:ReadWriteMany
+        - urn:alm:descriptor:com.tectonic.ui:select:ReadWriteOnce
       - displayName: File storage size
         path: file_storage_size
         x-descriptors:


### PR DESCRIPTION
When using the UI, there's only the ReadWriteMany value available for the file_storage_access_mode parameter.
ReadWriteOnce is also an available option.

https://github.com/pulp/pulp-operator/blob/ansible/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml#L159-L165

[noissue]