### PR TITLE
Add a .status.managed_cache_enabled field

### DIFF
--- a/apis/repo-manager.pulpproject.org/v1beta2/pulp_types.go
+++ b/apis/repo-manager.pulpproject.org/v1beta2/pulp_types.go
@@ -948,6 +948,8 @@ type PulpStatus struct {
 	AllowedContentChecksums string `json:"allowed_content_checksums,omitempty"`
 	// Controller status to keep tracking of deployment updates
 	LastDeploymentUpdate string `json:"last_deployment_update,omitempty"`
+	// Cache deployed by pulp-operator enabled
+	ManagedCacheEnabled bool `json:"managed_cache_enabled,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -168,7 +168,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     containerImage: quay.io/pulp/pulp-operator:devel
-    createdAt: "2023-12-05T11:18:07Z"
+    createdAt: "2023-12-20T11:42:34Z"
     description: Pulp is a platform for managing repositories of software packages
       and making them available to a large number of consumers.
     operators.operatorframework.io/builder: operator-sdk-v1.29.0

--- a/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
+++ b/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
@@ -10015,6 +10015,9 @@ spec:
               last_deployment_update:
                 description: Controller status to keep tracking of deployment updates
                 type: string
+              managed_cache_enabled:
+                description: Cache deployed by pulp-operator enabled
+                type: boolean
               object_storage_azure_secret:
                 description: The secret for Azure compliant object storage configuration.
                 type: string

--- a/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
+++ b/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
@@ -10016,6 +10016,9 @@ spec:
               last_deployment_update:
                 description: Controller status to keep tracking of deployment updates
                 type: string
+              managed_cache_enabled:
+                description: Cache deployed by pulp-operator enabled
+                type: boolean
               object_storage_azure_secret:
                 description: The secret for Azure compliant object storage configuration.
                 type: string

--- a/controllers/repo_manager/README.md
+++ b/controllers/repo_manager/README.md
@@ -263,6 +263,7 @@ PulpStatus defines the observed state of Pulp
 | pulp_secret_key | Name of the Secret to provide Django cryptographic signing. | string | false |
 | allowed_content_checksums | List of allowed checksum algorithms used to verify repository's integrity. | string | false |
 | last_deployment_update | Controller status to keep tracking of deployment updates | string | false |
+| managed_cache_enabled | Cache deployed by pulp-operator enabled | bool | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/controllers/repo_manager/controller.go
+++ b/controllers/repo_manager/controller.go
@@ -290,8 +290,10 @@ func cacheTasks(ctx context.Context, pulp *repomanagerpulpprojectorgv1beta2.Pulp
 			return &pulpController, err
 		}
 
-		// remove redis resources if cache is not enabled
-	} else {
+	}
+
+	// remove redis resources if cache is not enabled anymore
+	if managedCacheDisabled(pulp) {
 		pulpController, err := r.deprovisionCache(ctx, pulp, log)
 		if needsRequeue(err, pulpController) {
 			return &pulpController, err


### PR DESCRIPTION
This field will be helpful to avoid running the cache deprovisioning task in every reconciliation loop.
[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
