### PR TITLE
Do not get ingress default domain and ingressclass

### DIFF
--- a/.ci/scripts/bundle_check.sh
+++ b/.ci/scripts/bundle_check.sh
@@ -3,7 +3,7 @@
 make bundle-check
 
 echo "Comparing files ..."
-diff -qr bundle /tmp/bundle
+diff -qr --ignore-matching-lines='createdAt:.*' bundle /tmp/bundle
 if [ $? != 0 ]; then
   echo """
 There is probably an update made in the CRD that is pending in the above bundle file(s).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,6 +563,10 @@ jobs:
           kubectl get pulps.repo-manager.pulpproject.org
           sudo systemctl stop pulp-operator.service
           make local
+          if [[ "$INGRESS_TYPE" == "ingress" ]]; then
+            kubectl patch pulp example-pulp --type=merge -p '{"spec": { "web": {"replicas": 1 }}}'
+            kubectl patch pulp example-pulp --type=merge -p '{"spec": { "ingress_annotations": { "nginx.ingress.kubernetes.io/proxy-body-size": "0" } }}'
+          fi
           sleep 10
         shell: bash
       - name: Check and wait pulp-operator deploy

--- a/CHANGES/885.removal
+++ b/CHANGES/885.removal
@@ -1,0 +1,1 @@
+The operator will not get the default ingress domain nor verify the ingressclass anymore to avoid the need of clusterroles.

--- a/CHANGES/917.bugfix
+++ b/CHANGES/917.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue in OCP clusters where every ingress would be created with the same configurations (regardless of ingressclass).

--- a/CHANGES/918.bugfix
+++ b/CHANGES/918.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue in OCP clusters where the "pulp-redirect" Ingress would not get removed after modifying ingress_class_name.

--- a/CHANGES/923.bugfix
+++ b/CHANGES/923.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue in `Ingress.spec.rules.http.paths` from non "nginx" or "openshift-default" ingresses.

--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ SDK_BIN = $(LOCALBIN)/operator-sdk
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.9.2
 CRD_MARKDOWN_VERSION ?= v0.0.3
-OPERATOR_SDK_VERSION ?= v1.25.2
+OPERATOR_SDK_VERSION ?= v1.29.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/apis/repo-manager.pulpproject.org/v1beta2/pulp_types.go
+++ b/apis/repo-manager.pulpproject.org/v1beta2/pulp_types.go
@@ -139,6 +139,15 @@ type PulpSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress"}
 	IngressClassName string `json:"ingress_class_name,omitempty"`
 
+	// Define if the IngressClass provided has Nginx as Ingress Controller.
+	// If the Ingress Controller is not nginx the operator will automatically provision `pulp-web` pods to redirect the traffic.
+	// If it is a nginx controller the traffic will be forwarded to api and content pods.
+	// This variable is a workaround to avoid having to grant a ClusterRole (to do a get into the IngressClass and verify the controller).
+	// Default: false
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress"}
+	IsNginxIngress bool `json:"is_nginx_ingress,omitempty"`
+
 	// Ingress DNS host
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress"}
 	IngressHost string `json:"ingress_host,omitempty"`

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=pulp-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=beta
 LABEL operators.operatorframework.io.bundle.channel.default.v1=beta
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.29.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/pulp-operator-manager-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/pulp-operator-manager-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: pulp-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: pulp-operator-controller-manager
+  namespace: pulp-operator-system

--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -324,10 +324,10 @@ metadata:
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     containerImage: quay.io/pulp/pulp-operator:devel
-    createdAt: "2021-03-26 16:57:40"
+    createdAt: "2023-07-17T17:24:35Z"
     description: Pulp is a platform for managing repositories of software packages
       and making them available to a large number of consumers.
-    operators.operatorframework.io/builder: operator-sdk-v1.25.2
+    operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/pulp/pulp-operator
   name: pulp-operator.v1.0.0-alpha.9
@@ -3028,6 +3028,17 @@ spec:
         path: inhibit_version_constraint
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: 'Define if the IngressClass provided has Nginx as Ingress Controller.
+          If the Ingress Controller is not nginx the operator will automatically provision
+          `pulp-web` pods to redirect the traffic. If it is a nginx controller the
+          traffic will be forwarded to api and content pods. This variable is a workaround
+          to avoid having to grant a ClusterRole (to do a get into the IngressClass
+          and verify the controller). Default: false'
+        displayName: Is Nginx Ingress
+        path: is_nginx_ingress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress
       - description: Port exposed by pulp-web service when ingress_type==loadbalancer
         displayName: Loadbalancer Port
         path: loadbalancer_port
@@ -3491,22 +3502,6 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - config.openshift.io
-          resources:
-          - ingresses
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - networking.k8s.io
-          resources:
-          - ingressclasses
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews
@@ -3653,18 +3648,9 @@ spec:
           - create
           - patch
         - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
-        - apiGroups:
           - apps
-          - networking.k8s.io
           resources:
           - deployments
-          - ingresses
           - statefulsets
           verbs:
           - create
@@ -3691,7 +3677,10 @@ spec:
           resources:
           - configmaps
           - persistentvolumeclaims
+          - pods
+          - pods/log
           - secrets
+          - serviceaccounts
           - services
           verbs:
           - create
@@ -3701,6 +3690,13 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
         - apiGroups:
           - ""
           resources:
@@ -3718,24 +3714,13 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - pods
-          - pods/log
-          verbs:
-          - get
-          - list
-        - apiGroups:
-          - ""
-          resources:
           - pods/exec
           verbs:
           - create
         - apiGroups:
-          - ""
-          - rbac.authorization.k8s.io
+          - networking.k8s.io
           resources:
-          - rolebindings
-          - roles
-          - serviceaccounts
+          - ingresses
           verbs:
           - create
           - delete
@@ -3748,6 +3733,19 @@ spec:
           - policy
           resources:
           - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
           verbs:
           - create
           - delete

--- a/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
+++ b/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
@@ -24552,6 +24552,15 @@ spec:
                 description: 'Relax the check of image_version and image_web_version
                   not matching. Default: "false"'
                 type: boolean
+              is_nginx_ingress:
+                description: 'Define if the IngressClass provided has Nginx as Ingress
+                  Controller. If the Ingress Controller is not nginx the operator
+                  will automatically provision `pulp-web` pods to redirect the traffic.
+                  If it is a nginx controller the traffic will be forwarded to api
+                  and content pods. This variable is a workaround to avoid having
+                  to grant a ClusterRole (to do a get into the IngressClass and verify
+                  the controller). Default: false'
+                type: boolean
               loadbalancer_port:
                 description: Port exposed by pulp-web service when ingress_type==loadbalancer
                 format: int32

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: pulp-operator
   operators.operatorframework.io.bundle.channels.v1: beta
   operators.operatorframework.io.bundle.channel.default.v1: beta
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.2
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.29.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
+++ b/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
@@ -24553,6 +24553,15 @@ spec:
                 description: 'Relax the check of image_version and image_web_version
                   not matching. Default: "false"'
                 type: boolean
+              is_nginx_ingress:
+                description: 'Define if the IngressClass provided has Nginx as Ingress
+                  Controller. If the Ingress Controller is not nginx the operator
+                  will automatically provision `pulp-web` pods to redirect the traffic.
+                  If it is a nginx controller the traffic will be forwarded to api
+                  and content pods. This variable is a workaround to avoid having
+                  to grant a ClusterRole (to do a get into the IngressClass and verify
+                  the controller). Default: false'
+                type: boolean
               loadbalancer_port:
                 description: Port exposed by pulp-web service when ingress_type==loadbalancer
                 format: int32

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -1073,6 +1073,17 @@ spec:
         path: inhibit_version_constraint
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: 'Define if the IngressClass provided has Nginx as Ingress Controller.
+          If the Ingress Controller is not nginx the operator will automatically provision
+          `pulp-web` pods to redirect the traffic. If it is a nginx controller the
+          traffic will be forwarded to api and content pods. This variable is a workaround
+          to avoid having to grant a ClusterRole (to do a get into the IngressClass
+          and verify the controller). Default: false'
+        displayName: Is Nginx Ingress
+        path: is_nginx_ingress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress
       - description: Port exposed by pulp-web service when ingress_type==loadbalancer
         displayName: Loadbalancer Port
         path: loadbalancer_port

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,28 +1,5 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: manager-role
-rules:
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingressclasses
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
@@ -30,18 +7,9 @@ metadata:
   namespace: pulp-operator-system
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
   - apps
-  - networking.k8s.io
   resources:
   - deployments
-  - ingresses
   - statefulsets
   verbs:
   - create
@@ -68,7 +36,10 @@ rules:
   resources:
   - configmaps
   - persistentvolumeclaims
+  - pods
+  - pods/log
   - secrets
+  - serviceaccounts
   - services
   verbs:
   - create
@@ -78,6 +49,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -95,24 +73,13 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - pods/log
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ""
-  resources:
   - pods/exec
   verbs:
   - create
 - apiGroups:
-  - ""
-  - rbac.authorization.k8s.io
+  - networking.k8s.io
   resources:
-  - rolebindings
-  - roles
-  - serviceaccounts
+  - ingresses
   verbs:
   - create
   - delete
@@ -125,6 +92,19 @@ rules:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
   verbs:
   - create
   - delete

--- a/config/samples/simple.ingress.yaml
+++ b/config/samples/simple.ingress.yaml
@@ -38,6 +38,7 @@ spec:
   ingress_type: ingress
   ingress_host: ingress.local
   ingress_class_name: nginx
+  is_nginx_ingress: true
 
   pulp_settings:
     api_root: "/pulp/"

--- a/controllers/ingress.go
+++ b/controllers/ingress.go
@@ -35,44 +35,25 @@ type IngressPlugin struct {
 func IngressDefaults(resources any, plugins []IngressPlugin) (*netv1.Ingress, error) {
 	pulp := resources.(FunctionResources).Pulp
 	annotation := map[string]string{
-		"web": "false",
+		"web": "true",
 	}
 	var paths []netv1.HTTPIngressPath
 	var path netv1.HTTPIngressPath
 	pathType := netv1.PathTypePrefix
 
-	for _, plugin := range plugins {
-		if len(plugin.Rewrite) > 0 {
-			annotation["web"] = "true"
-			path = netv1.HTTPIngressPath{
-				Path:     "/",
-				PathType: &pathType,
-				Backend: netv1.IngressBackend{
-					Service: &netv1.IngressServiceBackend{
-						Name: pulp.Name + "-web-svc",
-						Port: netv1.ServiceBackendPort{
-							Number: 24880,
-						},
-					},
-				},
-			}
-			paths = append(paths, path)
-			break
-		}
-		path = netv1.HTTPIngressPath{
-			Path:     plugin.Path,
-			PathType: &pathType,
-			Backend: netv1.IngressBackend{
-				Service: &netv1.IngressServiceBackend{
-					Name: plugin.ServiceName,
-					Port: netv1.ServiceBackendPort{
-						Name: plugin.TargetPort,
-					},
+	path = netv1.HTTPIngressPath{
+		Path:     "/",
+		PathType: &pathType,
+		Backend: netv1.IngressBackend{
+			Service: &netv1.IngressServiceBackend{
+				Name: pulp.Name + "-web-svc",
+				Port: netv1.ServiceBackendPort{
+					Number: 24880,
 				},
 			},
-		}
-		paths = append(paths, path)
+		},
 	}
+	paths = append(paths, path)
 
 	for key, val := range pulp.Spec.IngressAnnotations {
 		annotation[key] = val

--- a/controllers/ocp/ingress.go
+++ b/controllers/ocp/ingress.go
@@ -18,7 +18,12 @@ package ocp
 
 import (
 	"github.com/pulp/pulp-operator/controllers"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // IngressOCP is the Ingress definition for OCP clusters
@@ -27,11 +32,25 @@ type IngressOCP struct{}
 // Deploy returns an Ingress based on default OCP IngressController (openshift.io/ingress-to-route)
 func (i IngressOCP) Deploy(resources controllers.FunctionResources, plugins []controllers.IngressPlugin) (*netv1.Ingress, error) {
 
-	pulp := resources.Pulp
+	// deploy redirect ingress
+	if err := deployOCPIngressRedirect(resources, plugins); err != nil {
+		return &netv1.Ingress{}, err
+	}
 
-	ingress, err := controllers.IngressDefaults(resources, plugins)
+	// deploy default ingress
+	return deployOCPIngress(resources, plugins)
+}
+
+// deployRedir defines the ocp ingress spec with the redirect rules
+func deployOCPIngressRedirect(resources controllers.FunctionResources, plugins []controllers.IngressPlugin) error {
+	pulp := resources.Pulp
+	log := resources.Logger
+	ingressName := pulp.Name + "-redirect"
+	conditionType := cases.Title(language.English, cases.Compact).String(pulp.Spec.DeploymentType) + "-Ingress-Ready"
+
+	expectedIngress, err := controllers.IngressDefaults(resources, plugins)
 	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	redirectAnnotation := map[string]string{
@@ -65,17 +84,120 @@ func (i IngressOCP) Deploy(resources controllers.FunctionResources, plugins []co
 		}
 	}
 
+	// if there is no plugin that needs a redirect, don't create the redirect route
+	if len(redirectPaths) == 0 {
+		return nil
+	}
+
 	for key, val := range pulp.Spec.IngressAnnotations {
 		redirectAnnotation[key] = val
 	}
 
-	ingress.ObjectMeta.Annotations = redirectAnnotation
-	ingress.Spec.IngressClassName = &pulp.Spec.IngressClassName
-	ingress.Spec.Rules[0].IngressRuleValue = netv1.IngressRuleValue{
+	expectedIngress.ObjectMeta.Annotations = redirectAnnotation
+	expectedIngress.ObjectMeta.Name = ingressName
+	expectedIngress.Spec.IngressClassName = &pulp.Spec.IngressClassName
+	expectedIngress.Spec.Rules[0].IngressRuleValue = netv1.IngressRuleValue{
 		HTTP: &netv1.HTTPIngressRuleValue{
 			Paths: redirectPaths,
 		},
 	}
 
+	// [TODO] Refactor this. We should not be deploying the ingress here (through this function).
+	// For now, keeping the same approach as of the old commits/implementation while I cannot find a
+	// better way.
+	currentIngress := &netv1.Ingress{}
+	if err = resources.Get(resources.Context, types.NamespacedName{Name: ingressName, Namespace: pulp.Namespace}, currentIngress); err != nil && errors.IsNotFound(err) {
+		log.Info("Creating a new ingress", "Ingress.Namespace", expectedIngress.Namespace, "Ingress.Name", ingressName)
+		controllers.UpdateStatus(resources.Context, resources.Client, pulp, metav1.ConditionFalse, conditionType, "CreatingIngress", "Creating "+pulp.Name+"-ingress")
+		err = resources.Create(resources.Context, expectedIngress)
+		if err != nil {
+			log.Error(err, "Failed to create new ingress", "Ingress.Namespace", expectedIngress.Namespace, "Ingress.Name", ingressName)
+			controllers.UpdateStatus(resources.Context, resources.Client, pulp, metav1.ConditionFalse, conditionType, "ErrorCreatingIngress", "Failed to create "+pulp.Name+"-ingress: "+err.Error())
+			return err
+		}
+	} else if err != nil {
+		log.Error(err, "Failed to get ingress")
+		return err
+	}
+
+	// Ensure ingress specs are as expected
+	if _, err := controllers.ReconcileObject(controllers.FunctionResources{Context: resources.Context, Client: resources.Client, Pulp: pulp, Scheme: resources.Scheme, Logger: log}, expectedIngress, currentIngress, conditionType); err != nil {
+		return err
+	}
+
+	// Ensure ingress labels and annotations are as expected
+	if _, err := controllers.ReconcileMetadata(controllers.FunctionResources{Context: resources.Context, Client: resources.Client, Pulp: pulp, Scheme: resources.Scheme, Logger: log}, expectedIngress, currentIngress, conditionType); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// deploy defines the default ocp ingress spec (rules to api and content services that don't need redirection)
+func deployOCPIngress(resources controllers.FunctionResources, plugins []controllers.IngressPlugin) (*netv1.Ingress, error) {
+	pulp := resources.Pulp
+	var paths []netv1.HTTPIngressPath
+	pathType := netv1.PathTypePrefix
+
+	ingress, err := controllers.IngressDefaults(resources, plugins)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, plugin := range plugins {
+		if len(plugin.Rewrite) == 0 {
+			path := netv1.HTTPIngressPath{
+				Path:     plugin.Path,
+				PathType: &pathType,
+				Backend: netv1.IngressBackend{
+					Service: &netv1.IngressServiceBackend{
+						Name: plugin.ServiceName,
+						Port: netv1.ServiceBackendPort{
+							Name: plugin.TargetPort,
+						},
+					},
+				},
+			}
+			paths = append(paths, path)
+		}
+	}
+
+	annotations := map[string]string{
+		"web": "false",
+	}
+	hAProxyTimeout := pulp.Spec.HAProxyTimeout
+	if len(hAProxyTimeout) == 0 {
+		hAProxyTimeout = "180s"
+	}
+	annotations["haproxy.router.openshift.io/timeout"] = hAProxyTimeout
+
+	for key, val := range pulp.Spec.IngressAnnotations {
+		annotations[key] = val
+	}
+
+	ingress.ObjectMeta.Annotations = annotations
+	ingress.Spec.IngressClassName = &pulp.Spec.IngressClassName
+	ingress.Spec.Rules[0].HTTP.Paths = paths
 	return ingress, nil
+}
+
+// UpdateIngressClass will handle the modifications needed when changing to/from "openshift-default" ingressclass
+func UpdateIngressClass(resources controllers.FunctionResources) {
+
+	pulp := resources.Pulp
+	ctx := resources.Context
+
+	// if the new IngressClass is an "openshift-default"
+	if pulp.Spec.IngressClassName == controllers.DefaultOCPIngressClass {
+		// remove pulp-web components
+		controllers.RemovePulpWebResources(resources)
+	}
+
+	// if it was an Ingress with "openshift-default" IngressClass and is not anymore, remove "pulp-redirect" Ingress
+	if pulp.Status.IngressClassName == controllers.DefaultOCPIngressClass && pulp.Spec.IngressClassName != controllers.DefaultOCPIngressClass {
+		ingress := &netv1.Ingress{}
+		if err := resources.Get(ctx, types.NamespacedName{Name: pulp.Name + "-redirect", Namespace: pulp.Namespace}, ingress); !errors.IsNotFound(err) {
+			resources.Delete(ctx, ingress)
+		}
+	}
 }

--- a/controllers/ocp/route.go
+++ b/controllers/ocp/route.go
@@ -140,7 +140,7 @@ func PulpRouteController(resources controllers.FunctionResources, restClient res
 			ServiceName: pulp.Name + "-api-svc",
 		},
 	}
-	routeHost := GetRouteHost(ctx, resources.Client, pulp)
+	routeHost := GetRouteHost(pulp)
 	pulpPlugins = append(defaultPlugins, pulpPlugins...)
 
 	// channel used to receive the return value from each goroutine

--- a/controllers/ocp/utils.go
+++ b/controllers/ocp/utils.go
@@ -20,8 +20,8 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	configv1 "github.com/openshift/api/config/v1"
 	repomanagerpulpprojectorgv1beta2 "github.com/pulp/pulp-operator/apis/repo-manager.pulpproject.org/v1beta2"
+	"github.com/pulp/pulp-operator/controllers"
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,12 +134,12 @@ func mountCASpec(pulp *repomanagerpulpprojectorgv1beta2.Pulp, volumes []corev1.V
 }
 
 // GetRouteHost defines route host based on ingress default cluster domain if no .spec.route_host defined
-func GetRouteHost(ctx context.Context, client client.Client, pulp *repomanagerpulpprojectorgv1beta2.Pulp) string {
-	routeHost := pulp.Spec.RouteHost
+func GetRouteHost(pulp *repomanagerpulpprojectorgv1beta2.Pulp) string {
 	if len(pulp.Spec.RouteHost) == 0 {
-		ingress := &configv1.Ingress{}
-		client.Get(ctx, types.NamespacedName{Name: "cluster"}, ingress)
-		routeHost = pulp.Name + "." + ingress.Spec.Domain
+		controllers.CustomZapLogger().Warn(`ingress_type defined as "route" but no route_host provided.`)
+		controllers.CustomZapLogger().Warn(`Setting "example.com" as the default hostname for routes ...`)
+		return "example.com"
 	}
-	return routeHost
+
+	return pulp.Spec.RouteHost
 }

--- a/controllers/repo_manager/README.md
+++ b/controllers/repo_manager/README.md
@@ -165,6 +165,7 @@ PulpSpec defines the desired state of Pulp
 | ingress_type | The ingress type to use to reach the deployed instance. Default: none (will not expose the service) | string | false |
 | ingress_annotations | Annotations for the Ingress | map[string]string | false |
 | ingress_class_name | IngressClassName is used to inform the operator which ingressclass should be used to provision the ingress. Default: \"\" (will use the default ingress class) | string | false |
+| is_nginx_ingress | Define if the IngressClass provided has Nginx as Ingress Controller. If the Ingress Controller is not nginx the operator will automatically provision `pulp-web` pods to redirect the traffic. If it is a nginx controller the traffic will be forwarded to api and content pods. This variable is a workaround to avoid having to grant a ClusterRole (to do a get into the IngressClass and verify the controller). Default: false | bool | false |
 | ingress_host | Ingress DNS host | string | false |
 | ingress_tls_secret | Ingress TLS secret | string | false |
 | route_host | Route DNS host. Default: <operator's name> + \".\" + ingress.Spec.Domain | string | false |

--- a/controllers/repo_manager/controller.go
+++ b/controllers/repo_manager/controller.go
@@ -60,14 +60,12 @@ type RepoManagerReconciler struct {
 //+kubebuilder:rbac:groups=repo-manager.pulpproject.org,namespace=pulp-operator-system,resources=pulps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=repo-manager.pulpproject.org,namespace=pulp-operator-system,resources=pulps/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=repo-manager.pulpproject.org,namespace=pulp-operator-system,resources=pulps/finalizers,verbs=update
-//+kubebuilder:rbac:groups=apps;networking.k8s.io,namespace=pulp-operator-system,resources=deployments;statefulsets;ingresses,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=get;list;watch
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingressclasses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=networking.k8s.io,namespace=pulp-operator-system,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=route.openshift.io,namespace=pulp-operator-system,resources=routes;routes/custom-host,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,namespace=pulp-operator-system,resources=pods;pods/log,verbs=get;list;
-//+kubebuilder:rbac:groups=core;rbac.authorization.k8s.io,namespace=pulp-operator-system,resources=roles;rolebindings;serviceaccounts,verbs=create;update;patch;delete;watch;get;list;
-//+kubebuilder:rbac:groups=core,namespace=pulp-operator-system,resources=configmaps;secrets;services;persistentvolumeclaims,verbs=create;update;patch;delete;watch;get;list;
-//+kubebuilder:rbac:groups="",namespace=pulp-operator-system,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace=pulp-operator-system,resources=roles;rolebindings,verbs=create;update;patch;delete;watch;get;list
+//+kubebuilder:rbac:groups=core,namespace=pulp-operator-system,resources=pods;pods/log;serviceaccounts;configmaps;secrets;services;persistentvolumeclaims,verbs=create;update;patch;delete;watch;get;list
+//+kubebuilder:rbac:groups=core,namespace=pulp-operator-system,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=apps,namespace=pulp-operator-system,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=policy,namespace=pulp-operator-system,resources=poddisruptionbudgets,verbs=get;list;create;delete;patch;update;watch
 //+kubebuilder:rbac:groups=batch,namespace=pulp-operator-system,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
 

--- a/controllers/restore/deploy.go
+++ b/controllers/restore/deploy.go
@@ -131,7 +131,7 @@ func (r *RepoManagerRestoreReconciler) scaleDeployments(ctx context.Context, pul
 		pulp.Spec.Api.Replicas = 1
 		pulp.Spec.Content.Replicas = 1
 		pulp.Spec.Worker.Replicas = 1
-		isNginxIngress := strings.ToLower(pulp.Spec.IngressType) == "ingress" && !controllers.IsNginxIngressSupported(r, pulp.Spec.IngressClassName)
+		isNginxIngress := strings.ToLower(pulp.Spec.IngressType) == "ingress" && !controllers.IsNginxIngressSupported(pulp)
 		if strings.ToLower(pulp.Spec.IngressType) != "route" && !isNginxIngress {
 			pulp.Spec.Web.Replicas = 1
 		}

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("pulp-operator version: 1.0.5-alpha.9")
+	setupLog.Info("pulp-operator version: 1.0.6-alpha.9")
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")


### PR DESCRIPTION
After a discussion, the team decided that would be better to remove the ingress class checks and also automatically collecting the default ingress domain because they would need cluster roles.
fixes #885
fixes #917
fixes #918
fixes #923

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
