### PR TITLE
Update signing scripts to work with passphrase

### DIFF
--- a/.ci/assets/kubernetes/signing_scripts.configmap.yaml
+++ b/.ci/assets/kubernetes/signing_scripts.configmap.yaml
@@ -14,7 +14,7 @@ data:
       PASSWORD="password"
 
       # Create a detached signature
-      gpg --quiet --batch --yes --passphrase \
+      gpg --quiet --batch --pinentry-mode loopback --yes --passphrase \
           $PASSWORD --homedir ~/.gnupg/ --detach-sign --default-key $ADMIN_ID \
           --armor --output $SIGNATURE_PATH $FILE_PATH
 
@@ -29,7 +29,7 @@ data:
     #!/usr/bin/env bash
     set -u
     # This GPG_TTY variable might be needed on a container image that is not running as root.
-    #export GPG_TTY=$(tty)
+    export GPG_TTY=$(tty)
     # Create a file with passphrase only if the key is password protected.
     # echo "Galaxy2022" > /tmp/key_password.txt
     # pulp_container SigningService will pass the next 3 variables to the script.

--- a/CHANGES/994.bugfix
+++ b/CHANGES/994.bugfix
@@ -1,0 +1,1 @@
+Fixed signing-scripts to be compatible with passphrase in the gpg key.


### PR DESCRIPTION
This commit updates the script so that it will not ask for the passphrase key protection and instead use the supplied one in batch mode.

fixes: #994

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
