### PR TITLE
Modify the SC definition in simple-ocp sample

### DIFF
--- a/config/samples/simple-ocp.yaml
+++ b/config/samples/simple-ocp.yaml
@@ -24,11 +24,11 @@ spec:
   admin_password_secret: "example-pulp-admin-password"
 
   database:
-    postgres_storage_class: gp3-csi
+    postgres_storage_class: managed-csi
 
   file_storage_access_mode: "ReadWriteOnce"
   file_storage_size: "2Gi"
-  file_storage_storage_class: gp3-csi
+  file_storage_storage_class: azurefile-csi
 
   ingress_type: route
   route_host: route_host_placeholder


### PR DESCRIPTION
prow tests were failing with:
```
persistentvolumeclaim/example-pulp-postgres-example-pulp-database-0   storageclass.storage.k8s.io "gp3-csi" not found
persistentvolumeclaim/example-pulp-file-storage                       storageclass.storage.k8s.io "gp3-csi" not found
```
[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://pulpproject.org/pulpcore/docs/dev/guides/git/#commit-message

If not, please add `[noissue]` to your commit message
