### PR TITLE
Adds two-deployments job to GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,50 @@ jobs:
         run: |
           /tmp/operator-sdk run bundle-upgrade --use-http localhost:5001/pulp-operator-bundle:new
         shell: bash
+  two-deployments:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Go environment
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Install kind
+        run: |
+          .ci/scripts/kind_with_registry.sh
+        shell: bash
+      - name: Install OLM
+        run: |
+          make sdkbin OPERATOR_SDK_VERSION=v1.29.0 LOCALBIN=/tmp
+          /tmp/operator-sdk olm install
+        shell: bash
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install Pulp CRD
+        run: |
+          make install
+        shell: bash
+      - name: Build bundle image
+        run: |
+          make bundle-build bundle-push BUNDLE_IMG=localhost:5001/pulp-operator-bundle:testing
+        shell: bash
+      - name: Install the operator
+        run: |
+          /tmp/operator-sdk run bundle --skip-tls localhost:5001/pulp-operator-bundle:testing
+        shell: bash
+      - name: Deploy example-pulp and test-pulp
+        run: |
+          kubectl apply -f config/samples/simple-with-reduced-migration-cpu.yaml
+          kubectl apply -f config/samples/simple-test.yaml
+      - name: Check and wait for example-pulp deployment
+        run: kubectl wait --for condition=Pulp-Operator-Finished-Execution pulp/example-pulp --timeout=900s
+        shell: bash
+      - name: Check and wait for test-pulp deployment
+        run: kubectl wait --for condition=Pulp-Operator-Finished-Execution pulp/test-pulp --timeout=900s
   envtest:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGES/1100.misc
+++ b/CHANGES/1100.misc
@@ -1,0 +1,1 @@
+Added an additional GHA job that tests deploying two Pulps in one namespace.

--- a/config/samples/simple-test.yaml
+++ b/config/samples/simple-test.yaml
@@ -1,0 +1,52 @@
+apiVersion: repo-manager.pulpproject.org/v1beta2
+kind: Pulp
+metadata:
+  name: test-pulp
+spec:
+  telemetry:
+    enabled: true
+  deployment_type: pulp
+  image_version: nightly
+  image_web_version: nightly
+  api:
+    replicas: 1
+  content:
+    replicas: 1
+  worker:
+    replicas: 1
+  web:
+    replicas: 1
+  migration_job:
+    container:
+      resource_requirements:
+        requests:
+          cpu: "250m"
+        limits:
+          cpu: "250m"
+
+  database:
+    postgres_storage_class: standard
+
+  file_storage_access_mode: "ReadWriteOnce"
+  file_storage_size: "2Gi"
+  file_storage_storage_class: standard
+
+  # Redis configs
+  cache:
+    enabled: true
+    redis_storage_class: standard
+
+  ingress_type: nodeport
+  nodeport_port: 30001
+
+  pulp_settings:
+    api_root: "/pulp/"
+    allowed_export_paths:
+      - /tmp
+    allowed_import_paths:
+      - /tmp
+    telemetry: false
+    token_server: http://nodeport.local:30001/token/
+    content_origin: http://nodeport.local:30001
+    ansible_api_hostname: http://nodeport.local:30001
+

--- a/config/samples/simple-with-reduced-migration-cpu.yaml
+++ b/config/samples/simple-with-reduced-migration-cpu.yaml
@@ -1,0 +1,51 @@
+apiVersion: repo-manager.pulpproject.org/v1beta2
+kind: Pulp
+metadata:
+  name: example-pulp
+spec:
+  telemetry:
+    enabled: true
+  deployment_type: pulp
+  image_version: nightly
+  image_web_version: nightly
+  api:
+    replicas: 1
+  content:
+    replicas: 1
+  worker:
+    replicas: 1
+  web:
+    replicas: 1
+  migration_job:
+    container:
+      resource_requirements:
+        requests:
+          cpu: "250m"
+        limits:
+          cpu: "250m"
+
+  database:
+    postgres_storage_class: standard
+
+  file_storage_access_mode: "ReadWriteOnce"
+  file_storage_size: "2Gi"
+  file_storage_storage_class: standard
+
+  # Redis configs
+  cache:
+    enabled: true
+    redis_storage_class: standard
+
+  ingress_type: nodeport
+  nodeport_port: 30000
+
+  pulp_settings:
+    api_root: "/pulp/"
+    allowed_export_paths:
+      - /tmp
+    allowed_import_paths:
+      - /tmp
+    telemetry: false
+    token_server: http://nodeport.local:30000/token/
+    content_origin: http://nodeport.local:30000
+    ansible_api_hostname: http://nodeport.local:30000


### PR DESCRIPTION
The two-deployments job tests that 2 deployments of Pulp in one namespace are able to start succesfully. No tests are run after the operator reports that the deployments are up.

closes: #1100

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
