### PR TITLE
Update CI container registry from ghcr to quay

### DIFF
--- a/.ci/scripts/pulp_container/export_repository.sh
+++ b/.ci/scripts/pulp_container/export_repository.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-podman pull ghcr.io/pulp/test-fixture-1:manifest_a
+podman pull quay.io/pulp/test-fixture-1:manifest_a
 
 # push a tagged image to the registry
 podman login ${REGISTRY_ADDR} -u admin -p password --tls-verify=false
-podman tag ghcr.io/pulp/test-fixture-1:manifest_a \
+podman tag quay.io/pulp/test-fixture-1:manifest_a \
   ${REGISTRY_ADDR}/test/fixture:manifest_a
 podman push ${REGISTRY_ADDR}/test/fixture:manifest_a --tls-verify=false
 

--- a/.ci/scripts/pulp_container/remote.sh
+++ b/.ci/scripts/pulp_container/remote.sh
@@ -4,7 +4,7 @@ REMOTE_NAME=$(head /dev/urandom | tr -dc a-z | head -c5)
 echo "Creating $REMOTE_NAME remote that points to an external source of container images."
 REMOTE_HREF=$(http POST $BASE_ADDR/pulp/api/v3/remotes/container/container/ \
     name=$REMOTE_NAME \
-    url='https://ghcr.io' \
+    url='https://quay.io' \
     upstream_name='pulp/test-fixture-1' | jq -r '.pulp_href')
 
 echo "Inspecting new Remote."

--- a/.github/workflows/scripts/show_logs.sh
+++ b/.github/workflows/scripts/show_logs.sh
@@ -21,7 +21,7 @@ echo ::endgroup::
 
 echo ::group::OPERATOR_LOGS
 journalctl --unit=pulp-operator -n 10000 --no-pager --output=cat
-kubectl logs -l app.kubernetes.io/component=operator -c manager --tail=10000
+kubectl logs -l app.kubernetes.io/component=operator -c manager --tail=10000 || true
 echo ::endgroup::
 
 echo ::group::DESCRIBE_JOBS


### PR DESCRIPTION
Migrate the pulp/test-fixture-1 image references in the CI scripts from ghcr.io to quay.io because ghcr has been extremely slow in the last months causing the pipeline to fail.

[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://pulpproject.org/pulpcore/docs/dev/guides/git/#commit-message

If not, please add `[noissue]` to your commit message
