### PR TITLE
feat: add configurable S3 addressing style support

### DIFF
--- a/controllers/repo_manager/secret.go
+++ b/controllers/repo_manager/secret.go
@@ -476,7 +476,7 @@ func s3Settings(resources controllers.FunctionResources, pulpSettings *string, c
 		return
 	}
 
-	var s3SecretKey, s3KeyId, s3Endpoint, s3Region, s3AddressingStyle string
+	var s3SecretKey, s3KeyId, s3Endpoint, s3Region string
 	if len(optionalKey["s3-secret-access-key"]) > 0 {
 		s3SecretKey = fmt.Sprintf("%12s\"secret_key\": \"%v\",\n", "", optionalKey["s3-secret-access-key"])
 	}
@@ -493,10 +493,6 @@ func s3Settings(resources controllers.FunctionResources, pulpSettings *string, c
 		s3Region = fmt.Sprintf("%12s\"region_name\": \"%v\",\n", "", optionalKey["s3-region"])
 	}
 
-	if len(optionalKey["s3-addressing-style"]) > 0 {
-		s3AddressingStyle = fmt.Sprintf("%12s\"addressing_style\": \"%v\",\n", "", optionalKey["s3-addressing-style"])
-	}
-
 	s3Options := `        "OPTIONS": {
             "signature_version": "s3v4",
             "addressing_style": "` + getAddressingStyle(optionalKey) + `",
@@ -506,7 +502,6 @@ func s3Settings(resources controllers.FunctionResources, pulpSettings *string, c
 	s3Options += s3KeyId
 	s3Options += s3Endpoint
 	s3Options += s3Region
-	s3Options += s3AddressingStyle
 	s3Options += fmt.Sprintf("%8s},\n", "")
 
 	*pulpSettings += `MEDIA_ROOT = ""

--- a/docs/admin/guides/configurations/pulp_settings.md
+++ b/docs/admin/guides/configurations/pulp_settings.md
@@ -114,7 +114,7 @@ STORAGES = {
             "region_name": ...,
             "endpoint_url": ...,
             "signature_version": "s3v4",
-            "addressing_style": "path",
+            "addressing_style": ...,
         },
     },
 }


### PR DESCRIPTION
## Description
This PR adds configurable S3 addressing style support to the Pulp operator, allowing users to specify whether to use "path" or "virtual" addressing style for S3-compatible storage services.

## Problem
Currently, the S3 addressing style is hardcoded to "path" in the operator code (line 429 in `secret.go`), which causes issues with S3-compatible services like Tencent COS that require "virtual" addressing style. This results in `PathStyleDomainForbidden` errors when trying to use these services.

## Solution
- Add `s3-addressing-style` key support in S3 secret retrieval
- Make `addressing_style` configurable instead of hardcoded "path"
- Add `getAddressingStyle` helper function with "path" as default
- Support both "path" and "virtual" addressing styles
- Maintain backward compatibility

## Changes
- **`controllers/repo_manager/secret.go`**:
  - Add `s3-addressing-style` to secret retrieval keys
  - Add `s3AddressingStyle` variable and logic
  - Update `s3Options` to use configurable addressing style
  - Add `getAddressingStyle` helper function

## Configuration
Users can now specify the addressing style in their S3 secret:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: pulp-s3-secret
  namespace: pulp
type: Opaque
stringData:
  s3-bucket-name: "my-bucket"
  s3-endpoint: "https://s3.amazonaws.com"
  s3-region: "us-east-1"
  s3-access-key-id: "AKIAIOSFODNN7EXAMPLE"
  s3-secret-access-key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
  s3-addressing-style: "virtual"  # New: "path" or "virtual"
```

## Breaking Changes
None - this change is backward compatible and defaults to the existing "path" behavior.

## Related Issues
Fixes S3 storage fails with `PathStyleDomainForbidden` error for Tencent COS and other S3-compatible services that require virtual-hosted-style URLs.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is properly commented
- [x] Changes are backward compatible
- [ ] Unit tests added/updated
- [ ] Documentation updated (if applicable)