### PR TITLE
Centralize labels definition in settings package

### DIFF
--- a/.ci/scripts/backup_and_restore.sh
+++ b/.ci/scripts/backup_and_restore.sh
@@ -36,8 +36,7 @@ kubectl delete -f config/samples/$CUSTOM_RESOURCE
 # deleting resources that have no operator owerReference to better validate that
 # restore controller will recreate them instead of "reusing" the older ones
 kubectl delete secrets --all
-kubectl delete pvc -l "app.kubernetes.io/component=storage"
-kubectl delete pvc -l "owner=pulp-dev"
+kubectl delete pvc -l pulp_cr=galaxy-example
 kubectl wait --for=delete --timeout=300s -f config/samples/$CUSTOM_RESOURCE
 
 kubectl apply -f config/samples/$RESTORE_RESOURCE

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -152,22 +152,11 @@ func (d *CommonDeployment) setReplicas(pulp repomanagerpulpprojectorgv1beta2.Pul
 
 // setLabels defines the pod and deployment labels
 func (d *CommonDeployment) setLabels(pulp repomanagerpulpprojectorgv1beta2.Pulp, pulpcoreType settings.PulpcoreType) {
-	pulpType := strings.ToLower(string(pulpcoreType))
-	d.podLabels = map[string]string{
-		"app.kubernetes.io/name":       pulp.Spec.DeploymentType + "-" + pulpType,
-		"app.kubernetes.io/instance":   pulp.Spec.DeploymentType + "-" + pulpType + "-" + pulp.Name,
-		"app.kubernetes.io/component":  pulpType,
-		"app.kubernetes.io/part-of":    pulp.Spec.DeploymentType,
-		"app.kubernetes.io/managed-by": pulp.Spec.DeploymentType + "-operator",
-		"app":                          "pulp-" + pulpType,
-		"pulp_cr":                      pulp.Name,
-	}
-
+	d.podLabels = settings.PulpcoreLabels(pulp, strings.ToLower(string(pulpcoreType)))
 	d.deploymentLabels = make(map[string]string)
 	for k, v := range d.podLabels {
 		d.deploymentLabels[k] = v
 	}
-	d.deploymentLabels["owner"] = "pulp-dev"
 }
 
 // setAffinity defines the affinity rules

--- a/controllers/ingress.go
+++ b/controllers/ingress.go
@@ -83,15 +83,7 @@ func IngressDefaults(resources any, plugins []IngressPlugin) (*netv1.Ingress, er
 			},
 		}
 	}
-	labels := map[string]string{
-		"app.kubernetes.io/name":       "ingress",
-		"app.kubernetes.io/instance":   "ingress-" + pulp.Name,
-		"app.kubernetes.io/component":  "ingress",
-		"app.kubernetes.io/part-of":    pulp.Spec.DeploymentType,
-		"app.kubernetes.io/managed-by": pulp.Spec.DeploymentType + "-operator",
-		"pulp_cr":                      pulp.Name,
-		"owner":                        "pulp-dev",
-	}
+	labels := settings.CommonLabels(*pulp)
 
 	ingress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/ocp/route.go
