### PR TITLE
Add a field to suppress the check of image_version

### DIFF
--- a/apis/repo-manager.pulpproject.org/v1beta2/pulp_types.go
+++ b/apis/repo-manager.pulpproject.org/v1beta2/pulp_types.go
@@ -245,6 +245,12 @@ type PulpSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ImageVersion string `json:"image_version,omitempty"`
 
+	// Relax the check of image_version and image_web_version not matching.
+	// Default: "false"
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	InhibitVersionConstraint bool `json:"inhibit_version_constraint,omitempty"`
+
 	// Image pull policy for container image.
 	// Default: "IfNotPresent"
 	// +kubebuilder:validation:Optional

--- a/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
+++ b/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
@@ -24548,6 +24548,10 @@ spec:
                 - NodePort
                 - nodeport
                 type: string
+              inhibit_version_constraint:
+                description: 'Relax the check of image_version and image_web_version
+                  not matching. Default: "false"'
+                type: boolean
               loadbalancer_port:
                 description: Port exposed by pulp-web service when ingress_type==loadbalancer
                 format: int32

--- a/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
+++ b/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
@@ -24549,6 +24549,10 @@ spec:
                 - NodePort
                 - nodeport
                 type: string
+              inhibit_version_constraint:
+                description: 'Relax the check of image_version and image_web_version
+                  not matching. Default: "false"'
+                type: boolean
               loadbalancer_port:
                 description: Port exposed by pulp-web service when ingress_type==loadbalancer
                 format: int32

--- a/controllers/repo_manager/README.md
+++ b/controllers/repo_manager/README.md
@@ -183,6 +183,7 @@ PulpSpec defines the desired state of Pulp
 | container_auth_private_key_name | Private Key name from `<operator's name> + \"-container-auth-certs\"` Secret. Default: \"container_auth_private_key.pem\" | string | false |
 | image | The image name (repo name) for the pulp image. Default: \"quay.io/pulp/pulp-minimal:stable\" | string | false |
 | image_version | The image version for the pulp image. Default: \"stable\" | string | false |
+| inhibit_version_constraint | Relax the check of image_version and image_web_version not matching. Default: \"false\" | bool | false |
 | image_pull_policy | Image pull policy for container image. Default: \"IfNotPresent\" | string | false |
 | api | Api defines desired state of pulpcore-api resources | [Api](#api) | true |
 | database | Database defines desired state of postgres resources | [Database](#database) | false |

--- a/controllers/repo_manager/controller.go
+++ b/controllers/repo_manager/controller.go
@@ -146,8 +146,12 @@ func (r *RepoManagerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	needsPulpWeb := strings.ToLower(pulp.Spec.IngressType) != "route" && !controllers.IsNginxIngressSupported(r, pulp.Spec.IngressClassName)
 	if needsPulpWeb && pulp.Spec.ImageVersion != pulp.Spec.ImageWebVersion {
-		log.Error(nil, "imageVersion should be equal to ImageWebVersion. Please, define image_version and image_web_version with the same value")
-		return ctrl.Result{}, nil
+		if pulp.Spec.InhibitVersionConstraint {
+			controllers.CustomZapLogger().Warn("image_version should be equal to image_web_version! Using different versions is not recommended and can make the application unreachable")
+		} else {
+			log.Error(nil, "image_version should be equal to image_web_version. Please, define image_version and image_web_version with the same value")
+			return ctrl.Result{}, nil
+		}
 	}
 
 	// in case of ingress_type == ingress.


### PR DESCRIPTION
This commit adds a field in CRD to allow bypassing the verification of `image_version` being different than `image_web_version`. It can be useful in situations like testing news configs without re-building both images with the same tag.
[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
