### PR TITLE
Fix bkp issue in pulp-secret-key and special chars

### DIFF
--- a/CHANGES/1098.bugfix
+++ b/CHANGES/1098.bugfix
@@ -1,0 +1,1 @@
+Fixed a backup issue in pulp-secret-key with special chars.

--- a/controllers/backup/secret.go
+++ b/controllers/backup/secret.go
@@ -55,7 +55,7 @@ func (r *RepoManagerBackupReconciler) backupSecret(ctx context.Context, pulpBack
 	containerTokenSecret := getContainerTokenSecret(ctx, pulpBackup, pulp)
 
 	// PULP-SECRET-KEY
-	if err := r.createBackupFile(ctx, secretType{"pulp_secret_key", pulpBackup, backupDir, "pulp_secret_key.yaml", pulpSecretKey, pod}); err != nil {
+	if err := r.createSecretBackupFile(ctx, secretType{"pulp_secret_key", pulpBackup, backupDir, "pulp_secret_key.yaml", pulpSecretKey, pod}); err != nil {
 		return err
 	}
 	log.Info("PulpSecretKey secret backup finished")
@@ -120,14 +120,14 @@ func (r *RepoManagerBackupReconciler) backupSecret(ctx context.Context, pulpBack
 
 	// LDAP CONFIG SECRET
 	if len(pulp.Spec.LDAP.Config) > 0 {
-		if err := r.backupLDAPSecret(ctx, secretType{"ldap_secret", pulpBackup, backupDir, "ldap_secret.yaml", pulp.Spec.LDAP.Config, pod}); err != nil {
+		if err := r.createSecretBackupFile(ctx, secretType{"ldap_secret", pulpBackup, backupDir, "ldap_secret.yaml", pulp.Spec.LDAP.Config, pod}); err != nil {
 			return err
 		}
 		log.Info("LDAP secret backup finished")
 	}
 	// LDAP CA SECRET
 	if len(pulp.Spec.LDAP.CA) > 0 {
-		if err := r.backupLDAPSecret(ctx, secretType{"ldap_ca_secret", pulpBackup, backupDir, "ldap_ca_secret.yaml", pulp.Spec.LDAP.CA, pod}); err != nil {
+		if err := r.createSecretBackupFile(ctx, secretType{"ldap_ca_secret", pulpBackup, backupDir, "ldap_ca_secret.yaml", pulp.Spec.LDAP.CA, pod}); err != nil {
 			return err
 		}
 		log.Info("LDAP CA secret backup finished")
@@ -169,10 +169,10 @@ func (r *RepoManagerBackupReconciler) createBackupFile(ctx context.Context, secr
 	return nil
 }
 
-// backupLDAPSecret stores a copy of the LDAP Secrets in YAML format.
+// createSecretBackupFile stores a copy of the Secrets in YAML format.
 // Since we don't need to keep compatibility with ansible version anymore, this
 // method does not need to follow an specific struct and should work with any Secret.
-func (r *RepoManagerBackupReconciler) backupLDAPSecret(ctx context.Context, secretType secretType) error {
+func (r *RepoManagerBackupReconciler) createSecretBackupFile(ctx context.Context, secretType secretType) error {
 	log := r.RawLogger
 	secret := &corev1.Secret{}
 	err := r.Get(ctx, types.NamespacedName{Name: secretType.secretName, Namespace: secretType.pulpBackup.Namespace}, secret)

--- a/controllers/restore/secret.go
+++ b/controllers/restore/secret.go
@@ -102,7 +102,7 @@ func (r *RepoManagerRestoreReconciler) restoreSecret(ctx context.Context, pulpRe
 	r.RawLogger.V(1).Info("Restoring from golang backup version")
 
 	// restore pulp-secret-key secret
-	if _, err := r.secret(ctx, resourceTypePulpSecretKey, "pulp_secret_key", backupDir, "pulp_secret_key.yaml", pod, pulpRestore); err != nil {
+	if _, err := r.restoreSecretFromYaml(ctx, resourceTypePulpSecretKey, "secret_key", backupDir, "pulp_secret_key.yaml", pod, pulpRestore); err != nil {
 		return err
 	}
 
@@ -146,10 +146,10 @@ func (r *RepoManagerRestoreReconciler) restoreSecret(ctx context.Context, pulpRe
 	}
 
 	// restore ldap secret(s)
-	if found, err := r.restoreLDAPSecrets(ctx, resourceTypeLDAP, "ldap_secret", backupDir, "ldap_secret.yaml", pod, pulpRestore); found && err != nil {
+	if found, err := r.restoreSecretFromYaml(ctx, resourceTypeLDAP, "ldap_secret", backupDir, "ldap_secret.yaml", pod, pulpRestore); found && err != nil {
 		return err
 	}
-	if found, err := r.restoreLDAPSecrets(ctx, resourceTypeLDAP, "ldap_ca_secret", backupDir, "ldap_ca_secret.yaml", pod, pulpRestore); found && err != nil {
+	if found, err := r.restoreSecretFromYaml(ctx, resourceTypeLDAP, "ldap_ca_secret", backupDir, "ldap_ca_secret.yaml", pod, pulpRestore); found && err != nil {
 		return err
 	}
 
@@ -290,10 +290,10 @@ func setStatusField(fieldName, fieldValue string, pulpRestore *repomanagerpulppr
 	return nil
 }
 
-// restoreLDAPSecrets restores the Secret from a YAML file.
+// restoreSecretFromYaml restores the Secret from a YAML file.
 // Since we don't need to keep compatibility with ansible version anymore, this
 // method does not need to follow an specific struct and should work with any Secret.
-func (r *RepoManagerRestoreReconciler) restoreLDAPSecrets(ctx context.Context, resourceType, secretNameKey, backupDir, backupFile string, pod *corev1.Pod, pulpRestore *repomanagerpulpprojectorgv1beta2.PulpRestore) (bool, error) {
+func (r *RepoManagerRestoreReconciler) restoreSecretFromYaml(ctx context.Context, resourceType, secretNameKey, backupDir, backupFile string, pod *corev1.Pod, pulpRestore *repomanagerpulpprojectorgv1beta2.PulpRestore) (bool, error) {
 
 	log := r.RawLogger
 	ldapSecretFile := backupDir + "/" + backupFile

--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("pulp-operator version: 1.0.3-beta.2")
+	setupLog.Info("pulp-operator version: 1.0.4-beta.2")
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")


### PR DESCRIPTION
Instead of using the `createBackupFile` method (that stores the Secret data in plain text) using the `createSecretBackupFile` method (which stores the entire Secret object in YAML format and without decoding it) fixed the issue with the special chars.

fixes: #1098

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
