### PR TITLE
Add support to RPM signing service

### DIFF
--- a/CHANGES/1401.feature
+++ b/CHANGES/1401.feature
@@ -1,0 +1,1 @@
+Added support to RPM signing service.

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -559,6 +559,10 @@ func signingMetadataVolumes(resources any, storageType []string, volumes []corev
 			item := corev1.KeyToPath{Key: settings.AptSigningScriptName, Path: settings.AptSigningScriptName}
 			secretItems = append(secretItems, item)
 		}
+		if DeployRpmSign(*secret) {
+			item := corev1.KeyToPath{Key: settings.RpmSigningScriptName, Path: settings.RpmSigningScriptName}
+			secretItems = append(secretItems, item)
+		}
 		volumePermissions := int32(0755)
 		signingSecretVolume := []corev1.Volume{
 			{

--- a/controllers/settings/jobs.go
+++ b/controllers/settings/jobs.go
@@ -17,6 +17,7 @@ const (
 	ContainerSigningScriptName  = "container_script.sh"
 	CollectionSigningScriptName = "collection_script.sh"
 	AptSigningScriptName        = "apt_script.sh"
+	RpmSigningScriptName        = "rpm_script.sh"
 )
 
 func MigrationJob(pulpName string) string {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -898,6 +898,12 @@ func DeployAptSign(secret corev1.Secret) bool {
 	return contains
 }
 
+// DeployRpmSign returns true if signingScript secret is defined with an rpm script
+func DeployRpmSign(secret corev1.Secret) bool {
+	_, contains := secret.Data[settings.RpmSigningScriptName]
+	return contains
+}
+
 // SetDefaultSecurityContext defines the container security configuration to be in compliance with PodSecurity "restricted:v1.24"
 func SetDefaultSecurityContext() *corev1.SecurityContext {
 	allowPrivilegeEscalation, runAsNonRoot := false, true


### PR DESCRIPTION
closes: #1401

This PR enables supporting RPM signing service.

The signing script name should be `rpm_script.sh` inside the secret `signing-scripts`. Includes a working example.

As with other signing service types, the signing secret should already be in place.