+++ b/controllers/ocp/route.go
@@ -72,12 +72,7 @@ func PulpRouteController(resources controllers.FunctionResources, restClient res
 	conditionType := cases.Title(language.English, cases.Compact).String(pulp.Spec.DeploymentType) + "-Route-Ready"
 
 	podList := &corev1.PodList{}
-	labels := map[string]string{
-		"app.kubernetes.io/part-of":    pulp.Spec.DeploymentType,
-		"app.kubernetes.io/managed-by": pulp.Spec.DeploymentType + "-operator",
-		"app.kubernetes.io/instance":   pulp.Spec.DeploymentType + "-worker-" + pulp.Name,
-		"app.kubernetes.io/component":  "worker",
-	}
+	labels := settings.PulpcoreLabels(*pulp, "worker")
 	listOpts := []client.ListOption{
 		client.InNamespace(pulp.Namespace),
 		client.MatchingLabels(labels),
@@ -227,9 +222,7 @@ func PulpRouteObject(ctx context.Context, resources controllers.FunctionResource
 		annotation["haproxy.router.openshift.io/rewrite-target"] = p.Rewrite
 	}
 
-	labels := map[string]string{}
-	labels["pulp_cr"] = resources.Pulp.Name
-	labels["owner"] = "pulp-dev"
+	labels := settings.CommonLabels(*resources.Pulp)
 	for k, v := range resources.Pulp.Spec.RouteLabels {
 		labels[k] = v
 	}

--- a/controllers/repo_manager/controller.go
+++ b/controllers/repo_manager/controller.go
@@ -89,7 +89,7 @@ func (r *RepoManagerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	isOpenShift, _ := controllers.IsOpenShift()
 	if isOpenShift {
 		log.V(1).Info("Running on OpenShift cluster")
-		if err := pulp_ocp.CreateRHOperatorPullSecret(r.Client, ctx, req.NamespacedName.Namespace, pulp.Name); err != nil {
+		if err := pulp_ocp.CreateRHOperatorPullSecret(r.Client, ctx, *pulp); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/controllers/repo_manager/controller_test.go
+++ b/controllers/repo_manager/controller_test.go
@@ -46,13 +46,12 @@ var _ = Describe("Pulp controller", Ordered, func() {
 	format.MaxLength = 0
 
 	labelsSts := map[string]string{
-		"app.kubernetes.io/name":       "postgres",
-		"app.kubernetes.io/instance":   "postgres-" + PulpName,
+		"app.kubernetes.io/name":       OperatorType + "-database",
+		"app.kubernetes.io/instance":   OperatorType + "-database-" + PulpName,
 		"app.kubernetes.io/component":  "database",
 		"app.kubernetes.io/part-of":    OperatorType,
-		"app.kubernetes.io/managed-by": PulpName,
-		"owner":                        "pulp-dev",
-		"app":                          "postgresql",
+		"app.kubernetes.io/managed-by": OperatorType + "-operator",
+		"app":                          "pulp-database",
 		"pulp_cr":                      PulpName,
 	}
 
@@ -529,12 +528,13 @@ var _ = Describe("Pulp controller", Ordered, func() {
 			Name:      StsName,
 			Namespace: PulpNamespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/name":       "postgres",
-				"app.kubernetes.io/instance":   "postgres-" + PulpName,
+				"app.kubernetes.io/name":       OperatorType + "-database",
+				"app.kubernetes.io/instance":   OperatorType + "-database-" + PulpName,
 				"app.kubernetes.io/component":  "database",
 				"app.kubernetes.io/part-of":    OperatorType,
-				"app.kubernetes.io/managed-by": PulpName,
-				"owner":                        "pulp-dev",
+				"app.kubernetes.io/managed-by": OperatorType + "-operator",
+				"app":                          "pulp-database",
+				"pulp_cr":                      PulpName,
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{

--- a/controllers/repo_manager/ingress.go
+++ b/controllers/repo_manager/ingress.go
@@ -45,12 +45,7 @@ func (r *RepoManagerReconciler) pulpIngressController(ctx context.Context, pulp 
 	conditionType := cases.Title(language.English, cases.Compact).String(pulp.Spec.DeploymentType) + "-Ingress-Ready"
 
 	podList := &corev1.PodList{}
-	labels := map[string]string{
-		"app.kubernetes.io/part-of":    pulp.Spec.DeploymentType,
-		"app.kubernetes.io/managed-by": pulp.Spec.DeploymentType + "-operator",
-		"app.kubernetes.io/instance":   pulp.Spec.DeploymentType + "-content-" + pulp.Name,
-		"app.kubernetes.io/component":  "content",
-	}
+	labels := settings.PulpcoreLabels(*pulp, "content")
 	listOpts := []client.ListOption{
 		client.InNamespace(pulp.Namespace),
 		client.MatchingLabels(labels),

--- a/controllers/repo_manager/job.go
+++ b/controllers/repo_manager/job.go
@@ -66,6 +66,7 @@ func (r *RepoManagerReconciler) updateAdminPasswordJob(ctx context.Context, pulp
 			BackoffLimit:            &backOffLimit,
 			TTLSecondsAfterFinished: &jobTTL,
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      "Never",
 					Containers:         containers,
@@ -224,6 +225,7 @@ func (r *RepoManagerReconciler) migrationJob(ctx context.Context, pulp *repomana
 			BackoffLimit:            &backOffLimit,
 			TTLSecondsAfterFinished: &jobTTL,
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      "Never",
 					Containers:         containers,
@@ -270,10 +272,7 @@ func migrationContainer(pulp *repomanagerpulpprojectorgv1beta2.Pulp) corev1.Cont
 
 // jobLabels defines the common labels used in Jobs
 func jobLabels(pulp repomanagerpulpprojectorgv1beta2.Pulp) map[string]string {
-	return map[string]string{
-		"app.kubernetes.io/managed-by": pulp.Spec.DeploymentType + "-operator",
-		"pulp_cr":                      pulp.Name,
-	}
+	return settings.CommonLabels(pulp)
 }
 
 // updateContentChecksumsJob creates a k8s Job to update the list of allowed content checksums
@@ -303,6 +302,7 @@ func (r *RepoManagerReconciler) updateContentChecksumsJob(ctx context.Context, p
 			BackoffLimit:            &backOffLimit,
 			TTLSecondsAfterFinished: &jobTTL,
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      "Never",
 					Containers:         containers,

--- a/controllers/repo_manager/pdb.go
+++ b/controllers/repo_manager/pdb.go
@@ -59,16 +59,15 @@ func (r *RepoManagerReconciler) pdbController(ctx context.Context, pulp *repoman
 			// add label selector to PDBSpec
 			// even though it is possible to pass a selector through PodDisruptionBudgetSpec we will overwrite
 			// any config passed through pulp CR with the following
+			labels := settings.PulpcoreLabels(*pulp, strings.ToLower(string(component)))
 			pdb.Selector = &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app.kubernetes.io/component": strings.ToLower(string(component)),
-					"pulp_cr":                     pulp.Name,
-				},
+				MatchLabels: labels,
 			}
 			expectedPDB := &policy.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      pdbName,
 					Namespace: pulp.Namespace,
+					Labels:    labels,
 				},
 				Spec: *pdb,
 			}

--- a/controllers/repo_manager/secret.go
+++ b/controllers/repo_manager/secret.go
@@ -81,6 +81,7 @@ func pulpServerSecret(resources controllers.FunctionResources) client.Object {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      settings.PulpServerSecret(pulp.Name),
 			Namespace: pulp.Namespace,
+			Labels:    settings.CommonLabels(*pulp),
 		},
 		StringData: map[string]string{
 			"settings.py": pulp_settings,
@@ -99,6 +100,7 @@ func pulpDBFieldsEncryptionSecret(resources controllers.FunctionResources) clien
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pulp.Spec.DBFieldsEncryptionSecret,
 			Namespace: pulp.Namespace,
+			Labels:    settings.CommonLabels(*pulp),
 		},
 		StringData: map[string]string{
 			"database_fields.symmetric.key": createFernetKey(),
@@ -115,6 +117,7 @@ func pulpAdminPasswordSecret(resources controllers.FunctionResources) client.Obj
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pulp.Spec.AdminPasswordSecret,
 			Namespace: pulp.Namespace,
+			Labels:    settings.CommonLabels(*pulp),
 		},
 		StringData: map[string]string{
 			"password": createPwd(32),
@@ -132,6 +135,7 @@ func pulpDjangoKeySecret(resources controllers.FunctionResources) client.Object 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pulp.Spec.PulpSecretKey,
 			Namespace: pulp.Namespace,
+			Labels:    settings.CommonLabels(*pulp),
 		},
 		StringData: map[string]string{
 			"secret_key": djangoKey(),
@@ -149,6 +153,7 @@ func pulpContainerAuth(resources controllers.FunctionResources) client.Object {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pulp.Spec.ContainerTokenSecret,
 			Namespace: pulp.Namespace,
+			Labels:    settings.CommonLabels(*pulp),
 		},
 		StringData: map[string]string{
 			"container_auth_private_key.pem": privKey,

--- a/controllers/repo_manager/utils.go
+++ b/controllers/repo_manager/utils.go
@@ -206,10 +206,7 @@ func (r *RepoManagerReconciler) updateIngressType(ctx context.Context, pulp *rep
 	if strings.ToLower(pulp.Status.IngressType) == "route" && !isRoute(pulp) {
 
 		route := &routev1.Route{}
-		routesLabelSelector := map[string]string{
-			"pulp_cr": pulp.Name,
-			"owner":   "pulp-dev",
-		}
+		routesLabelSelector := settings.CommonLabels(*pulp)
 		listOpts := []client.DeleteAllOfOption{
 			client.InNamespace(pulp.Namespace),
 			client.MatchingLabels(routesLabelSelector),
@@ -231,10 +228,7 @@ func (r *RepoManagerReconciler) updateIngressType(ctx context.Context, pulp *rep
 	if strings.ToLower(pulp.Status.IngressType) == "ingress" && strings.ToLower(pulp.Spec.IngressType) != "ingress" {
 
 		ingress := &netv1.Ingress{}
-		ingresssLabelSelector := map[string]string{
-			"pulp_cr": pulp.Name,
-			"owner":   "pulp-dev",
-		}
+		ingresssLabelSelector := settings.CommonLabels(*pulp)
 		listOpts := []client.DeleteAllOfOption{
 			client.InNamespace(pulp.Namespace),
 			client.MatchingLabels(ingresssLabelSelector),

--- a/controllers/repo_manager/web.go
+++ b/controllers/repo_manager/web.go
@@ -189,14 +189,7 @@ func (r *RepoManagerReconciler) deploymentForPulpWeb(m *repomanagerpulpprojector
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      settings.WEB.DeploymentName(m.Name),
 			Namespace: m.Namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/name":       "nginx",
-				"app.kubernetes.io/instance":   "nginx-" + m.Name,
-				"app.kubernetes.io/component":  "web",
-				"app.kubernetes.io/part-of":    m.Spec.DeploymentType,
-				"app.kubernetes.io/managed-by": m.Spec.DeploymentType + "-operator",
-				"owner":                        "pulp-dev",
-			},
+			Labels:    ls,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -270,14 +263,7 @@ func (r *RepoManagerReconciler) deploymentForPulpWeb(m *repomanagerpulpprojector
 // labelsForPulpWeb returns the labels for selecting the resources
 // belonging to the given pulp CR name.
 func labelsForPulpWeb(m *repomanagerpulpprojectorgv1beta2.Pulp) map[string]string {
-	return map[string]string{
-		"app.kubernetes.io/name":       "nginx",
-		"app.kubernetes.io/instance":   "nginx-" + m.Name,
-		"app.kubernetes.io/component":  "web",
-		"app.kubernetes.io/part-of":    m.Spec.DeploymentType,
-		"app.kubernetes.io/managed-by": m.Spec.DeploymentType + "-operator",
-		"pulp_cr":                      m.Name,
-	}
+	return settings.PulpcoreLabels(*m, "web")
 }
 
 // serviceForPulpWeb returns a service object for pulp-web
@@ -522,6 +508,7 @@ func (r *RepoManagerReconciler) pulpWebConfigMap(m *repomanagerpulpprojectorgv1b
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      settings.PulpWebConfigMapName(m.Name),
 			Namespace: m.Namespace,
+			Labels:    settings.CommonLabels(*m),
 		},
 		Data: data,
 	}

--- a/controllers/settings/labels.go
+++ b/controllers/settings/labels.go
@@ -1,0 +1,27 @@
+package settings
+
+import (
+	repomanagerpulpprojectorgv1beta2 "github.com/pulp/pulp-operator/apis/repo-manager.pulpproject.org/v1beta2"
+)
+
+func PulpcoreLabels(pulp repomanagerpulpprojectorgv1beta2.Pulp, pulpType string) map[string]string {
+	deploymentType := pulp.Spec.DeploymentType
+	return map[string]string{
+		"app.kubernetes.io/name":       deploymentType + "-" + pulpType,
+		"app.kubernetes.io/instance":   deploymentType + "-" + pulpType + "-" + pulp.Name,
+		"app.kubernetes.io/component":  pulpType,
+		"app.kubernetes.io/part-of":    deploymentType,
+		"app.kubernetes.io/managed-by": deploymentType + "-operator",
+		"app":                          "pulp-" + pulpType,
+		"pulp_cr":                      pulp.Name,
+	}
+}
+
+func CommonLabels(pulp repomanagerpulpprojectorgv1beta2.Pulp) map[string]string {
+	deploymentType := pulp.Spec.DeploymentType
+	return map[string]string{
+		"app.kubernetes.io/part-of":    deploymentType,
+		"app.kubernetes.io/managed-by": deploymentType + "-operator",
+		"pulp_cr":                      pulp.Name,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("pulp-operator version: 1.0.5-beta.2")
+	setupLog.Info("pulp-operator version: 1.0.6-beta.2")
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")


### PR DESCRIPTION
:warning: THIS IS A BREAKING CHANGE! :warning:

This PR centralizes the definition of the labels used by Pulp resources. The operator can get into
an errored state trying to update some resources but failing to do so because `Selector` is an
immutable field.
To workaround this issue:
* make sure to have a backup of all pulp components (pvc, secrets, pulp cr, etc), especially database
* make sure there is no pending task:
```
2023-09-15T15:08:23Z    INFO    repo_manager/controller.go:235  Operator tasks synced
```
* reprovision the sts and deployments
```
oc delete sts pulp-database
oc delete deployment pulp-web pulp-redis
```
