### PR TITLE
Feature flag should be boolean, not string type

### DIFF
--- a/bundle/manifests/pulp.pulpproject.org_pulps.yaml
+++ b/bundle/manifests/pulp.pulpproject.org_pulps.yaml
@@ -443,7 +443,7 @@ spec:
                   GALAXY_FEATURE_FLAGS:
                     properties:
                       execution_environments:
-                        type: string
+                        type: boolean
                     type: object
                   debug:
                     type: string

--- a/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
+++ b/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
@@ -67,7 +67,7 @@ spec:
                   GALAXY_FEATURE_FLAGS:
                     properties:
                       execution_environments:
-                        type: string
+                        type: boolean
                     type: object
                 type: object
               sso_secret:


### PR DESCRIPTION
The execution_environments feature flag should be a boolean, not a string type in the CRD schema. 