### PR TITLE
Enable IRSA for aws s3 backends

### DIFF
--- a/CHANGES/1327.bugfix
+++ b/CHANGES/1327.bugfix
@@ -1,0 +1,2 @@
+S3 backend attributes `s3-access-key-id` and `s3-secret-access-key` made optional
+to allow authentication via AWS IAM roles for Kubernetes service accounts.


### PR DESCRIPTION
Enable access via IAM Role Service Accounts for S3 backends by making the attributes s3-access-key-id and s3-secret-access-key optional in object_storage_s3_secret

closes #1327

