### PR TITLE
Fix an issue with wrong route/ingress paths

### DIFF
--- a/controllers/repo_manager/secret.go
+++ b/controllers/repo_manager/secret.go
@@ -560,7 +560,7 @@ func addCustomPulpSettings(resources controllers.FunctionResources, pulpSettings
 
 	settings := ""
 	for _, k := range sortKeys(settingsCM.Data) {
-		settings = settings + fmt.Sprintf("%v = %v\n", k, settingsCM.Data[k])
+		settings = settings + fmt.Sprintf("%v = %v\n", strings.ToUpper(k), settingsCM.Data[k])
 	}
 
 	*pulpSettings = *pulpSettings + settings

--- a/main.go
+++ b/main.go
@@ -201,7 +201,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("pulp-operator version: 1.0.7-beta.5")
+	setupLog.Info("pulp-operator version: 1.0.8-beta.5")
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")


### PR DESCRIPTION
This commit fixes an issue with `ingress.spec.rules.http.paths.path` not being updated after changing `CONTENT_ORIGIN_PATH` or `API_ROOT` in the `custom_pulp_setting` ConfigMap.

[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
