### PR TITLE
Change the link to download oc (used in prow test)

### DIFF
--- a/.ci/prow/Dockerfile.ci-operator
+++ b/.ci/prow/Dockerfile.ci-operator
@@ -8,7 +8,7 @@ RUN pip3 install -U pip  && \
     pip3 install ansible jmespath molecule more-itertools openshift yamllint pulp-cli
 
 RUN curl -Lo /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64  && \
-    curl -Lo ocp.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz  && \
+    curl -Lo ocp.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux-amd64-rhel8.tar.gz  && \
     tar xvzf ocp.tar.gz -C /usr/local/bin oc --skip-old-files && rm ocp.tar.gz  && \
     chmod ug+x /usr/local/bin/kind /usr/local/bin/oc
 


### PR DESCRIPTION
The tests in prow are failing to run:
```
 ERRO[2025-04-24T16:42:00Z] 
  * could not run steps: step deploy-pulp-on-openshift failed: "deploy-pulp-on-openshift" test steps failed: "deploy-pulp-on-openshift" pod "deploy-pulp-on-openshift-deploy-pulp" failed: could not watch pod: the pod ci-op-lkxb6fk0/deploy-pulp-on-openshift-deploy-pulp failed after 37s (failed containers: test): ContainerFailed one or more containers exited
Container test exited with code 1, reason Error
---
oc: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by oc)
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:84","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.internalRun","level":"error","msg":"Error executing test process","severity":"error","time":"2025-04-24T16:30:01Z"}
error: failed to execute wrapped command: exit status 1
---
```
ref: https://access.redhat.com/solutions/7077895
