### PR TITLE
Add a log message with current version

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,6 +180,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	setupLog.Info("pulp-operator version: 1.0.1-alpha.6")
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")


### PR DESCRIPTION
Providing the current version in logs can be helpful during troubleshooting. For example, when an issue already fixed in version X is found in the running operator this is probably because the version deployed is older than the one with the fix. [noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
