### PR TITLE
Update postgres in config samples and bkp/restore

### DIFF
--- a/.ci/scripts/prepare-object-storage.sh
+++ b/.ci/scripts/prepare-object-storage.sh
@@ -2,7 +2,7 @@
 #!/usr/bin/env bash
 
 if [[ "$COMPONENT_TYPE" == "azure" ]]; then
-  docker run -d -p 10000:10000 --name pulp-azurite mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0
+  docker run -d -p 10000:10000 --name pulp-azurite mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck
   sleep 5
   AZURE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://pulp-azurite:10000/devstoreaccount1;"
   echo $(minikube ip)   pulp-azurite | sudo tee -a /etc/hosts

--- a/.ci/scripts/pulp_ansible/remote-collection.sh
+++ b/.ci/scripts/pulp_ansible/remote-collection.sh
@@ -1,7 +1,7 @@
 # Create a remote that syncs some versions of django into your repository.
 pulp ansible remote -t "collection" create \
     --name "cbar" \
-    --url "https://galaxy-dev.ansible.com/" \
-    --requirements $'collections:\n  - testing.ansible_testing_content'
+    --url "https://galaxy.ansible.com/" \
+    --requirements $'collections:\n  - ansible.galaxy_collection'
 # If requirements are in a file
 # you can use the option '--requirements @<file_name>' instead.

--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -22,6 +22,7 @@ metadata:
             },
             "custom_pulp_settings": "settings",
             "database": {
+              "postgres_image": "postgres:15",
               "postgres_storage_class": "standard"
             },
             "file_storage_access_mode": "ReadWriteMany",

--- a/config/samples/external_db.yaml
+++ b/config/samples/external_db.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:13
+          image: postgres:15
           imagePullPolicy: "IfNotPresent"
           envFrom:
           - secretRef:

--- a/config/samples/k8s_versions_ci.yaml
+++ b/config/samples/k8s_versions_ci.yaml
@@ -36,6 +36,7 @@ spec:
   web:
     replicas: 1
   database:
+    postgres_image: postgres:15
     postgres_storage_class: standard
     postgres_storage_requirements: "1Gi"
   cache:

--- a/config/samples/minimal.yaml
+++ b/config/samples/minimal.yaml
@@ -5,6 +5,7 @@ metadata:
   name: example-pulp
 spec:
   database:
+    postgres_image: postgres:15
     postgres_storage_class: standard
 
   file_storage_storage_class: standard

--- a/config/samples/pulp-with-hpa.yaml
+++ b/config/samples/pulp-with-hpa.yaml
@@ -55,6 +55,7 @@ spec:
 
   # Database configuration
   database:
+    postgres_image: postgres:15
     postgres_storage_requirements: "8Gi"
 
   # Cache configuration

--- a/config/samples/repo-manager.pulpproject.org_v1_pulp.yaml
+++ b/config/samples/repo-manager.pulpproject.org_v1_pulp.yaml
@@ -33,6 +33,7 @@ spec:
     replicas: 1
 
   database:
+    postgres_image: postgres:15
     postgres_storage_class: standard
 
   file_storage_access_mode: "ReadWriteMany"

--- a/config/samples/simple-ocp.yaml
+++ b/config/samples/simple-ocp.yaml
@@ -24,6 +24,7 @@ spec:
   admin_password_secret: "example-pulp-admin-password"
 
   database:
+    postgres_image: postgres:15
     postgres_storage_class: managed-csi
 
   file_storage_access_mode: "ReadWriteOnce"

--- a/config/samples/simple-test.yaml
+++ b/config/samples/simple-test.yaml
@@ -29,6 +29,7 @@ spec:
     replicas: 1
 
   database:
+    postgres_image: postgres:15
     postgres_storage_class: standard
 
   file_storage_access_mode: "ReadWriteOnce"

--- a/config/samples/simple-trust-manager.yaml
+++ b/config/samples/simple-trust-manager.yaml
@@ -58,6 +58,7 @@ spec:
   mount_trusted_ca_configmap_key: "example-pulp-trusted-ca-bundle:ca-bundle.crt"
 
   database:
