### PR TITLE
Fix sso_secret key enumeration

### DIFF
--- a/controllers/repo_manager/sso.go
+++ b/controllers/repo_manager/sso.go
@@ -2,6 +2,8 @@ package repo_manager
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/pulp/pulp-operator/controllers"
@@ -61,7 +63,7 @@ func ssoConfig(resource controllers.FunctionResources, pulpSettings *string) err
 	}
 
 	// Inject SSO settings into pulp_settings
-	for key := range settings {
+	for _, key := range slices.Sorted(maps.Keys(settings)) {
 		*pulpSettings = *pulpSettings + fmt.Sprintf("%v = \"%v\"\n", strings.ToUpper(key), settings[key])
 	}
 


### PR DESCRIPTION
The sso_secret option in the Pulp CR is not enumerated correctly. It uses a standard 'for key := range x' which will always be in a random order in Golang. This causes the operator to continuously think the secret data changed and reconcile the resources in an infinite loop.

This PR addresses this by ensuring they are always enumerated in the same order.

Fixes #1395 
