### PR TITLE
Modified the way to provide custom Pulp settings

### DIFF
--- a/CHANGES/1271.bugfix
+++ b/CHANGES/1271.bugfix
@@ -1,0 +1,3 @@
+Modified the way to provide custom Pulp settings. Instead of using a field of
+type `RawExtension`, the new `custom_pulp_settings` field allow to pass the name
+of a `ConfigMap` with the configurations.

--- a/apis/repo-manager.pulpproject.org/v1beta2/pulp_types.go
+++ b/apis/repo-manager.pulpproject.org/v1beta2/pulp_types.go
@@ -281,11 +281,19 @@ type PulpSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	Cache Cache `json:"cache,omitempty"`
 
-	// Definition of /etc/pulp/settings.py config file.
+	// [DEPRECATED] Definition of /etc/pulp/settings.py config file.
+	// This field is deprecated and will be removed in the future, use the
+	// custom_pulp_settings field instead.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	PulpSettings runtime.RawExtension `json:"pulp_settings,omitempty"`
+
+	// Name of the ConfigMap to define Pulp configurations not available
+	// through this CR.
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
+	CustomPulpSettings string `json:"custom_pulp_settings,omitempty"`
 
 	// The image name (repo name) for the pulp webserver image.
 	// Default: "quay.io/pulp/pulp-web"

--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -168,7 +168,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     containerImage: quay.io/pulp/pulp-operator:devel
-    createdAt: "2024-04-08T17:36:58Z"
+    createdAt: "2024-07-04T17:02:20Z"
     description: Pulp is a platform for managing repositories of software packages
       and making them available to a large number of consumers.
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
@@ -604,6 +604,12 @@ spec:
         path: content.topology_spread_constraints
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Name of the ConfigMap to define Pulp configurations not available
+          through this CR.
+        displayName: Custom Pulp Settings
+        path: custom_pulp_settings
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Database defines desired state of postgres resources
         displayName: Database
         path: database
@@ -936,7 +942,9 @@ spec:
         path: pulp_secret_key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Definition of /etc/pulp/settings.py config file.
+      - description: '[DEPRECATED] Definition of /etc/pulp/settings.py config file.
+          This field is deprecated and will be removed in the future, use the custom_pulp_settings
+          field instead.'
         displayName: Pulp Settings
         path: pulp_settings
         x-descriptors:

--- a/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
+++ b/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
@@ -5895,6 +5895,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              custom_pulp_settings:
+                description: Name of the ConfigMap to define Pulp configurations not
+                  available through this CR.
+                type: string
               database:
                 description: Database defines desired state of postgres resources
                 properties:
@@ -7735,7 +7739,9 @@ spec:
                   Default: "pulp-secret-key"'
                 type: string
               pulp_settings:
-                description: Definition of /etc/pulp/settings.py config file.
+                description: '[DEPRECATED] Definition of /etc/pulp/settings.py config
+                  file. This field is deprecated and will be removed in the future,
+                  use the custom_pulp_settings field instead.'
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               pvc:

--- a/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
+++ b/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
@@ -5896,6 +5896,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              custom_pulp_settings:
+                description: Name of the ConfigMap to define Pulp configurations not
+                  available through this CR.
+                type: string
               database:
                 description: Database defines desired state of postgres resources
                 properties:
@@ -7736,7 +7740,9 @@ spec:
                   Default: "pulp-secret-key"'
                 type: string
               pulp_settings:
-                description: Definition of /etc/pulp/settings.py config file.
+                description: '[DEPRECATED] Definition of /etc/pulp/settings.py config
+                  file. This field is deprecated and will be removed in the future,
+                  use the custom_pulp_settings field instead.'
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               pvc:

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -600,6 +600,12 @@ spec:
         path: content.topology_spread_constraints
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Name of the ConfigMap to define Pulp configurations not available
+          through this CR.
+        displayName: Custom Pulp Settings
+        path: custom_pulp_settings
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Database defines desired state of postgres resources
         displayName: Database
         path: database
@@ -932,7 +938,9 @@ spec:
         path: pulp_secret_key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Definition of /etc/pulp/settings.py config file.
