### PR TITLE
Use PG 14 in CI

### DIFF
--- a/config/samples/k8s_versions_ci.yaml
+++ b/config/samples/k8s_versions_ci.yaml
@@ -38,6 +38,7 @@ spec:
   database:
     postgres_storage_class: standard
     postgres_storage_requirements: "1Gi"
+    postgres_image: 'postgres:14'
   cache:
     enabled: true
     redis_storage_class: standard

--- a/config/samples/simple.azure.ci.yaml
+++ b/config/samples/simple.azure.ci.yaml
@@ -44,3 +44,4 @@ spec:
     replicas: 1
   database:
     postgres_storage_class: standard
+    postgres_image: 'postgres:14'

--- a/config/samples/simple.s3.ci.yaml
+++ b/config/samples/simple.s3.ci.yaml
@@ -45,3 +45,4 @@ spec:
     replicas: 1
   database:
     postgres_storage_class: standard
+    postgres_image: 'postgres:14'


### PR DESCRIPTION
PostgreSQL 14 is the minimum required version for Django 5. Let's use that in the CI so that CI passes.

https://github.com/pulp/pulp-operator/issues/1589 is open to fix this in the operator defaults.