### PR TITLE
Remove `REDIRECT_TO_OBJECT_STORAGE` definition

### DIFF
--- a/controllers/repo_manager/secret.go
+++ b/controllers/repo_manager/secret.go
@@ -359,8 +359,7 @@ func azureSettings(resources controllers.FunctionResources, pulpSettings *string
 		return
 	}
 
-	*pulpSettings = *pulpSettings + `REDIRECT_TO_OBJECT_STORAGE = True
-MEDIA_ROOT = ""
+	*pulpSettings = *pulpSettings + `MEDIA_ROOT = ""
 STORAGES = {
     "default": {
         "BACKEND": "storages.backends.azure_storage.AzureStorage",
@@ -436,8 +435,7 @@ func s3Settings(resources controllers.FunctionResources, pulpSettings *string, c
 	s3Options += s3Region
 	s3Options += fmt.Sprintf("%8s},\n", "")
 
-	*pulpSettings += `REDIRECT_TO_OBJECT_STORAGE = True
-MEDIA_ROOT = ""
+	*pulpSettings += `MEDIA_ROOT = ""
 STORAGES = {
     "default": {
         "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",


### PR DESCRIPTION
By default, it is already defined as `True` (and ignored for local file storage). Removing it to avoid conflicts when it is also defined in `custom_pulp_settings`.
ref: https://github.com/pulp/pulpcore/issues/6761

[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://pulpproject.org/pulpcore/docs/dev/guides/git/#commit-message

If not, please add `[noissue]` to your commit message
