### PR TITLE
Remove the `API_ROOT` from default settings

### DIFF
--- a/CHANGES/1411.bugfix
+++ b/CHANGES/1411.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue with duplicated `API_ROOT` definition when the config is also set in `custom_pulp_settings` ConfigMap.

--- a/controllers/repo_manager/secret.go
+++ b/controllers/repo_manager/secret.go
@@ -260,7 +260,6 @@ PUBLIC_KEY_PATH = "/etc/pulp/keys/container_auth_public_key.pem"
 STATIC_ROOT = "/var/lib/operator/static/"
 TOKEN_AUTH_DISABLED = False
 TOKEN_SIGNATURE_ALGORITHM = "ES256"
-API_ROOT = "/pulp/"
 `
 }
 


### PR DESCRIPTION
We don't need to set a default value for `API_ROOT` in the operator because it is already defined in pulpcore:
https://github.com/pulp/pulpcore/blob/61ac2b622eeaff7f3fde0cbe40d2e9919d43ebbc/pulpcore/app/settings.py#L100

note: this commit will **not** handle a possible issue with duplicate value for the other default configs.

fixes: #1411

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://docs.pulpproject.org/pulpcore/contributing/git.html#commit-message

If not, please add `[noissue]` to your commit message
