### PR TITLE
feat: add gunicorn_access_logformat field to Api and Content specs

### DIFF
--- a/CHANGES/1564.feature
+++ b/CHANGES/1564.feature
@@ -1,0 +1,1 @@
+Added gunicorn_access_logformat field to customize access log format for api and content pods.

--- a/apis/repo-manager.pulpproject.org/v1/pulp_types.go
+++ b/apis/repo-manager.pulpproject.org/v1/pulp_types.go
@@ -435,6 +435,11 @@ type Api struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	GunicornWorkers int `json:"gunicorn_workers,omitempty"`
 
+	// For the gunicorn --access-logformat CLI command used to format the access logs.
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	GunicornAccessLogformat string `json:"gunicorn_access_logformat,omitempty"`
+
 	// Resource requirements for the pulp api container.
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:resourceRequirements","urn:alm:descriptor:com.tectonic.ui:advanced"}
@@ -530,6 +535,11 @@ type Content struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	GunicornWorkers int `json:"gunicorn_workers,omitempty"`
+
+	// For the gunicorn --access-logformat CLI command used to format the access logs.
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	GunicornAccessLogformat string `json:"gunicorn_access_logformat,omitempty"`
 
 	// Periodic probe of container service readiness.
 	// Container will be removed from service endpoints if the probe fails.

--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -216,6 +216,13 @@ spec:
         path: api.deployment_annotations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: For the gunicorn --access-logformat CLI command used to format
+          the access logs.
+        displayName: Gunicorn Access Logformat
+        path: api.gunicorn_access_logformat
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'The timeout for the gunicorn process. Default: 90'
         displayName: Gunicorn Timeout
         path: api.gunicorn_timeout
@@ -425,6 +432,13 @@ spec:
         path: content.deployment_annotations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: For the gunicorn --access-logformat CLI command used to format
+          the access logs.
+        displayName: Gunicorn Access Logformat
+        path: content.gunicorn_access_logformat
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'The timeout for the gunicorn process. Default: 90'
         displayName: Gunicorn Timeout
         path: content.gunicorn_timeout

--- a/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
+++ b/bundle/manifests/repo-manager.pulpproject.org_pulps.yaml
@@ -1370,6 +1370,10 @@ spec:
                       - name
                       type: object
                     type: array
+                  gunicorn_access_logformat:
+                    description: For the gunicorn --access-logformat CLI command used
+                      to format the access logs.
+                    type: string
                   gunicorn_timeout:
                     description: |-
                       The timeout for the gunicorn process.
@@ -4921,6 +4925,10 @@ spec:
                       - name
                       type: object
                     type: array
+                  gunicorn_access_logformat:
+                    description: For the gunicorn --access-logformat CLI command used
+                      to format the access logs.
+                    type: string
                   gunicorn_timeout:
                     description: |-
                       The timeout for the gunicorn process.

--- a/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
+++ b/config/crd/bases/repo-manager.pulpproject.org_pulps.yaml
@@ -1370,6 +1370,10 @@ spec:
                       - name
                       type: object
                     type: array
+                  gunicorn_access_logformat:
+                    description: For the gunicorn --access-logformat CLI command used
+                      to format the access logs.
+                    type: string
                   gunicorn_timeout:
                     description: |-
                       The timeout for the gunicorn process.
@@ -4921,6 +4925,10 @@ spec:
                       - name
                       type: object
                     type: array
+                  gunicorn_access_logformat:
+                    description: For the gunicorn --access-logformat CLI command used
+                      to format the access logs.
+                    type: string
                   gunicorn_timeout:
                     description: |-
                       The timeout for the gunicorn process.

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -226,6 +226,13 @@ spec:
         path: api.deployment_annotations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: For the gunicorn --access-logformat CLI command used to format
+          the access logs.
+        displayName: Gunicorn Access Logformat
+        path: api.gunicorn_access_logformat
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'The timeout for the gunicorn process. Default: 90'
         displayName: Gunicorn Timeout
         path: api.gunicorn_timeout
@@ -435,6 +442,13 @@ spec:
         path: content.deployment_annotations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: For the gunicorn --access-logformat CLI command used to format
+          the access logs.
+        displayName: Gunicorn Access Logformat
+        path: content.gunicorn_access_logformat
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'The timeout for the gunicorn process. Default: 90'
         displayName: Gunicorn Timeout
         path: content.gunicorn_timeout

--- a/controllers/repo_manager/README.md
+++ b/controllers/repo_manager/README.md
@@ -34,6 +34,7 @@ Api defines desired state of pulpcore-api resources
 | topology_spread_constraints | Topology rule(s) for the pods. | []corev1.TopologySpreadConstraint | false |
 | gunicorn_timeout | The timeout for the gunicorn process. Default: 90 | int | false |
 | gunicorn_workers | The number of gunicorn workers to use for the api. Default: 2 | int | false |
+| gunicorn_access_logformat | For the gunicorn --access-logformat CLI command used to format the access logs. | string | false |
 | resource_requirements | Resource requirements for the pulp api container. | corev1.ResourceRequirements | false |
 | readinessProbe | Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. | *corev1.Probe | false |
 | livenessProbe | Periodic probe of container liveness. Container will be restarted if the probe fails. | *corev1.Probe | false |
