### PR TITLE
Centralize resource names in settings package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,7 +689,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [containerized, components, galaxy]
-    if: github.event_name != 'pull_request'
+    if: |
+      github.event_name != 'pull_request' &&
+      github.repository_owner == 'pulp'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/scripts/show_logs.sh
+++ b/.github/workflows/scripts/show_logs.sh
@@ -75,11 +75,11 @@ kubectl logs --timestamps -l app.kubernetes.io/component=worker --tail=10000
 echo ::endgroup::
 
 echo ::group::PULP_WEB_PODS
-kubectl describe pods -l app.kubernetes.io/component=webserver
+kubectl describe pods -l app.kubernetes.io/component=web
 echo ::endgroup::
 
 echo ::group::PULP_WEB_LOGS
-kubectl logs -l app.kubernetes.io/component=webserver --tail=10000
+kubectl logs -l app.kubernetes.io/component=web --tail=10000
 echo ::endgroup::
 
 echo ::group::POSTGRES

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,4 +8,5 @@
     ".ci/scripts/prepare-object-storage.sh",
     "containers/compose/certs/database_fields.symmetric.key",
     ".github/workflows/ci.yml",
+    "controllers/settings/secrets.go",
   ]

--- a/controllers/ingress.go
+++ b/controllers/ingress.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"github.com/pulp/pulp-operator/controllers/settings"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -46,7 +47,7 @@ func IngressDefaults(resources any, plugins []IngressPlugin) (*netv1.Ingress, er
 		PathType: &pathType,
 		Backend: netv1.IngressBackend{
 			Service: &netv1.IngressServiceBackend{
-				Name: pulp.Name + "-web-svc",
+				Name: settings.PulpWebService(pulp.Name),
 				Port: netv1.ServiceBackendPort{
 					Number: 24880,
 				},

--- a/controllers/ocp/route.go
+++ b/controllers/ocp/route.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/pulp/pulp-operator/controllers"
+	"github.com/pulp/pulp-operator/controllers/settings"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	corev1 "k8s.io/api/core/v1"
@@ -119,25 +120,25 @@ func PulpRouteController(resources controllers.FunctionResources, restClient res
 			Name:        pulp.Name + "-content",
 			Path:        controllers.GetPulpSetting(pulp, "content_path_prefix"),
 			TargetPort:  "content-24816",
-			ServiceName: pulp.Name + "-content-svc",
+			ServiceName: settings.ContentService(pulp.Name),
 		},
 		{
 			Name:        pulp.Name + "-api-v3",
 			Path:        controllers.GetPulpSetting(pulp, "api_root") + "api/v3/",
 			TargetPort:  "api-24817",
-			ServiceName: pulp.Name + "-api-svc",
+			ServiceName: settings.ApiService(pulp.Name),
 		},
 		{
 			Name:        pulp.Name + "-auth",
 			Path:        "/auth/login/",
 			TargetPort:  "api-24817",
-			ServiceName: pulp.Name + "-api-svc",
+			ServiceName: settings.ApiService(pulp.Name),
 		},
 		{
 			Name:        pulp.Name,
 			Path:        "/",
 			TargetPort:  "api-24817",
-			ServiceName: pulp.Name + "-api-svc",
+			ServiceName: settings.ApiService(pulp.Name),
 		},
 	}
 	routeHost := GetRouteHost(pulp)

--- a/controllers/repo_manager/controller_test.go
+++ b/controllers/repo_manager/controller_test.go
@@ -34,6 +34,7 @@ const (
 	ApiName       = PulpName + "-api"
 	ContentName   = PulpName + "-content"
 	WorkerName    = PulpName + "-worker"
+	DBVolumeName  = PulpName + "-postgres"
 
 	timeout  = time.Minute
 	interval = time.Second
@@ -194,7 +195,7 @@ var _ = Describe("Pulp controller", Ordered, func() {
 
 	volumeMountsSts := []corev1.VolumeMount{
 		{
-			Name:      "postgres",
+			Name:      DBVolumeName,
 			MountPath: "/var/lib/postgresql/data",
 			SubPath:   "data",
 		},
@@ -509,7 +510,7 @@ var _ = Describe("Pulp controller", Ordered, func() {
 
 	volumeClaimTemplate := []corev1.PersistentVolumeClaim{{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "postgres",
+			Name: DBVolumeName,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -991,7 +992,7 @@ exec pulpcore-worker`,
 			By("Checking if sts template is configured to use emptyDir volume")
 			var found bool
 			for _, volume := range createdSts.Spec.Template.Spec.Volumes {
-				if volume.Name == "postgres" && reflect.DeepEqual(volume.VolumeSource.EmptyDir, &corev1.EmptyDirVolumeSource{}) {
+				if volume.Name == DBVolumeName && reflect.DeepEqual(volume.VolumeSource.EmptyDir, &corev1.EmptyDirVolumeSource{}) {
 					found = true
 					break
 				}

--- a/controllers/repo_manager/ingress.go
+++ b/controllers/repo_manager/ingress.go
@@ -26,6 +26,7 @@ import (
 	repomanagerpulpprojectorgv1beta2 "github.com/pulp/pulp-operator/apis/repo-manager.pulpproject.org/v1beta2"
 	"github.com/pulp/pulp-operator/controllers"
 	pulp_ocp "github.com/pulp/pulp-operator/controllers/ocp"
+	"github.com/pulp/pulp-operator/controllers/settings"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	corev1 "k8s.io/api/core/v1"
@@ -92,25 +93,25 @@ func (r *RepoManagerReconciler) pulpIngressController(ctx context.Context, pulp 
 			Name:        pulp.Name + "-content",
 			Path:        controllers.GetPulpSetting(pulp, "content_path_prefix"),
 			TargetPort:  "content-24816",
-			ServiceName: pulp.Name + "-content-svc",
+			ServiceName: settings.ContentService(pulp.Name),
 		},
 		{
 			Name:        pulp.Name + "-api-v3",
 			Path:        controllers.GetPulpSetting(pulp, "api_root") + "api/v3/",
 			TargetPort:  "api-24817",
-			ServiceName: pulp.Name + "-api-svc",
+			ServiceName: settings.ApiService(pulp.Name),
 		},
 		{
 			Name:        pulp.Name + "-auth",
 			Path:        "/auth/login/",
 			TargetPort:  "api-24817",
-			ServiceName: pulp.Name + "-api-svc",
+			ServiceName: settings.ApiService(pulp.Name),
 		},
 		{
 			Name:        pulp.Name,
 			Path:        "/",
 			TargetPort:  "api-24817",
-			ServiceName: pulp.Name + "-api-svc",
+			ServiceName: settings.ApiService(pulp.Name),
 		},
 	}
 	pulpPlugins = append(defaultPlugins, pulpPlugins...)

--- a/controllers/repo_manager/pdb.go
+++ b/controllers/repo_manager/pdb.go
@@ -19,10 +19,12 @@ package repo_manager
 import (
 	"context"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	repomanagerpulpprojectorgv1beta2 "github.com/pulp/pulp-operator/apis/repo-manager.pulpproject.org/v1beta2"
+	"github.com/pulp/pulp-operator/controllers/settings"
 	policy "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8s_error "k8s.io/apimachinery/pkg/api/errors"
@@ -34,17 +36,18 @@ import (
 // pdbController creates and reconciles {api,content,worker,web} pdbs
 func (r *RepoManagerReconciler) pdbController(ctx context.Context, pulp *repomanagerpulpprojectorgv1beta2.Pulp, log logr.Logger) (ctrl.Result, error) {
 
-	pdbList := map[string]*policy.PodDisruptionBudgetSpec{
-		"api":       pulp.Spec.Api.PDB,
-		"content":   pulp.Spec.Content.PDB,
-		"worker":    pulp.Spec.Worker.PDB,
-		"webserver": pulp.Spec.Web.PDB,
+	pdbList := map[settings.PulpcoreType]*policy.PodDisruptionBudgetSpec{
+		settings.API:     pulp.Spec.Api.PDB,
+		settings.CONTENT: pulp.Spec.Content.PDB,
+		settings.WORKER:  pulp.Spec.Worker.PDB,
+		settings.WEB:     pulp.Spec.Web.PDB,
 	}
 
 	for component, pdb := range pdbList {
 
+		pdbName := component.PDBName(pulp.Name)
 		pdbFound := &policy.PodDisruptionBudget{}
-		err := r.Get(ctx, types.NamespacedName{Name: component + "-pdb", Namespace: pulp.Namespace}, pdbFound)
+		err := r.Get(ctx, types.NamespacedName{Name: pdbName, Namespace: pulp.Namespace}, pdbFound)
 
 		// check if PDB is defined
 		// we need to check if pdb != nil (no .Spec.<component>.PDB field defined)
@@ -58,12 +61,13 @@ func (r *RepoManagerReconciler) pdbController(ctx context.Context, pulp *repoman
 			// any config passed through pulp CR with the following
 			pdb.Selector = &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app.kubernetes.io/component": component,
+					"app.kubernetes.io/component": strings.ToLower(string(component)),
+					"pulp_cr":                     pulp.Name,
 				},
 			}
 			expectedPDB := &policy.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      component + "-pdb",
+					Name:      pdbName,
 					Namespace: pulp.Namespace,
 				},
 				Spec: *pdb,
@@ -72,22 +76,22 @@ func (r *RepoManagerReconciler) pdbController(ctx context.Context, pulp *repoman
 
 			// Create PDB if not found
 			if err != nil && k8s_error.IsNotFound(err) {
-				log.Info("Creating a new " + component + " PDB ...")
+				log.Info("Creating a new " + pdbName + " PDB ...")
 				err = r.Create(ctx, expectedPDB)
 				if err != nil {
-					log.Error(err, "Failed to create new "+component+" PDB")
+					log.Error(err, "Failed to create new "+pdbName+" PDB")
 					return ctrl.Result{}, err
 				}
 				// PDB created successfully - return and requeue
 				return ctrl.Result{Requeue: true}, nil
 			} else if err != nil {
-				log.Error(err, "Failed to get "+component+" PDB")
+				log.Error(err, "Failed to get "+pdbName+" PDB")
 				return ctrl.Result{}, err
 			}
 
 			// Reconcile PDB
 			if !equality.Semantic.DeepDerivative(expectedPDB.Spec, pdbFound.Spec) {
-				log.Info("The " + component + "PDB has been modified! Reconciling ...")
+				log.Info("The " + pdbName + " PDB has been modified! Reconciling ...")
 
 				// I'm not sure why the error:
 				// "metadata.resourceVersion: Invalid value: 0x0: must be specified for an update"
@@ -96,7 +100,7 @@ func (r *RepoManagerReconciler) pdbController(ctx context.Context, pulp *repoman
 				expectedPDB.SetResourceVersion(pdbFound.GetResourceVersion())
 				err = r.Update(ctx, expectedPDB)
 				if err != nil {
-					log.Error(err, "Error trying to update the "+component+" PDB object ... ")
+					log.Error(err, "Error trying to update the "+pdbName+" PDB object ... ")
 					return ctrl.Result{}, err
 				}
 				return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
@@ -109,7 +113,7 @@ func (r *RepoManagerReconciler) pdbController(ctx context.Context, pulp *repoman
 			if err != nil && k8s_error.IsNotFound(err) {
 				continue
 			} else if err != nil {
-				log.Error(err, "Failed to get "+component+" PDB")
+				log.Error(err, "Failed to get "+pdbName+" PDB")
 				return ctrl.Result{}, err
 			}
 

--- a/controllers/repo_manager/secret.go
+++ b/controllers/repo_manager/secret.go
@@ -24,6 +24,7 @@ import (
 
 	repomanagerpulpprojectorgv1beta2 "github.com/pulp/pulp-operator/apis/repo-manager.pulpproject.org/v1beta2"
 	"github.com/pulp/pulp-operator/controllers"
+	"github.com/pulp/pulp-operator/controllers/settings"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	corev1 "k8s.io/api/core/v1"
@@ -78,7 +79,7 @@ func pulpServerSecret(resources controllers.FunctionResources) client.Object {
 
 	sec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pulp.Name + "-server",
+			Name:      settings.PulpServerSecret(pulp.Name),
 			Namespace: pulp.Namespace,
 		},
 		StringData: map[string]string{
@@ -96,7 +97,7 @@ func pulpDBFieldsEncryptionSecret(resources controllers.FunctionResources) clien
 	pulp := resources.Pulp
 	sec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pulp.Name + "-db-fields-encryption",
+			Name:      pulp.Spec.DBFieldsEncryptionSecret,
 			Namespace: pulp.Namespace,
 		},
 		StringData: map[string]string{

--- a/controllers/settings/configmap.go
+++ b/controllers/settings/configmap.go
@@ -1,0 +1,21 @@
+// This file contains resource names and constants that are used to provision
+// the Kubernetes objects. We are centralizing them here to make it easier to
+// maintain and, in case we decide to support multiple CRs running in the same
+// namespace, to avoid name colision or code repetition.
+// Since go const does not allow to pass variables and there is no immutable vars
+// we are encapsulating the constants in each function to return a value based
+// on Pulp CR name.
+
+package settings
+
+const (
+	caConfigMapName = "user-ca-bundle"
+)
+
+func EmptyCAConfigMapName(pulpName string) string {
+	return pulpName + "-" + caConfigMapName
+}
+
+func PulpWebConfigMapName(pulpName string) string {
+	return pulpName + "-configmap"
+}

--- a/controllers/settings/deployments.go
+++ b/controllers/settings/deployments.go
@@ -1,0 +1,25 @@
+// This file contains resource names and constants that are used to provision
+// the Kubernetes objects. We are centralizing them here to make it easier to
+// maintain and, in case we decide to support multiple CRs running in the same
+// namespace, to avoid name colision or code repetition.
+// Since go const does not allow to pass variables and there is no immutable vars
+// we are encapsulating the constants in each function to return a value based
+// on Pulp CR name.
+
+package settings
+
+import "strings"
+
+type PulpcoreType string
+
+const (
+	API     PulpcoreType = "Api"
+	CONTENT PulpcoreType = "Content"
+	WORKER  PulpcoreType = "Worker"
+	WEB     PulpcoreType = "Web"
+	CACHE   PulpcoreType = "Redis"
+)
+
+func (t PulpcoreType) DeploymentName(pulpName string) string {
+	return pulpName + "-" + strings.ToLower(string(t))
+}

--- a/controllers/settings/jobs.go
+++ b/controllers/settings/jobs.go
@@ -1,0 +1,25 @@
+// This file contains resource names and constants that are used to provision
+// the Kubernetes objects. We are centralizing them here to make it easier to
+// maintain and, in case we decide to support multiple CRs running in the same
+// namespace, to avoid name colision or code repetition.
+// Since go const does not allow to pass variables and there is no immutable vars
+// we are encapsulating the constants in each function to return a value based
+// on Pulp CR name.
+
+package settings
+
+const (
+	migrationJob       = "pulpcore-migration-"
+	resetAdminPwdJob   = "reset-admin-password-"
+	updateChecksumsJob = "update-content-checksums-"
+)
+
+func MigrationJob(pulpName string) string {
+	return pulpName + "-" + migrationJob
+}
+func ResetAdminPwdJob(pulpName string) string {
+	return pulpName + "-" + resetAdminPwdJob
+}
+func UpdateChecksumsJob(pulpName string) string {
+	return pulpName + "-" + updateChecksumsJob
+}

--- a/controllers/settings/pdbs.go
+++ b/controllers/settings/pdbs.go
@@ -1,0 +1,15 @@
+// This file contains resource names and constants that are used to provision
+// the Kubernetes objects. We are centralizing them here to make it easier to
+// maintain and, in case we decide to support multiple CRs running in the same
+// namespace, to avoid name colision or code repetition.
+// Since go const does not allow to pass variables and there is no immutable vars
+// we are encapsulating the constants in each function to return a value based
+// on Pulp CR name.
+
+package settings
+
+import "strings"
+
+func (t PulpcoreType) PDBName(pulpName string) string {
+	return pulpName + "-" + strings.ToLower(string(t))
+}

--- a/controllers/settings/pvc.go
+++ b/controllers/settings/pvc.go
@@ -1,0 +1,25 @@
+// This file contains resource names and constants that are used to provision
+// the Kubernetes objects. We are centralizing them here to make it easier to
+// maintain and, in case we decide to support multiple CRs running in the same
+// namespace, to avoid name colision or code repetition.
+// Since go const does not allow to pass variables and there is no immutable vars
+// we are encapsulating the constants in each function to return a value based
+// on Pulp CR name.
+
+package settings
+
+const (
+	pulpFileStorage = "file-storage"
+	DBVolumeName    = "postgres"
+	cacheVolumeName = "redis-data"
+)
+
+func DefaultPulpFileStorage(pulpName string) string {
+	return pulpName + "-" + pulpFileStorage
+}
+func DefaultDBPVC(pulpName string) string {
+	return pulpName + "-postgres"
+}
+func DefaultCachePVC(pulpName string) string {
+	return pulpName + "-" + cacheVolumeName
+}

--- a/controllers/settings/secrets.go
+++ b/controllers/settings/secrets.go
@@ -1,0 +1,41 @@
+// This file contains resource names and constants that are used to provision
+// the Kubernetes objects. We are centralizing them here to make it easier to
+// maintain and, in case we decide to support multiple CRs running in the same
+// namespace, to avoid name colision or code repetition.
+// Since go const does not allow to pass variables and there is no immutable vars
+// we are encapsulating the constants in each function to return a value based
+// on Pulp CR name.
+
+package settings
+
+const (
+	adminPassword            = "admin-password"
+	djangoSecretKey          = "secret-key"
+	containerTokenSecret     = "container-auth"
+	pulpServerSecret         = "server"
+	dBFieldsEncryptionSecret = "db-fields-encryption"
+	rhOperatorPullSecretName = "redhat-operators-pull-secret"
+	postgresConfiguration    = "postgres-configuration"
+)
+
+func DefaultAdminPassword(pulpName string) string {
+	return pulpName + "-" + adminPassword
+}
+func DefaultDjangoSecretKey(pulpName string) string {
+	return pulpName + "-" + djangoSecretKey
+}
+func DefaultContainerTokenSecret(pulpName string) string {
+	return pulpName + "-" + containerTokenSecret
+}
+func PulpServerSecret(pulpName string) string {
+	return pulpName + "-" + pulpServerSecret
+}
+func DefaultDBFieldsEncryptionSecret(pulpName string) string {
+	return pulpName + "-" + dBFieldsEncryptionSecret
+}
+func RedHatOperatorPullSecret(pulpName string) string {
+	return pulpName + "-" + rhOperatorPullSecretName
+}
+func DefaultDBSecret(pulpName string) string {
+	return pulpName + "-" + postgresConfiguration
+}

--- a/controllers/settings/service_account.go
+++ b/controllers/settings/service_account.go
@@ -1,0 +1,13 @@
+// This file contains resource names and constants that are used to provision
+// the Kubernetes objects. We are centralizing them here to make it easier to
+// maintain and, in case we decide to support multiple CRs running in the same
+// namespace, to avoid name colision or code repetition.
+// Since go const does not allow to pass variables and there is no immutable vars
+// we are encapsulating the constants in each function to return a value based
+// on Pulp CR name.
+
+package settings
+
+func PulpServiceAccount(pulpName string) string {
+	return pulpName
+}

--- a/controllers/settings/services.go
+++ b/controllers/settings/services.go
@@ -1,0 +1,28 @@
+// This file contains resource names and constants that are used to provision
+// the Kubernetes objects. We are centralizing them here to make it easier to
+// maintain and, in case we decide to support multiple CRs running in the same
+// namespace, to avoid name colision or code repetition.
+// Since go const does not allow to pass variables and there is no immutable vars
+// we are encapsulating the constants in each function to return a value based
+// on Pulp CR name.
+
+package settings
+
+func ApiService(pulpName string) string {
+	return pulpName + "-api-svc"
+}
+func ContentService(pulpName string) string {
+	return pulpName + "-content-svc"
+}
+func WorkerService(pulpName string) string {
+	return pulpName + "-worker-svc"
+}
+func PulpWebService(pulpName string) string {
+	return pulpName + "-web-svc"
+}
+func DBService(pulpName string) string {
+	return pulpName + "-database-svc"
+}
+func CacheService(pulpName string) string {
+	return pulpName + "-redis-svc"
+}

--- a/controllers/settings/statefulsets.go
+++ b/controllers/settings/statefulsets.go
@@ -1,0 +1,13 @@
+// This file contains resource names and constants that are used to provision
+// the Kubernetes objects. We are centralizing them here to make it easier to
+// maintain and, in case we decide to support multiple CRs running in the same
+// namespace, to avoid name colision or code repetition.
+// Since go const does not allow to pass variables and there is no immutable vars
+// we are encapsulating the constants in each function to return a value based
+// on Pulp CR name.
+
+package settings
+
+func DefaultDBStatefulSet(pulpName string) string {
+	return pulpName + "-database"
+}

--- a/controllers/settings/telemetry.go
+++ b/controllers/settings/telemetry.go
@@ -1,0 +1,23 @@
+// This file contains resource names and constants that are used to provision
+// the Kubernetes objects. We are centralizing them here to make it easier to
+// maintain and, in case we decide to support multiple CRs running in the same
+// namespace, to avoid name colision or code repetition.
+// Since go const does not allow to pass variables and there is no immutable vars
+// we are encapsulating the constants in each function to return a value based
+// on Pulp CR name.
+
+package settings
+
+const (
+	otelConfigName    = "otel-collector-config"
+	otelServiceName   = "otel-collector-svc"
+	OtelConfigFile    = "otel-collector-config.yaml"
+	OtelContainerPort = 8889
+)
+
+func OtelConfigMapName(pulpName string) string {
+	return pulpName + "-" + otelConfigName
+}
+func OtelServiceName(pulpName string) string {
+	return pulpName + "-" + otelServiceName
+}

--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("pulp-operator version: 1.0.2-beta.2")
+	setupLog.Info("pulp-operator version: 1.0.3-beta.2")
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")


### PR DESCRIPTION
:warning: **THIS IS A BREAKING CHANGE!** :warning:

**TL;DR**
For some specific scenarios, after upgrading the operator, some errors may appear.
**scenario1:**
```
database:
  postgres_storage_class: <storage class name>
```

**scenario2:**
Any installation with pulp-web.

---

This PR centralizes the k8s resource names definition in a unique place. It will be helpful in case we decide to allow multiple instances of Pulp running in the same namespace.

### Postgres
Since we are trying to avoid name conflicts, we had to change the name of the volume used by postgres sts, but this is an immutable field and when the operator tries to modify it it will get into an infinite reconcile error loop. To workaround this situation:
* make sure to have a backup of all pulp components (pvc, secrets, pulp cr, etc), especially database
* make sure there is no pending task:
```
2023-09-15T15:08:23Z	INFO	repo_manager/controller.go:235  Operator tasks synced
```
* put the operator into an unmanaged state:
```
PULP_CR_NAME=<NAME OF PULP CR>
kubectl patch pulp $PULP_CR_NAME --type merge -p '{"spec": {"unmanaged": true}}'
```
* collect the current pvc in use:
```
kubectl get pvc -l pulp_cr=${PULP_CR_NAME},app.kubernetes.io/component=database -oname 
```
* update pulp cr to use this pvc:
```
kubectl patch pulp $PULP_CR_NAME --type json -p '[{"op": "remove", "path": "/spec/database/postgres_storage_class"}, {"op": "add", "path": "/spec/database/pvc","value": "postgres-'${PULP_CR_NAME}'-database-0"}]'
```
* double-check the patch:
```
kubectl get pulp $PULP_CR_NAME -oyaml
  database:
    pvc: postgres-test-2-database-0
```
* delete the current sts: 
```
kubectl delete sts ${PULP_CR_NAME}-database
```
* put the operator into a managed state again:
```
kubectl patch pulp $PULP_CR_NAME --type merge -p '{"spec": {"unmanaged": false}}'
```

### pulp-web
Another breaking change is in case the installation has a pulp-web deployment. This PR changes a label/labelselector from pulp-web deployment so, after upgrading the operator, it can get into an infinite loop trying to update the deployment and getting an error because the field (labelselector) is immutable. To workaround this error just delete the pulp-web deployment and a new one will be provisioned with the new label.
```
kubectl delete deployment -l app.kubernetes.io/component=webserver,app.kubernetes.io/part-of=pulp
```


ref: #1025
[noissue]
