### PR TITLE
Fix deploy job in CI when pushing to a tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
             export IMG=quay.io/pulp/pulp-operator:nightly
             export CATALOG_IMG=quay.io/pulp/pulp-operator-catalog:nightly
             export BUNDLE_IMG=quay.io/pulp/pulp-operator-bundle:nightly
-          else
+          elif [ "$GITHUB_EVENT_NAME" != "push" ] || [[ ! "$GITHUB_REF" =~ ^refs/tags/ ]]; then
             export VERSION=$(awk '/^VERSION \?= / {print $3}' Makefile)-dev
           fi
           make docker-buildx bundle-build bundle-push catalog-build catalog-push


### PR DESCRIPTION
When we are pushing to a git tag, we should not deploy the image with a -dev suffix, instead the image VERSION should use the value from Makefile.
[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://pulpproject.org/pulpcore/docs/dev/guides/git/#commit-message

If not, please add `[noissue]` to your commit message
