### PR TITLE
Add "otel" label back to telemetry Service

### DIFF
--- a/controllers/telemetry.go
+++ b/controllers/telemetry.go
@@ -186,12 +186,14 @@ func ServiceOtel(resources FunctionResources) client.Object {
 	targetPort := intstr.IntOrString{IntVal: settings.OtelContainerPort}
 	serviceType := corev1.ServiceType("ClusterIP")
 	name := resources.Name
+	labels := settings.CommonLabels(*resources.Pulp)
+	labels["otel"] = ""
 
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      settings.OtelServiceName(name),
 			Namespace: resources.Namespace,
-			Labels:    settings.CommonLabels(*resources.Pulp),
+			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
 			InternalTrafficPolicy: &serviceInternalTrafficPolicyCluster,


### PR DESCRIPTION
Fix a regression added in
https://github.com/pulp/pulp-operator/pull/1109/files#diff-83f59b06f166f6814a7451c68f2786eca1db98bbdc8bbe2a3fd3198e6a46b2f0L194-L196 [noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
