### PR TITLE
Update object storage restart pods documentation

### DIFF
--- a/docs/configuring/storage.md
+++ b/docs/configuring/storage.md
@@ -136,10 +136,7 @@ spec:
 ...
 ```
 
-and restart the API pods to get the new configuration.
-```
-$ kubectl -n $PULP_NAMESPACE delete pod -l app.kubernetes.io/component=api
-```
+After that, Pulp Operator will automatically update the `settings.py` config file and redeploy pulpcore pods to get the new configuration.
 
 ### Configure AWS S3
 
@@ -180,10 +177,7 @@ spec:
 ...
 ```
 
-and restart the API pods to get the new configuration.
-```
-$ kubectl -n $PULP_NAMESPACE delete pod -l app.kubernetes.io/component=api
-```
+After that, Pulp Operator will automatically update the `settings.py` config file and redeploy pulpcore pods to get the new configuration.
 
 
 ## Configuring Pulp Operator in non-production clusters


### PR DESCRIPTION
With commit #972 users do not need to manually redeploy the pods to get the new configuration.
[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
