### PR TITLE
Let the K8S cluster decide on ipFamily usage

### DIFF
--- a/config/samples/external_cache.yaml
+++ b/config/samples/external_cache.yaml
@@ -70,9 +70,8 @@ metadata:
     app.kubernetes.io/component: cache
 spec:
   internalTrafficPolicy: Cluster
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
+  # Let Kubernetes default this from the cluster Service CIDR.
+  # Required for IPv6-only clusters.
   ports:
   - name: redis-6379
     port: 6379

--- a/controllers/repo_manager/api.go
+++ b/controllers/repo_manager/api.go
@@ -144,7 +144,6 @@ func serviceAPIObject(pulp pulpv1.Pulp) *corev1.Service {
 func serviceAPISpec(pulp pulpv1.Pulp) corev1.ServiceSpec {
 
 	serviceInternalTrafficPolicyCluster := corev1.ServiceInternalTrafficPolicyType("Cluster")
-	ipFamilyPolicyType := corev1.IPFamilyPolicyType("SingleStack")
 	serviceAffinity := corev1.ServiceAffinity("None")
 	servicePortProto := corev1.Protocol("TCP")
 	targetPort := intstr.IntOrString{IntVal: 24817}
@@ -152,8 +151,8 @@ func serviceAPISpec(pulp pulpv1.Pulp) corev1.ServiceSpec {
 
 	return corev1.ServiceSpec{
 		InternalTrafficPolicy: &serviceInternalTrafficPolicyCluster,
-		IPFamilies:            []corev1.IPFamily{"IPv4"},
-		IPFamilyPolicy:        &ipFamilyPolicyType,
+		// Let Kubernetes default this from the cluster Service CIDR.
+		// Required for IPv6-only clusters.
 		Ports: []corev1.ServicePort{{
 			Name:       "api-24817",
 			Port:       24817,

--- a/controllers/repo_manager/content.go
+++ b/controllers/repo_manager/content.go
@@ -115,7 +115,6 @@ func serviceContentObject(pulp pulpv1.Pulp) *corev1.Service {
 func serviceContentSpec(pulp pulpv1.Pulp) corev1.ServiceSpec {
 
 	serviceInternalTrafficPolicyCluster := corev1.ServiceInternalTrafficPolicyType("Cluster")
-	ipFamilyPolicyType := corev1.IPFamilyPolicyType("SingleStack")
 	serviceAffinity := corev1.ServiceAffinity("None")
 	servicePortProto := corev1.Protocol("TCP")
 	targetPort := intstr.IntOrString{IntVal: 24816}
@@ -123,8 +122,8 @@ func serviceContentSpec(pulp pulpv1.Pulp) corev1.ServiceSpec {
 
 	return corev1.ServiceSpec{
 		InternalTrafficPolicy: &serviceInternalTrafficPolicyCluster,
-		IPFamilies:            []corev1.IPFamily{"IPv4"},
-		IPFamilyPolicy:        &ipFamilyPolicyType,
+		// Let Kubernetes default this from the cluster Service CIDR.
+		// Required for IPv6-only clusters.
 		Ports: []corev1.ServicePort{{
 			Name:       "content-24816",
 			Port:       24816,

--- a/controllers/repo_manager/database.go
+++ b/controllers/repo_manager/database.go
@@ -475,7 +475,6 @@ func labelsForDatabasePods(m *pulpv1.Pulp) map[string]string {
 // serviceForDatabase returns a service object for postgres pods
 func serviceForDatabase(m *pulpv1.Pulp) *corev1.Service {
 	serviceInternalTrafficPolicyCluster := corev1.ServiceInternalTrafficPolicyType("Cluster")
-	ipFamilyPolicyType := corev1.IPFamilyPolicyType("SingleStack")
 	serviceAffinity := corev1.ServiceAffinity("None")
 	servicePortProto := corev1.Protocol("TCP")
 	targetPort := intstr.IntOrString{IntVal: 5432}
@@ -492,8 +491,8 @@ func serviceForDatabase(m *pulpv1.Pulp) *corev1.Service {
 			ClusterIP:             "None",
 			ClusterIPs:            []string{"None"},
 			InternalTrafficPolicy: &serviceInternalTrafficPolicyCluster,
-			IPFamilies:            []corev1.IPFamily{"IPv4"},
-			IPFamilyPolicy:        &ipFamilyPolicyType,
+			// Let Kubernetes default this from the cluster Service CIDR.
+			// Required for IPv6-only clusters.
 			Ports: []corev1.ServicePort{{
 				Port:       5432,
 				Protocol:   servicePortProto,

--- a/controllers/telemetry.go
+++ b/controllers/telemetry.go
@@ -180,7 +180,6 @@ service:
 // serviceOtel defines a service to expose otel metrics
 func ServiceOtel(resources FunctionResources) client.Object {
 	serviceInternalTrafficPolicyCluster := corev1.ServiceInternalTrafficPolicyType("Cluster")
-	ipFamilyPolicyType := corev1.IPFamilyPolicyType("SingleStack")
 	serviceAffinity := corev1.ServiceAffinity("None")
 	servicePortProto := corev1.Protocol("TCP")
 	targetPort := intstr.IntOrString{IntVal: settings.OtelContainerPort}
@@ -197,8 +196,8 @@ func ServiceOtel(resources FunctionResources) client.Object {
 		},
 		Spec: corev1.ServiceSpec{
 			InternalTrafficPolicy: &serviceInternalTrafficPolicyCluster,
-			IPFamilies:            []corev1.IPFamily{"IPv4"},
-			IPFamilyPolicy:        &ipFamilyPolicyType,
+			// Let Kubernetes default this from the cluster Service CIDR.
+			// Required for IPv6-only clusters.
 			Ports: []corev1.ServicePort{{
 				Name:       "otel-" + strconv.Itoa(settings.OtelContainerPort),
 				Port:       settings.OtelContainerPort,


### PR DESCRIPTION
Hi Team =)

We also ran into the No-Startup issue in our IPv6 only K8s cluster, I read about in #1380 – and the solution is as simple as letting the cluster decide on ipFamily usage.
I did not find any reason why the Pulp operator should keep requiring `ipFamilyPolicy: SingleStack` or should be locked in with `IPv4` family – and would be happy to contribute these changes into the project =)

All the best,
Martin