### PR TITLE
Rename RELATED_IMAGE_ for GPG init container

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -1084,6 +1084,8 @@ spec:
                   value: redis:latest
                 - name: RELATED_IMAGE_PULP_POSTGRES
                   value: postgres:13
+                - name: RELATED_IMAGE_PULP_INIT_GPG_CONTAINER
+                  value: quay.io/centos/centos:stream9
                 image: quay.io/pulp/pulp-operator:v0.15.0.dev
                 livenessProbe:
                   httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,6 +62,8 @@ spec:
               value: redis:latest
             - name: RELATED_IMAGE_PULP_POSTGRES
               value: postgres:13
+            - name: RELATED_IMAGE_PULP_INIT_GPG_CONTAINER
+              value: quay.io/centos/centos:stream9
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -938,6 +938,8 @@ spec:
                   value: redis:latest
                 - name: RELATED_IMAGE_PULP_POSTGRES
                   value: postgres:13
+                - name: RELATED_IMAGE_PULP_INIT_GPG_CONTAINER
+                  value: quay.io/centos/centos:stream9
                 image: quay.io/pulp/pulp-operator:devel
                 name: pulp-manager
                 resources: {}

--- a/roles/pulp-api/tasks/signing_service.yml
+++ b/roles/pulp-api/tasks/signing_service.yml
@@ -14,7 +14,7 @@
 - name: Set GPG initContainer image
   set_fact:
     gpg_init_container_image: >-
-      {{ lookup('env', 'RELATED_IMAGE_GPG_INIT_CONTAINER') |
+      {{ lookup('env', 'RELATED_IMAGE_PULP_INIT_GPG_CONTAINER') |
          default(__gpg_init_container_image,true) }}
 
 - name: Check for signing keys


### PR DESCRIPTION
Follow-up for https://github.com/pulp/pulp-operator/pull/1002

This PR does the following:
* Adds the GPG init container RELATED_IMAGE_ ref everywhere needed (CSV & manager deployment)
* Renames it from `RELATED_IMAGE_GPG_INIT_CONTAINER` to `RELATED_IMAGE_PULP_INIT_GPG_CONTAINER` for consistency with other projects.