### PR TITLE
Temporarily pin the pulp-web version in CI samples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
         shell: bash
       - name: Updating registries configuration
         run: |
-          if [ -f "/etc/docker/daemon.json" ]
+          if [ -f "/etc/docker/daemon.json" ] || sudo systemctl is-active --quiet docker
           then
             echo "INFO:
             Updating docker configuration
@@ -294,7 +294,7 @@ jobs:
         shell: bash
       - name: Updating registries configuration
         run: |
-          if [ -f "/etc/docker/daemon.json" ]
+          if [ -f "/etc/docker/daemon.json" ] || sudo systemctl is-active --quiet docker
           then
             echo "INFO:
             Updating docker configuration
@@ -399,7 +399,7 @@ jobs:
         shell: bash
       - name: Updating registries configuration
         run: |
-          if [ -f "/etc/docker/daemon.json" ]
+          if [ -f "/etc/docker/daemon.json" ] || sudo systemctl is-active --quiet docker
           then
             echo "INFO:
             Updating docker configuration
@@ -643,7 +643,7 @@ jobs:
         shell: bash
       - name: Updating registries configuration
         run: |
-          if [ -f "/etc/docker/daemon.json" ]
+          if [ -f "/etc/docker/daemon.json" ] || sudo systemctl is-active --quiet docker
           then
             echo "INFO:
             Updating docker configuration

--- a/.github/workflows/k8s_versions.yml
+++ b/.github/workflows/k8s_versions.yml
@@ -41,7 +41,7 @@ jobs:
         shell: bash
       - name: Updating registries configuration
         run: |
-          if [ -f "/etc/docker/daemon.json" ]
+          if [ -f "/etc/docker/daemon.json" ] || sudo systemctl is-active --quiet docker
           then
             echo "INFO:
             Updating docker configuration
@@ -139,7 +139,7 @@ jobs:
         shell: bash
       - name: Updating registries configuration
         run: |
-          if [ -f "/etc/docker/daemon.json" ]
+          if [ -f "/etc/docker/daemon.json" ] || sudo systemctl is-active --quiet docker
           then
             echo "INFO:
             Updating docker configuration
@@ -239,7 +239,7 @@ jobs:
         shell: bash
       - name: Updating registries configuration
         run: |
-          if [ -f "/etc/docker/daemon.json" ]
+          if [ -f "/etc/docker/daemon.json" ] || sudo systemctl is-active --quiet docker
           then
             echo "INFO:
             Updating docker configuration

--- a/config/samples/k8s_versions_ci.yaml
+++ b/config/samples/k8s_versions_ci.yaml
@@ -4,7 +4,8 @@ metadata:
   name: example-pulp
 spec:
   image_version: stable
-  image_web_version: stable
+  image_web_version: 3.63.4
+  inhibit_version_constraint: true
 
   api:
     replicas: 1

--- a/config/samples/ldap.yaml
+++ b/config/samples/ldap.yaml
@@ -18,7 +18,8 @@ metadata:
 spec:
   image: localhost/pulp-minimal
   image_version: stable
-  image_web_version: stable
+  image_web_version: 3.63.4
+  inhibit_version_constraint: true
   ldap:
     config: pulp-ldap-secret
   api:

--- a/config/samples/simple-external-db.yaml
+++ b/config/samples/simple-external-db.yaml
@@ -21,7 +21,8 @@ spec:
     external_db_secret: external-database
 
   image_version: stable
-  image_web_version: stable
+  image_web_version: 3.63.4
+  inhibit_version_constraint: true
   api:
     replicas: 1
   content:

--- a/config/samples/simple-test.yaml
+++ b/config/samples/simple-test.yaml
@@ -7,7 +7,8 @@ spec:
     enabled: true
   deployment_type: pulp
   image_version: stable
-  image_web_version: stable
+  image_web_version: 3.63.4
+  inhibit_version_constraint: true
   api:
     replicas: 1
   content:

--- a/config/samples/simple-with-reduced-migration-cpu.yaml
+++ b/config/samples/simple-with-reduced-migration-cpu.yaml
@@ -7,7 +7,8 @@ spec:
     enabled: true
   deployment_type: pulp
   image_version: stable
-  image_web_version: stable
+  image_web_version: 3.63.4
+  inhibit_version_constraint: true
   api:
     replicas: 1
   content:

--- a/config/samples/simple.ingress.yaml
+++ b/config/samples/simple.ingress.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   deployment_type: pulp
   image_version: stable
-  image_web_version: stable
+  image_web_version: 3.63.4
+  inhibit_version_constraint: true
 #  affinity:
 #    nodeAffinity:
 #      requiredDuringSchedulingIgnoredDuringExecution:

--- a/config/samples/simple.yaml
+++ b/config/samples/simple.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   deployment_type: pulp
   image_version: stable
-  image_web_version: stable
+  image_web_version: 3.63.4
+  inhibit_version_constraint: true
 #  affinity:
 #    nodeAffinity:
 #      requiredDuringSchedulingIgnoredDuringExecution:

--- a/config/samples/telemetry.yaml
+++ b/config/samples/telemetry.yaml
@@ -6,7 +6,8 @@ spec:
   telemetry:
     enabled: true
   image_version: stable
-  image_web_version: stable
+  image_web_version: 3.63.4
+  inhibit_version_constraint: true
   api:
     replicas: 1
   content:


### PR DESCRIPTION
pulp-oci-image repo has been updated and we are currently missing the amd64 architecture for pulp-web image in Quay. As a workaround, this commit pins to an older image that still supports amd64. [noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
