### PR TITLE
[ansible] rbac: remove resourceNames for OCP ingresses

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -1011,8 +1011,6 @@ spec:
       - rules:
         - apiGroups:
           - config.openshift.io
-          resourceNames:
-          - cluster
           resources:
           - ingresses
           verbs:

--- a/config/rbac/cluster_role.yaml
+++ b/config/rbac/cluster_role.yaml
@@ -6,8 +6,6 @@ metadata:
 rules:
   - apiGroups:
       - config.openshift.io
-    resourceNames:
-      - cluster
     resources:
       - ingresses
     verbs:


### PR DESCRIPTION
When using resourceNames on the config.openshift.io apigroup for querying the ingresses resource then we don't need to specify the resourceNames.
Using it will generate a permission error during the operator execution but won't cause the deployment to fail.

```console
[E0526 01:41:41.701732 7 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:245: Failed to watch config.openshift.io/v1, Kind=Ingress: failed to list config.openshift.io/v1, Kind=Ingress: ingresses.config.openshift.io is forbidden: User "system:serviceaccount:aap:automation-hub-operator-sa" cannot list resource "ingresses" in API group "config.openshift.io" at the cluster scope
```

[noissue]