### PR TITLE
Update GALAXY_FEATURE_FLAGS in controllers/repo_manager/secret.go

### DIFF
--- a/controllers/repo_manager/secret.go
+++ b/controllers/repo_manager/secret.go
@@ -173,9 +173,7 @@ GALAXY_CONTAINER_SIGNING_SERVICE = "container-default"
 ANSIBLE_API_HOSTNAME = "` + rootUrl + `"
 ANSIBLE_CERTS_DIR = "/etc/pulp/keys/"
 CONTENT_ORIGIN = "` + rootUrl + `"
-GALAXY_FEATURE_FLAGS = {
-  'execution_environments': 'True',
-}
+GALAXY_FEATURE_FLAGS = {'execution_environments': 'True', 'ai_deny_index': 'True'}
 PRIVATE_KEY_PATH = "/etc/pulp/keys/container_auth_private_key.pem"
 PUBLIC_KEY_PATH = "/etc/pulp/keys/container_auth_public_key.pem"
 STATIC_ROOT = "/var/lib/operator/static/"


### PR DESCRIPTION
This should resolve the immediate problems with #1132

The missing 'ai_deny_index' sub key is added, and the the key = value is all one line. This PR does not solve how pulp_settings replaces existing keys in settings.py that have multi-line values.

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