+    postgres_image: postgres:15
     postgres_storage_class: standard
 
   file_storage_access_mode: "ReadWriteOnce"

--- a/config/samples/simple-with-reduced-migration-cpu.yaml
+++ b/config/samples/simple-with-reduced-migration-cpu.yaml
@@ -29,6 +29,7 @@ spec:
     replicas: 1
 
   database:
+    postgres_image: postgres:15
     postgres_storage_class: standard
 
   file_storage_access_mode: "ReadWriteOnce"

--- a/config/samples/simple.azure.ci.yaml
+++ b/config/samples/simple.azure.ci.yaml
@@ -43,4 +43,5 @@ spec:
   web:
     replicas: 1
   database:
+    postgres_image: postgres:15
     postgres_storage_class: standard

--- a/config/samples/simple.ingress.yaml
+++ b/config/samples/simple.ingress.yaml
@@ -24,6 +24,7 @@ spec:
   worker:
     replicas: 1
   database:
+    postgres_image: postgres:15
     postgres_storage_class: standard
 
   file_storage_access_mode: "ReadWriteMany"

--- a/config/samples/simple.ldap.yaml
+++ b/config/samples/simple.ldap.yaml
@@ -48,6 +48,7 @@ spec:
   nodeport_port: 30000
 
   database:
+    postgres_image: postgres:15
     postgres_storage_class: standard
 
   file_storage_access_mode: "ReadWriteMany"

--- a/config/samples/simple.s3.ci.yaml
+++ b/config/samples/simple.s3.ci.yaml
@@ -44,4 +44,5 @@ spec:
   web:
     replicas: 1
   database:
+    postgres_image: postgres:15
     postgres_storage_class: standard

--- a/config/samples/simple.telemetry.yaml
+++ b/config/samples/simple.telemetry.yaml
@@ -31,6 +31,7 @@ spec:
   web:
     replicas: 1
   database:
+    postgres_image: postgres:15
     postgres_storage_class: standard
 
   file_storage_access_mode: "ReadWriteMany"

--- a/config/samples/simple.yaml
+++ b/config/samples/simple.yaml
@@ -40,6 +40,7 @@ spec:
     replicas: 1
 
   database:
+    postgres_image: postgres:15
     postgres_storage_class: standard
 
   file_storage_access_mode: "ReadWriteMany"

--- a/controllers/backup/controller.go
+++ b/controllers/backup/controller.go
@@ -196,7 +196,7 @@ func (r *RepoManagerBackupReconciler) createBackupPod(ctx context.Context, pulpB
 	// [TO-DO] define postgres image based on the database implementation type
 	// if external database: we should gather from an user input (pulpbackup CR) postgres version
 	// if provisioned by operator: we should gather, for example, from pulp CR spec or from database deployment spec
-	postgresImage := "docker.io/library/postgres:13"
+	postgresImage := "docker.io/library/postgres:15"
 	volumeMounts := []corev1.VolumeMount{{
 		Name:      pulpBackup.Name + "-backup",
 		ReadOnly:  false,

--- a/controllers/restore/utils.go
+++ b/controllers/restore/utils.go
@@ -96,7 +96,7 @@ func (r *RepoManagerRestoreReconciler) createRestorePod(ctx context.Context, pul
 	// [TO-DO] define postgres image based on the database implementation type
 	// if external database: we should gather from an user input (pulpRestore CR) postgres version
 	// if provisioned by operator: we should gather, for example, from pulp CR spec or from database deployment spec
-	postgresImage := "docker.io/library/postgres:13"
+	postgresImage := "docker.io/library/postgres:15"
 
 	volumeMounts := []corev1.VolumeMount{{
 		Name:      pulpRestore.Name + "-backup",


### PR DESCRIPTION
This commit fix some issues in CI, but mainly the postgres version incompatibility with django 5.

Update postgres to 15 in CR samples, bkp and restore controllers. This is a workaround to be able to make the CI green and publish version 1.3.0 while we work on the issue with postgres 13 upgrade.

[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://pulpproject.org/pulpcore/docs/dev/guides/git/#commit-message

If not, please add `[noissue]` to your commit message
