### PR TITLE
Change apiVersion to avoid failure while deploying hub

### DIFF
--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -218,7 +218,7 @@
 
 - name: Check PostgreSQL status
   k8s_info:
-    api_version: v1
+    api_version: apps/v1
     kind: StatefulSet
     namespace: '{{ ansible_operator_meta.namespace }}'
     name: '{{ ansible_operator_meta.name }}-postgres-{{ postgres_version }}'

--- a/roles/postgres/tasks/upgrade_postgres.yml
+++ b/roles/postgres/tasks/upgrade_postgres.yml
@@ -218,7 +218,7 @@
 - name: Remove old Postgres StatefulSet
   k8s:
     kind: StatefulSet
-    api_version: v1
+    api_version: apps/v1
     namespace: "{{ ansible_operator_meta.namespace }}"
     name: "{{ ansible_operator_meta.name }}-postgres"
     state: absent

--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -1,6 +1,6 @@
 # Postgres StatefulSet.
 ---
-apiVersion: v1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: '{{ ansible_operator_meta.name }}-postgres-{{ postgres_version }}'

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-api"

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-content"

--- a/roles/pulp-status/tasks/main.yml
+++ b/roles/pulp-status/tasks/main.yml
@@ -103,7 +103,7 @@
 
 - name: Remove resource manager deployment
   kubernetes.core.k8s:
-    api_version: v1
+    api_version: apps/v1
     kind: Deployment
     name: "{{ ansible_operator_meta.name }}-resource-manager"
     namespace: "{{ ansible_operator_meta.namespace }}"

--- a/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
+++ b/roles/pulp-web/templates/pulp-web.deployment.yaml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-web"

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-worker"

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-redis"


### PR DESCRIPTION
Change apiVersion to avoid failure while deploying hub

Resolves:
https://issues.redhat.com/browse/AAP-28261

Mirrors:
https://github.com/ansible/galaxy-operator/pull/129/commits/4b526eb82d94695194fb910dc77db39e567b6bc2