+      - description: '[DEPRECATED] Definition of /etc/pulp/settings.py config file.
+          This field is deprecated and will be removed in the future, use the custom_pulp_settings
+          field instead.'
         displayName: Pulp Settings
         path: pulp_settings
         x-descriptors:

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -728,7 +728,7 @@ func (d *CommonDeployment) setInitContainerResourceRequirements(pulp repomanager
 }
 
 // setReadinessProbe defines the container readinessprobe
-func (d *CommonDeployment) setReadinessProbe(pulp repomanagerpulpprojectorgv1beta2.Pulp, pulpcoreType settings.PulpcoreType) {
+func (d *CommonDeployment) setReadinessProbe(resources any, pulp repomanagerpulpprojectorgv1beta2.Pulp, pulpcoreType settings.PulpcoreType) {
 	readinessProbe := reflect.ValueOf(pulp.Spec).FieldByName(string(pulpcoreType)).FieldByName("ReadinessProbe").Interface().(*corev1.Probe)
 	switch pulpcoreType {
 	case settings.API:
@@ -738,7 +738,7 @@ func (d *CommonDeployment) setReadinessProbe(pulp repomanagerpulpprojectorgv1bet
 					Exec: &corev1.ExecAction{
 						Command: []string{
 							"/usr/bin/readyz.py",
-							GetPulpSetting(&pulp, "api_root") + "api/v3/status/",
+							GetAPIRoot(resources.(FunctionResources).Client, &pulp) + "api/v3/status/",
 						},
 					},
 				},
@@ -756,7 +756,7 @@ func (d *CommonDeployment) setReadinessProbe(pulp repomanagerpulpprojectorgv1bet
 					Exec: &corev1.ExecAction{
 						Command: []string{
 							"/usr/bin/readyz.py",
-							GetPulpSetting(&pulp, "content_path_prefix"),
+							GetContentPathPrefix(resources.(FunctionResources).Client, &pulp),
 						},
 					},
 				},
@@ -790,7 +790,7 @@ func (d *CommonDeployment) setReadinessProbe(pulp repomanagerpulpprojectorgv1bet
 }
 
 // setReadinessProbe defines the container livenessprobe
-func (d *CommonDeployment) setLivenessProbe(pulp repomanagerpulpprojectorgv1beta2.Pulp, pulpcoreType settings.PulpcoreType) {
+func (d *CommonDeployment) setLivenessProbe(resources any, pulp repomanagerpulpprojectorgv1beta2.Pulp, pulpcoreType settings.PulpcoreType) {
 	livenessProbe := reflect.ValueOf(pulp.Spec).FieldByName(string(pulpcoreType)).FieldByName("LivenessProbe").Interface().(*corev1.Probe)
 	switch pulpcoreType {
 	case settings.API:
@@ -799,7 +799,7 @@ func (d *CommonDeployment) setLivenessProbe(pulp repomanagerpulpprojectorgv1beta
 				FailureThreshold: 10,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: GetPulpSetting(&pulp, "api_root") + "api/v3/status/",
+						Path: GetAPIRoot(resources.(FunctionResources).Client, &pulp) + "api/v3/status/",
 						Port: intstr.IntOrString{
 							IntVal: 24817,
 						},
@@ -1126,8 +1126,8 @@ func (d *CommonDeployment) build(resources any, pulpcoreType settings.PulpcoreTy
 	d.setVolumes(resources, pulpcoreType)
 	d.setVolumeMounts(*pulp, pulpcoreType)
 	d.setResourceRequirements(*pulp, pulpcoreType)
-	d.setLivenessProbe(*pulp, pulpcoreType)
-	d.setReadinessProbe(*pulp, pulpcoreType)
+	d.setLivenessProbe(resources, *pulp, pulpcoreType)
+	d.setReadinessProbe(resources, *pulp, pulpcoreType)
 	d.setImage(*pulp)
 	d.setTopologySpreadConstraints(*pulp, pulpcoreType)
 	d.setInitContainerResourceRequirements(*pulp, pulpcoreType)

--- a/controllers/ocp/route.go
+++ b/controllers/ocp/route.go
@@ -113,13 +113,13 @@ func PulpRouteController(resources controllers.FunctionResources, restClient res
 	defaultPlugins := []RoutePlugin{
 		{
 			Name:        pulp.Name + "-content",
-			Path:        controllers.GetPulpSetting(pulp, "content_path_prefix"),
+			Path:        controllers.GetContentPathPrefix(resources.Client, pulp),
 			TargetPort:  "content-24816",
 			ServiceName: settings.ContentService(pulp.Name),
 		},
 		{
 			Name:        pulp.Name + "-api-v3",
-			Path:        controllers.GetPulpSetting(pulp, "api_root") + "api/v3/",
+			Path:        controllers.GetAPIRoot(resources.Client, pulp) + "api/v3/",
 			TargetPort:  "api-24817",
 			ServiceName: settings.ApiService(pulp.Name),
 		},

--- a/controllers/repo_manager/README.md
+++ b/controllers/repo_manager/README.md
@@ -222,7 +222,8 @@ PulpSpec defines the desired state of Pulp
 | worker | Worker defines desired state of pulpcore-worker resources | [Worker](#worker) | false |
 | web | Web defines desired state of pulpcore-web (reverse-proxy) resources | [Web](#web) | false |
 | cache | Cache defines desired state of redis resources | [Cache](#cache) | false |
-| pulp_settings | Definition of /etc/pulp/settings.py config file. | runtime.RawExtension | false |
+| pulp_settings | [DEPRECATED] Definition of /etc/pulp/settings.py config file. This field is deprecated and will be removed in the future, use the custom_pulp_settings field instead. | runtime.RawExtension | false |
+| custom_pulp_settings | Name of the ConfigMap to define Pulp configurations not available through this CR. | string | false |
 | image_web | The image name (repo name) for the pulp webserver image. Default: \"quay.io/pulp/pulp-web\" | string | false |
 | image_web_version | The image version for the pulp webserver image. Default: \"stable\" | string | false |
 | admin_password_secret | Secret where the administrator password can be found. Default: <operator's name> + \"-admin-password\" | string | false |

--- a/controllers/repo_manager/ingress.go
+++ b/controllers/repo_manager/ingress.go
@@ -86,13 +86,13 @@ func (r *RepoManagerReconciler) pulpIngressController(ctx context.Context, pulp 
 	defaultPlugins := []controllers.IngressPlugin{
 		{
 			Name:        pulp.Name + "-content",
-			Path:        controllers.GetPulpSetting(pulp, "content_path_prefix"),
+			Path:        controllers.GetContentPathPrefix(r.Client, pulp),
 			TargetPort:  "content-24816",
 			ServiceName: settings.ContentService(pulp.Name),
 		},
 		{
 			Name:        pulp.Name + "-api-v3",
-			Path:        controllers.GetPulpSetting(pulp, "api_root") + "api/v3/",
+			Path:        controllers.GetAPIRoot(r.Client, pulp) + "api/v3/",
 			TargetPort:  "api-24817",
 			ServiceName: settings.ApiService(pulp.Name),
 		},

--- a/controllers/repo_manager/utils.go
+++ b/controllers/repo_manager/utils.go
@@ -457,14 +457,14 @@ func ignoreCronjobStatus() predicate.Predicate {
 	}
 }
 
-// findPulpDependentSecrets will search for Pulp objects based on Secret names defined in Pulp CR.
-// It is used to "link" these Secrets (not "owned" by Pulp operator) with Pulp object
-func (r *RepoManagerReconciler) findPulpDependentSecrets(ctx context.Context, secret client.Object) []reconcile.Request {
+// findPulpDependentObjects will search for Pulp objects based on Secret/ConfigMap names defined in Pulp CR.
+// It is used to "link" these Secrets/ConfigMaps (not "owned" by Pulp operator) with Pulp object
+func (r *RepoManagerReconciler) findPulpDependentObjects(ctx context.Context, obj client.Object) []reconcile.Request {
 
 	associatedPulp := repomanagerpulpprojectorgv1beta2.PulpList{}
 	opts := &client.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("secrets", secret.GetName()),
-		Namespace:     secret.GetNamespace(),
+		FieldSelector: fields.OneTermEqualSelector("objects", obj.GetName()),
+		Namespace:     obj.GetNamespace(),
 	}
 	if err := r.List(context.TODO(), &associatedPulp, opts); err != nil {
 		return []reconcile.Request{}

--- a/controllers/repo_manager/web.go
+++ b/controllers/repo_manager/web.go
@@ -164,7 +164,7 @@ func (r *RepoManagerReconciler) deploymentForPulpWeb(m *repomanagerpulpprojector
 			FailureThreshold: 2,
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path: controllers.GetPulpSetting(m, "api_root") + "api/v3/status/",
+					Path: controllers.GetAPIRoot(funcResources.Client, m) + "api/v3/status/",
 					Port: intstr.IntOrString{
 						IntVal: 8080,
 					},
@@ -471,7 +471,7 @@ func (r *RepoManagerReconciler) pulpWebConfigMap(m *repomanagerpulpprojectorgv1b
 				proxy_pass http://pulp-content;
 			}
 
-			location ` + controllers.GetPulpSetting(m, "api_root") + `api/v3/ {
+			location ` + controllers.GetAPIRoot(r.Client, m) + `api/v3/ {
 				proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 				proxy_set_header X-Forwarded-Proto $scheme;
 				proxy_set_header Host $http_host;

--- a/main.go
+++ b/main.go
@@ -177,7 +177,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("pulp-operator version: 1.0.1-beta.5")
+	setupLog.Info("pulp-operator version: 1.0.2-beta.5")
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/staging_docs/admin/guides/configurations/database.md
+++ b/staging_docs/admin/guides/configurations/database.md
@@ -15,7 +15,7 @@ If no `database` parameter is defined, Pulp operator will deploy PostgreSQL with
 * **no data will be persisted**, the container will mount an emptyDir (all data will be lost in case of pod restart)
 
 
-A new `Secret` (&lt;deployment-name>-postgres-configuration) will also be created with some information like:
+A new `Secret` (<deployment-name>-postgres-configuration) will also be created with some information like:
 
   * the database name
   * the admin user

--- a/staging_docs/admin/guides/configurations/pulp_settings.md
+++ b/staging_docs/admin/guides/configurations/pulp_settings.md
@@ -31,7 +31,7 @@ based on the definitions of `Pulp CR`.
 There are 2 ways to configure the settings:
 
 * [via specific fields](#pulp-operator-defined-settings)
-* [via `pulp_settings` field](#custom-settings)
+* [via `custom_pulp_settings` field](#custom-settings)
 
 ## Pulp Operator Defined Settings
 
@@ -189,16 +189,28 @@ API_ROOT = "/pulp/"
 ## Custom Settings
 
 !!! WARNING
-    Use `pulp_settings` field with caution. Since Pulp Operator will not manage
-    nor validate these settings, providing invalid values can cause disruption or
+    Use the `custom_pulp_settings` field with caution. Since Pulp Operator will not manage
+    nor validate the contents from the ConfigMap, providing invalid values can cause disruption or
     unexpected behaviors.
 
 Most of Pulp configurations should be done using the settings [presented before](/pulp_operator/configuring/pulp_settings/#pulp-operator-defined-settings),
-but sometimes it is not possible. In this case, Pulp CR has the `pulp_settings`
-field that can be used to define additional configurations. For example, to disable
-[Pulp analytics](https://docs.pulpproject.org/pulpcore/configuration/settings.html#analytics):
+but sometimes it is not possible. In this case, Pulp CR has the `custom_pulp_settings`
+field that can be used to define a `ConfigMap` with the additional Pulp configurations.
+
+For example, to disable
+[Pulp analytics](https://docs.pulpproject.org/pulpcore/configuration/settings.html#analytics), first create a new ConfigMap:
+```bash
+$ kubectl create configmap settings  --from-literal=ANALYTICS=False
+```
+
+update Pulp CR with this new `ConfigMap`:
+
 ```yaml
 spec:
-  pulp_settings:
-    analytics: false
+  custom_pulp_settings: settings
 ```
+
+
+!!! Info
+    The `pulp_settings` field is deprecated!
+    Use the `custom_pulp_settings` field instead.


### PR DESCRIPTION
Instead of providing custom configurations through the `pulp_settings` RawExtension field, this commit adds a new field called `custom_pulp_settings` which receives the name of a ConfigMap (that users should create manually) with the custom configurations.

closes: #1271

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