@@ -85,6 +86,7 @@ Content defines desired state of pulpcore-content resources
 | topology_spread_constraints | Topology rule(s) for the pods. | []corev1.TopologySpreadConstraint | false |
 | gunicorn_timeout | The timeout for the gunicorn process. Default: 90 | int | false |
 | gunicorn_workers | The number of gunicorn workers to use for the api. Default: 2 | int | false |
+| gunicorn_access_logformat | For the gunicorn --access-logformat CLI command used to format the access logs. | string | false |
 | readinessProbe | Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. | *corev1.Probe | false |
 | livenessProbe | Periodic probe of container liveness. Container will be restarted if the probe fails. | *corev1.Probe | false |
 | pdb | PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods | *policy.PodDisruptionBudgetSpec | false |

--- a/controllers/repo_manager/controller_test.go
+++ b/controllers/repo_manager/controller_test.go
@@ -183,6 +183,7 @@ var _ = Describe("Pulp controller", Ordered, func() {
 		customEnvVar,
 		{Name: "PULP_GUNICORN_TIMEOUT", Value: strconv.Itoa(90)},
 		{Name: "PULP_API_WORKERS", Value: strconv.Itoa(2)},
+		{Name: "PULP_GUNICORN_ACCESS_LOGFORMAT", Value: `pulp [%({correlation-id}o)s]: %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"`},
 		{Name: "POSTGRES_SERVICE_HOST", Value: PulpName + "-database-svc"},
 		{Name: "POSTGRES_SERVICE_PORT", Value: "5432"},
 		{Name: "REDIS_SERVICE_HOST", Value: PulpName + "-redis-svc." + PulpNamespace},
@@ -193,6 +194,7 @@ var _ = Describe("Pulp controller", Ordered, func() {
 		customEnvVar,
 		{Name: "PULP_GUNICORN_TIMEOUT", Value: strconv.Itoa(90)},
 		{Name: "PULP_CONTENT_WORKERS", Value: strconv.Itoa(2)},
+		{Name: "PULP_GUNICORN_ACCESS_LOGFORMAT", Value: `%a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i"`},
 		{Name: "POSTGRES_SERVICE_HOST", Value: PulpName + "-database-svc"},
 		{Name: "POSTGRES_SERVICE_PORT", Value: "5432"},
 		{Name: "REDIS_SERVICE_HOST", Value: PulpName + "-redis-svc." + PulpNamespace},
@@ -626,12 +628,13 @@ var _ = Describe("Pulp controller", Ordered, func() {
 then
   PULP_API_ENTRYPOINT=("pulpcore-api")
 else
-  PULP_API_ENTRYPOINT=("gunicorn" "pulpcore.app.wsgi:application" "--name" "pulp-api" "--access-logformat" "pulp [%({correlation-id}o)s]: %(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\"")
+  PULP_API_ENTRYPOINT=("gunicorn" "pulpcore.app.wsgi:application" "--name" "pulp-api")
 fi
 exec "${PULP_API_ENTRYPOINT[@]}" \
 --bind "[::]:24817" \
 --timeout "${PULP_GUNICORN_TIMEOUT}" \
 --workers "${PULP_API_WORKERS}" \
+--access-logformat "${PULP_GUNICORN_ACCESS_LOGFORMAT}" \
 --access-logfile -`,
 		},
 		Env: envVarsApi,
@@ -745,6 +748,7 @@ exec "${PULP_CONTENT_ENTRYPOINT[@]}" \
 --bind "[::]:24816" \
 --timeout "${PULP_GUNICORN_TIMEOUT}" \
 --workers "${PULP_CONTENT_WORKERS}" \
+--access-logformat "${PULP_GUNICORN_ACCESS_LOGFORMAT}" \
 --access-logfile -
 `,
 						},


### PR DESCRIPTION
Summary
-------

Adds a new CRD field `gunicorn_access_logformat` to customize gunicorn's access log format for api and content pods.

Closes [#1564](https://github.com/pulp/pulp-operator/issues/1564)

Changes
-------

### pulp_types.go

-   Add `GunicornAccessLogformat` field to `Api` struct
-   Add `GunicornAccessLogformat` field to `Content` struct

### deployment.go

-   Modify `setEnvVars()`: Set `PULP_GUNICORN_ACCESS_LOGFORMAT` env var with default value if field is empty
-   Modify `pulpcoreApiContainerArgs()`: Remove hardcoded `--access-logformat` from gunicorn ENTRYPOINT array, add `--access-logformat "${PULP_GUNICORN_ACCESS_LOGFORMAT}"` to exec command
-   Modify `pulpcoreContentContainerArgs()`: Add `--access-logformat "${PULP_GUNICORN_ACCESS_LOGFORMAT}"` to exec command

### controller_test.go

-   Add `PULP_GUNICORN_ACCESS_LOGFORMAT` to `envVarsApi` and `envVarsContent`
-   Update `apiContainers` and content container Args to match new shell script behavior

**Default format:**

```
pulp [%({correlation-id}o)s]: %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"

```

This preserves existing behavior when the field is not specified - the default includes the correlation-id header from django_guid.

Usage
-----

```source-yaml
spec:
  api:
    gunicorn_access_logformat: '{"remote_ip": "%(h)s", "method": "%(m)s", "path": "%(U)s", "status": "%(s)s"}'
  content:
    gunicorn_access_logformat: '{"remote_ip": "%(h)s", "method": "%(m)s", "path": "%(U)s", "status": "%(s)s"}'
```