### PR TITLE
fix(secret): stop pulp-server Secret churn from nondeterministic map iteration

### DIFF
--- a/controllers/repo_manager/secret.go
+++ b/controllers/repo_manager/secret.go
@@ -620,24 +620,19 @@ func debugLogging(resources controllers.FunctionResources, pulpSettings *string)
 // needsMigrationSetting defines settings.py with some specific configurations that when changed will
 // also trigger a migration job
 func needsMigrationSetting(resources controllers.FunctionResources, pulpSettings *string, customSettings map[string]struct{}) {
-	for operatorFieldName, pulpFieldName := range controllers.MigrationSettingsList() {
-		customSettingsFound := false
-		if _, exists := customSettings[pulpFieldName]; exists {
-			logMessage := fmt.Sprintf("%v should not be defined in custom_pulp_settings. Use pulp.Spec.%v instead", pulpFieldName, strings.ToLower(pulpFieldName))
+	for _, s := range controllers.MigrationSettingsList() {
+		if _, exists := customSettings[s.PulpField]; exists {
+			logMessage := fmt.Sprintf("%v should not be defined in custom_pulp_settings. Use pulp.Spec.%v instead", s.PulpField, strings.ToLower(s.PulpField))
 			controllers.CustomZapLogger().Warn(logMessage)
-			customSettingsFound = true
-		}
-		if customSettingsFound {
 			continue
 		}
 
-		config := reflect.ValueOf(resources.Pulp.Spec).FieldByName(operatorFieldName).Bool()
+		config := reflect.ValueOf(resources.Pulp.Spec).FieldByName(s.OperatorField).Bool()
 		if !config {
-			return
+			continue
 		}
 		configCapitalized := cases.Title(language.English, cases.Compact).String(strconv.FormatBool(config))
-		*pulpSettings = *pulpSettings + fmt.Sprintf("%v = %v\n", pulpFieldName, configCapitalized)
-
+		*pulpSettings = *pulpSettings + fmt.Sprintf("%v = %v\n", s.PulpField, configCapitalized)
 	}
 }
 

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -297,13 +297,21 @@ func StorageTypeChanged(pulp *pulpv1.Pulp) bool {
 	return currentStorageType != definedStorageType[0]
 }
 
-// MigrationSettingsList returns a map[string]string of configurations that should trigger a migration job
-// note: in the current implementation, all fields should be boolean. Trying to add a non-bool field
+// MigrationSetting pairs a Pulp CR field name (on Spec/Status) with the
+// corresponding setting key written to settings.py.
+type MigrationSetting struct {
+	OperatorField string
+	PulpField     string
+}
+
+// MigrationSettingsList returns the configurations that should trigger a migration job,
+// in a stable, deterministic order.
+// Note: in the current implementation, all fields should be boolean. Trying to add a non-bool field
 // to the list will fail SettingNeedsMigrationChanged execution.
-func MigrationSettingsList() map[string]string {
-	return map[string]string{
-		"RedirectToObjectStorage":  "REDIRECT_TO_OBJECT_STORAGE",
-		"HideGuardedDistributions": "HIDE_GUARDED_DISTRIBUTIONS",
+func MigrationSettingsList() []MigrationSetting {
+	return []MigrationSetting{
+		{"HideGuardedDistributions", "HIDE_GUARDED_DISTRIBUTIONS"},
+		{"RedirectToObjectStorage", "REDIRECT_TO_OBJECT_STORAGE"},
 	}
 }
 
@@ -311,11 +319,11 @@ func MigrationSettingsList() map[string]string {
 // returns a list with the settings modified
 func SettingNeedsMigrationChanged(pulp *pulpv1.Pulp) []string {
 	settingsChanged := []string{}
-	for setting := range MigrationSettingsList() {
-		currentSpec := reflect.ValueOf(pulp.Spec).FieldByName(setting).Bool()
-		oldSpec := reflect.ValueOf(pulp.Status).FieldByName(setting).Bool()
+	for _, s := range MigrationSettingsList() {
+		currentSpec := reflect.ValueOf(pulp.Spec).FieldByName(s.OperatorField).Bool()
+		oldSpec := reflect.ValueOf(pulp.Status).FieldByName(s.OperatorField).Bool()
 		if currentSpec != oldSpec {
-			settingsChanged = append(settingsChanged, setting)
+			settingsChanged = append(settingsChanged, s.OperatorField)
 		}
 	}
 	return settingsChanged


### PR DESCRIPTION
## Summary

The `pulp-server` Secret containing `settings.py` was being rewritten on nearly every reconcile when `spec.redirect_to_object_storage=true`. The rewrite removed and re-added the `REDIRECT_TO_OBJECT_STORAGE = True` line in rapid succession, and each change restarted all pulpcore Deployments.

Observed in operator logs:

```
INFO controllers/utils.go:741   The Data from Secret pulp-server has been modified! Reconciling ...
INFO repo_manager/utils.go:430  Reprovisioning pulpcore pods to get the new settings ...
INFO controllers/utils.go:741   The Data from Secret pulp-server has been modified! Reconciling ...
INFO repo_manager/utils.go:430  Reprovisioning pulpcore pods to get the new settings ...
... (repeats several times in 1–2 s) ...
INFO controllers/utils.go:741   The Spec from Deployment pulp-api has been modified! Reconciling ...
INFO controllers/utils.go:741   The Spec from Deployment pulp-content has been modified! Reconciling ...
INFO controllers/utils.go:741   The Spec from Deployment pulp-worker has been modified! Reconciling ...
```

## Root cause

`needsMigrationSetting` (in `controllers/repo_manager/secret.go`) iterated `controllers.MigrationSettingsList()` as a Go `map[string]string`. Go randomizes map range order per invocation. With the default CR (`RedirectToObjectStorage=true`, `HideGuardedDistributions=false`), the generated `settings.py` differed depending on which key the runtime visited first:

- If `HideGuardedDistributions` was visited first, `if !config { return }` aborted the loop and `REDIRECT_TO_OBJECT_STORAGE` was never written.
- If `RedirectToObjectStorage` was visited first, the line was written, then `HideGuardedDistributions` triggered the same early `return`.

Each time the freshly generated string differed from the stored Secret, `ReconcileObject` updated it and called `restartPulpCorePods`, cascading into Deployment reconciles.

## Fix

Two issues addressed at the source:

- `MigrationSettingsList` now returns `[]MigrationSetting` — a slice of named `OperatorField` / `PulpField` pairs — so iteration order is fixed at the data definition rather than reconstructed at each call site.
- The buggy `return` in `needsMigrationSetting` is replaced with `continue`, so a single disabled flag no longer skips later settings. (This latent bug would have resurfaced if both flags were ever `true` and ordering swapped.)

Both call sites of `MigrationSettingsList` were updated.

## Test plan

- [x] Apply a Pulp CR with `spec.redirect_to_object_storage=true` and observe operator logs over several reconcile cycles — the "Data from Secret pulp-server has been modified" / "Reprovisioning pulpcore pods" churn should not appear.
- [x] Verify the `pulp-server` Secret's `settings.py` contains `REDIRECT_TO_OBJECT_STORAGE = True` and is stable across reconciles.
- [x] Verify the pulpcore Deployments (`pulp-api`, `pulp-content`, `pulp-worker`) are not restarted on the steady-state reconcile.
- [ ] Verify migration is still triggered when `redirect_to_object_storage` or `hide_guarded_distributions` actually changes (`SettingNeedsMigrationChanged` path).
