### PR TITLE
Add back list & watch rules for cluster-wide ingresses

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -1017,6 +1017,8 @@ spec:
           - ingresses
           verbs:
           - get
+          - list
+          - watch
         serviceAccountName: pulp-operator-sa
       deployments:
       - label:

--- a/config/rbac/cluster_role.yaml
+++ b/config/rbac/cluster_role.yaml
@@ -12,3 +12,5 @@ rules:
       - ingresses
     verbs:
       - get
+      - list
+      - watch


### PR DESCRIPTION
This previous commit was not a clean revert, and missed two rules that are needed (list and watch) on the ingresses resource for the operator SA.  

* https://github.com/pulp/pulp-operator/commit/47d4ba6083094d4acacf88d76bda3a151b423e7d