### PR TITLE
Add a wait for API pods when image version changed

### DIFF
--- a/CHANGES/969.feature
+++ b/CHANGES/969.feature
@@ -1,0 +1,2 @@
+Modified the reconciliation for `pulpcore-content` to wait for `API` pods get
+into a READY state before updating the `Deployment` in case of image version change.

--- a/controllers/repo_manager/content.go
+++ b/controllers/repo_manager/content.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"strconv"
+	"time"
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -71,6 +72,12 @@ func (r *RepoManagerReconciler) pulpContentController(ctx context.Context, pulp 
 	deployment := &appsv1.Deployment{}
 	r.Get(ctx, types.NamespacedName{Name: pulp.Name + "-content", Namespace: pulp.Namespace}, deployment)
 	expected := deploymentForPulpContent(funcResources)
+	// before doing the reconciliation, in case of image version change
+	// we should wait for all API pods get upgraded
+	if controllers.CheckImageVersionModified(pulp, deployment) {
+		log.Info("A new image version has been provided! Waiting for API pods to upgrade first ...")
+		controllers.WaitAPIPods(r, pulp, deployment, time.Second*60)
+	}
 	if requeue, err := reconcileObject(funcResources, expected, deployment, conditionType); err != nil || requeue {
 		return ctrl.Result{Requeue: requeue}, err
 	}


### PR DESCRIPTION
closes: #969

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
