### PR TITLE
Use nodeport instead of port-forward in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
             "
 
             echo "$(cat /etc/docker/daemon.json | jq -s '.[0] + {
-            "insecure-registries" : ["ingress.local"]
+            "insecure-registries" : ["ingress.local","nodeport.local:30000"]
             }')" | sudo tee /etc/docker/daemon.json
             sudo service docker restart || true
           fi
@@ -172,7 +172,7 @@ jobs:
             Updating registries configuration
             "
             echo "[registries.insecure]
-            registries = ['ingress.local']
+            registries = ['ingress.local','nodeport.local:30000']
             " | sudo tee -a /etc/containers/registries.conf
           fi
         shell: bash
@@ -251,7 +251,7 @@ jobs:
             "
 
             echo "$(cat /etc/docker/daemon.json | jq -s '.[0] + {
-            "insecure-registries" : ["ingress.local"]
+            "insecure-registries" : ["ingress.local","nodeport.local:30000"]
             }')" | sudo tee /etc/docker/daemon.json
             sudo service docker restart || true
           fi
@@ -262,7 +262,7 @@ jobs:
             Updating registries configuration
             "
             echo "[registries.insecure]
-            registries = ['ingress.local']
+            registries = ['ingress.local','nodeport.local:30000']
             " | sudo tee -a /etc/containers/registries.conf
           fi
         shell: bash
@@ -356,7 +356,7 @@ jobs:
             "
 
             echo "$(cat /etc/docker/daemon.json | jq -s '.[0] + {
-            "insecure-registries" : ["ingress.local"]
+            "insecure-registries" : ["ingress.local","nodeport.local:30000"]
             }')" | sudo tee /etc/docker/daemon.json
             sudo service docker restart || true
           fi
@@ -367,7 +367,7 @@ jobs:
             Updating registries configuration
             "
             echo "[registries.insecure]
-            registries = ['ingress.local']
+            registries = ['ingress.local','nodeport.local:30000']
             " | sudo tee -a /etc/containers/registries.conf
           fi
         shell: bash
@@ -593,7 +593,7 @@ jobs:
             "
 
             echo "$(cat /etc/docker/daemon.json | jq -s '.[0] + {
-            "insecure-registries" : ["ingress.local"]
+            "insecure-registries" : ["ingress.local","nodeport.local:30000"]
             }')" | sudo tee /etc/docker/daemon.json
             sudo service docker restart || true
           fi
@@ -604,7 +604,7 @@ jobs:
             Updating registries configuration
             "
             echo "[registries.insecure]
-            registries = ['ingress.local']
+            registries = ['ingress.local','nodeport.local:30000']
             " | sudo tee -a /etc/containers/registries.conf
           fi
         shell: bash
@@ -719,7 +719,7 @@ jobs:
             "
 
             echo "$(cat /etc/docker/daemon.json | jq -s '.[0] + {
-            "insecure-registries" : ["ingress.local"]
+            "insecure-registries" : ["ingress.local","nodeport.local:30000"]
             }')" | sudo tee /etc/docker/daemon.json
             sudo service docker restart || true
           fi
@@ -730,7 +730,7 @@ jobs:
             Updating registries configuration
             "
             echo "[registries.insecure]
-            registries = ['ingress.local']
+            registries = ['ingress.local','nodeport.local:30000']
             " | sudo tee -a /etc/containers/registries.conf
           fi
         shell: bash


### PR DESCRIPTION
The `port-forward` command does not have a retry in case of pod failure. Because of that, sometimes the CI was failing like: _"an error occurred forwarding 24817 -> 24817: error forwarding port 24817 to pod <pod id>, uid : Error response from daemon: No such container"_ 
this commit updates the test script replacing the `port-forwarding` with the service `nodeport` which is also helpful to validate the `nodeport` configuration
[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
