### PR TITLE
Modify galaxy ocp sample DB StorageClass

### DIFF
--- a/config/samples/pulpproject_v1beta1_pulp_cr.galaxy.ocp.ci.yaml
+++ b/config/samples/pulpproject_v1beta1_pulp_cr.galaxy.ocp.ci.yaml
@@ -55,4 +55,4 @@ spec:
   file_storage_size: "5Gi"
   file_storage_storage_class: azurefile-csi
   database:
-    postgres_storage_class: azurefile-csi
+    postgres_storage_class: managed-csi


### PR DESCRIPTION
This commit modifies the DB StorageClass to workaround an issue in prow pipeline and postgres pods crashing because of a permission error:
```
chmod: changing permissions of '/var/lib/postgresql/data/pgdata': Operation not permitted
```

[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
