### PR TITLE
Update samples with stable image tag

### DIFF
--- a/config/samples/simple-external-cache.yaml
+++ b/config/samples/simple-external-cache.yaml
@@ -4,8 +4,8 @@ metadata:
   name: pulp
 spec:
   deployment_type: pulp
-  image_version: nightly
-  image_web_version: nightly
+  image_version: stable
+  image_web_version: stable
   api:
     replicas: 1
   content:

--- a/config/samples/simple-sso.yaml
+++ b/config/samples/simple-sso.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   deployment_type: pulp
   cache_enabled: true
-  image_version: nightly
-  image_web_version: nightly
+  image_version: stable
+  image_web_version: stable
 #  affinity:
 #    nodeAffinity:
 #      requiredDuringSchedulingIgnoredDuringExecution:

--- a/config/samples/simple-test.yaml
+++ b/config/samples/simple-test.yaml
@@ -6,8 +6,8 @@ spec:
   telemetry:
     enabled: true
   deployment_type: pulp
-  image_version: nightly
-  image_web_version: nightly
+  image_version: stable
+  image_web_version: stable
   api:
     replicas: 1
   content:

--- a/config/samples/simple-with-reduced-migration-cpu.yaml
+++ b/config/samples/simple-with-reduced-migration-cpu.yaml
@@ -6,8 +6,8 @@ spec:
   telemetry:
     enabled: true
   deployment_type: pulp
-  image_version: nightly
-  image_web_version: nightly
+  image_version: stable
+  image_web_version: stable
   api:
     replicas: 1
   content:

--- a/config/samples/simple.ingress.yaml
+++ b/config/samples/simple.ingress.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-pulp
 spec:
   deployment_type: pulp
-  image_version: nightly
-  image_web_version: nightly
+  image_version: stable
+  image_web_version: stable
 #  affinity:
 #    nodeAffinity:
 #      requiredDuringSchedulingIgnoredDuringExecution:

--- a/config/samples/simple.yaml
+++ b/config/samples/simple.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-pulp
 spec:
   deployment_type: pulp
-  image_version: nightly
-  image_web_version: nightly
+  image_version: stable
+  image_web_version: stable
 #  affinity:
 #    nodeAffinity:
 #      requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Our pipeline was failing for tests with nightly image, but was running fine for tests using stable. API logs:
```
2024-04-12T18:00:24.335914694Z pulp [e336954360eb4dd7907c1885ece3aca6]: django.request:ERROR: Internal Server Error: /v2/test/fixture/blobs/uploads/
2024-04-12T18:00:24.335953256Z Traceback (most recent call last):
2024-04-12T18:00:24.335959187Z   File "/usr/local/lib/python3.9/site-packages/django/core/handlers/exception.py", line 55, in inner
2024-04-12T18:00:24.335965158Z     response = get_response(request)
...
2024-04-12T18:00:24.336152879Z     raise LookupError("Could not determine ViewSet base name for model {}".format(model_class))
2024-04-12T18:00:24.336158811Z LookupError: Could not determine ViewSet base name for model <class 'pulp_container.app.models.Upload'>
```

Checking the versions of pulp_container plugin in each installation:
```
stable
  "container": "2.19.2",
nightly
  "container": "2.20.0.dev",
```

Updating the samples to use the same image to keep consistency and avoid such "misdirection" where the pipeline failure was not really because of the operator.

[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
