### PR TITLE
Bump checkout/setup-go/setup-python GH Actions

### DIFF
--- a/.github/actions/pre-reqs/action.yml
+++ b/.github/actions/pre-reqs/action.yml
@@ -12,11 +12,11 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     - name: Setup Go environment
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go.mod'
         cache: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,17 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # by default, it uses a depth of 1
           # this fetches all history so that we can read each commit
           fetch-depth: 0
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Setup Go environment
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: false
@@ -64,7 +64,7 @@ jobs:
   bundle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check if bundle files are updated
         run: |
           .ci/scripts/bundle_check.sh
@@ -76,9 +76,9 @@ jobs:
   two-deployments:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Go environment
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: false
@@ -89,7 +89,7 @@ jobs:
           make sdkbin OPERATOR_SDK_VERSION=v1.31.0 LOCALBIN=/tmp
           /tmp/operator-sdk olm install --version v0.31.0
         shell: bash
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Pulp CRD
         run: make install
       - name: Build operator image
@@ -150,11 +150,11 @@ jobs:
   envtest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Setup Go environment
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: false
@@ -167,7 +167,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/pre-reqs
         with:
           ingress-type: nodeport
@@ -181,7 +181,7 @@ jobs:
           kubectl create ns pulp-operator-system
           kubectl config set-context --current --namespace=pulp-operator-system
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: pulp/pulp-k8s-resources
           ref: main
@@ -190,7 +190,7 @@ jobs:
         run: |
           helm install --skip-crds --set namespace=pulp-operator-system --set image=localhost/pulp-operator:devel pulp helm-charts/chart
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Create Pulp Operator CR
         run: |
           kubectl apply -f .ci/assets/kubernetes/pulp-admin-password.secret.yaml
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/pre-reqs
         with:
           ingress-type: nodeport
@@ -258,7 +258,7 @@ jobs:
       github.event_name != 'pull_request' &&
       github.repository_owner == 'pulp'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/pre-reqs
         with:
           deploy: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -17,7 +17,7 @@ jobs:
           - COMPONENT_TYPE: s3
           - COMPONENT_TYPE: azure
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/pre-reqs"
         with:
           component-type: ${{ matrix.COMPONENT_TYPE }}

--- a/.github/workflows/k8s_versions.yml
+++ b/.github/workflows/k8s_versions.yml
@@ -17,7 +17,7 @@ jobs:
           - K8S_VERSION: v1.33.1
           - K8S_VERSION: v1.32.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/pre-reqs"
         with:
           minikube-version: ${{ matrix.K8S_VERSION }}
@@ -56,13 +56,13 @@ jobs:
           - K8S_VERSION: v1.33.7
           - K8S_VERSION: v1.32.11
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Setup Go environment
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: false
@@ -152,13 +152,13 @@ jobs:
           - K8S_VERSION: 1.33
           - K8S_VERSION: 1.32
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Setup Go environment
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: false

--- a/.github/workflows/pulp_versions.yml
+++ b/.github/workflows/pulp_versions.yml
@@ -17,7 +17,7 @@ jobs:
           - PULPCORE_VERSION: "3.85"
           - PULPCORE_VERSION: "3.73"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: "./.github/actions/pre-reqs"
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/pre-reqs
         with:
           deploy: true

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_name != 'main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Go environment
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: false
@@ -21,7 +21,7 @@ jobs:
           make sdkbin LOCALBIN=/tmp
           /tmp/operator-sdk olm install
         shell: bash
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: pulp/pulp-operator
           ref: 1.1.0
@@ -29,7 +29,7 @@ jobs:
         run: make bundle-build bundle-push BUNDLE_IMG=localhost:5001/pulp-operator-bundle:old
       - name: Install the operator
         run: /tmp/operator-sdk run bundle --skip-tls localhost:5001/pulp-operator-bundle:old --timeout 4m
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build bundle image
         run: make docker-build docker-push bundle bundle-build bundle-push VERSION=1.0.0-dev IMG=localhost:5001/pulp-operator:upgrade BUNDLE_IMG=localhost:5001/pulp-operator-bundle:new
       - name: Upgrade the operator
@@ -76,12 +76,12 @@ jobs:
           - INGRESS_TYPE: ingress
           - INGRESS_TYPE: nodeport
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/pre-reqs
         with:
           ingress-type:  ${{ matrix.INGRESS_TYPE }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: pulp/pulp-operator
           ref: main
@@ -108,7 +108,7 @@ jobs:
       - name: Logs [before upgrade]
         if: always()
         run: .github/workflows/scripts/show_logs.sh
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Upgrade pulp-operator
         run: |
           make install


### PR DESCRIPTION
Update actions/checkout v4→v5, actions/setup-go v5→v6, and actions/setup-python v5→v6 to resolve Node.js 20 deprecation warnings.

[noissue]

Thank you for your contribution!

If your PR needs a changelog entry:
* https://github.com/pulp/pulp-operator/issues/new
* https://pulpproject.org/pulpcore/docs/dev/guides/git/#commit-message

If not, please add `[noissue]` to your commit message
